### PR TITLE
Fix skdman link

### DIFF
--- a/docs/reproducible.md
+++ b/docs/reproducible.md
@@ -32,7 +32,7 @@ sudo apt update -y
 sudo apt-get install -y adoptopenjdk-16-hotspot=16.0.1+9-3
 ```
 
-A alternative option for all platforms is to use the [sdkman.io](sdkman.io) package manager ([Git Bash for Windows](https://git-scm.com/download/win) is a good choice on that platform).
+A alternative option for all platforms is to use the [sdkman.io](https://sdkman.io/) package manager ([Git Bash for Windows](https://git-scm.com/download/win) is a good choice on that platform).
 See the installation [instructions here](https://sdkman.io/install).
 Once installed, run
 ```shell


### PR DESCRIPTION
The current link takes me to `https://github.com/sparrowwallet/sparrow/blob/master/docs/sdkman.io` with an "404 not found error" message. 