### PR TITLE
Allow running `sparrow` script from other paths

### DIFF
--- a/sparrow
+++ b/sparrow
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 
+cd `dirname $0`
 args="$*"
 args="${args%"${args##*[![:space:]]}"}"
 


### PR DESCRIPTION
IIUC, it currently assumes that it's run locally using `./sparrow`.