### PR TITLE
Fix when getProxyServer returns null on getWhirlpool

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -455,7 +455,7 @@ public class AppServices {
     public Whirlpool getWhirlpool(String walletId) {
         Whirlpool whirlpool = whirlpoolMap.get(walletId);
         if(whirlpool == null) {
-            HostAndPort torProxy = AppServices.isTorRunning() ? HostAndPort.fromParts("localhost", TorService.PROXY_PORT) : (Config.get().getProxyServer().isEmpty() || !Config.get().isUseProxy() ? null : HostAndPort.fromString(Config.get().getProxyServer()));
+            HostAndPort torProxy = AppServices.isTorRunning() ? HostAndPort.fromParts("localhost", TorService.PROXY_PORT) : ((Config.get().getProxyServer() == null || Config.get().getProxyServer().isEmpty()) || !Config.get().isUseProxy() ? null : HostAndPort.fromString(Config.get().getProxyServer()));
             whirlpool = new Whirlpool(Network.get(), torProxy, Config.get().getScode(), 1, 15);
             whirlpoolMap.put(walletId, whirlpool);
         }


### PR DESCRIPTION
I wanted to try out the whirlpool, but I was getting an empty list of available pools.

State:
* Testnet
* No proxy server set
* Mixing UTXOs from a wallet generated by a previous [non whirpool] sparrow version.

I took a look, and `getProxyServer()` was returning `null`, and throwing an error. So I completed the condition, alongside with checking if it's empty. (I don't know if it can happen).