### PR TITLE
Update required Java version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you prefer to run Sparrow directly from source, it can be launched with
 
 `./sparrow`
 
-Java 14 or higher must be installed.
+Java 16 or higher must be installed.
 
 ## Configuration
 


### PR DESCRIPTION
Building with Java 14 results in the following error:

```
./sparrow/src/main/java/com/sparrowwallet/sparrow/whirlpool/dataSource/SparrowWalletStateSupplier.java:64: error: pattern matching in instanceof is a preview feature and is disabled by default.
            if(externalDestination.getPostmixHandler() instanceof SparrowPostmixHandler sparrowPostmixHandler) {
```