### PR TITLE
Clarify how to run sparrow from CL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The release binaries are reproducible from v1.5.0 onwards (pre codesigning and i
 
 ## Running
 
-If you prefer to run Sparrow directly from source, it can be launched with
+If you prefer to run Sparrow directly from source, it can be launched from within the project directory with
 
 `./sparrow`
 


### PR DESCRIPTION
This tiny Readme edit would, I think, have preempted the confusion that prompted #263 . I thought that the general install installed a global command, and didn't think, for some time, to run from within the directory. Dumb, but figured clarifying the doc would be better than just figuring it out silently on my own.