### PR TITLE
Fixes around transaction saving menu items

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -88,6 +88,9 @@ public class AppController implements Initializable {
     private Menu savePSBT;
 
     @FXML
+    private MenuItem savePSBTBinary;
+
+    @FXML
     private MenuItem exportWallet;
 
     @FXML
@@ -267,6 +270,7 @@ public class AppController implements Initializable {
         showLoadingLog.setSelected(Config.get().isShowLoadingLog());
         showUtxosChart.setSelected(Config.get().isShowUtxosChart());
         savePSBT.visibleProperty().bind(saveTransaction.visibleProperty().not());
+        savePSBTBinary.disableProperty().bind(saveTransaction.visibleProperty());
         exportWallet.setDisable(true);
         refreshWallet.disableProperty().bind(Bindings.or(exportWallet.disableProperty(), Bindings.or(serverToggle.disableProperty(), AppServices.onlineProperty().not())));
         sendToMany.disableProperty().bind(exportWallet.disableProperty());

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -269,6 +269,7 @@ public class AppController implements Initializable {
         showTxHex.setSelected(Config.get().isShowTransactionHex());
         showLoadingLog.setSelected(Config.get().isShowLoadingLog());
         showUtxosChart.setSelected(Config.get().isShowUtxosChart());
+        saveTransaction.setDisable(true);
         savePSBT.visibleProperty().bind(saveTransaction.visibleProperty().not());
         savePSBTBinary.disableProperty().bind(saveTransaction.visibleProperty());
         exportWallet.setDisable(true);

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -235,6 +235,8 @@ public class AppController implements Initializable {
                 if(tabs.getTabs().isEmpty()) {
                     Stage tabStage = (Stage)tabs.getScene().getWindow();
                     tabStage.setTitle("Sparrow");
+                    saveTransaction.setVisible(true);
+                    saveTransaction.setDisable(true);
                 }
             }
         });

--- a/src/main/resources/com/sparrowwallet/sparrow/app.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/app.fxml
@@ -29,7 +29,7 @@
                         </Menu>
                         <MenuItem fx:id="saveTransaction" mnemonicParsing="false" text="Save Transaction..." accelerator="Shortcut+S" onAction="#saveTransaction"/>
                         <Menu fx:id="savePSBT" mnemonicParsing="false" text="Save PSBT">
-                            <MenuItem text="As Binary..." onAction="#savePSBTBinary" accelerator="Shortcut+S"/>
+                            <MenuItem fx:id="savePSBTBinary" text="As Binary..." onAction="#savePSBTBinary" accelerator="Shortcut+S"/>
                             <MenuItem text="As Base64..." onAction="#savePSBTText"/>
                             <MenuItem text="As Binary (No Xpubs)..." onAction="#savePSBTBinaryNoXpubs"/>
                             <MenuItem text="As Base64 (No Xpubs)..." onAction="#savePSBTTextNoXpubs"/>


### PR DESCRIPTION
Three related minor issues are addressed:

1. `File -> Save transaction` and `File -> Save PSBT -> As Binary` share the Ctrl+S accelerator, but only one of the items should be enabled at a time. It turns out that even if the parent `File -> Save PSBT` menu is disabled, the `As Binary` accelerator is still active and gets priority over `Save transaction`. This PR explicitly disables `As Binary` along with `File -> Save PSBT` to address this.

2. When Sparrow starts up without any tabs open, the `Save transaction` menu item is enabled, but clicking it makes no sense and causes a `NullPointerException`. This PR disables it on startup. As far as I can tell, there is no session management or similar that would be disrupted by this.

3. When the last tab to be closed is a transaction tab (such that there are no more tabs open), the `File -> Save PSBT` menu item is still visible and enabled, and will cause a `NullPointerException` if selected. This PR fixes that.
