### PR TITLE
Add other requirements for building to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ or for those without SSH credentials:
 In order to build, Sparrow requires Java 16 to be installed. 
 The release binaries are built with [AdoptOpenJdk 16.0.1+9 Hotspot](https://adoptopenjdk.net/archive.html?variant=openjdk16&jvmVariant=hotspot).
 
-These binaries can be built from source using
+Other packages may also be necessary to build depending on the platform. On Debian/Ubuntu systems:
+
+`sudo apt install -y rpm fakeroot binutils`
+
+
+The Sparrow binaries can be built from source using
 
 `./gradlew jpackage`
 


### PR DESCRIPTION
The "other requirements" are listed in the [reproducible builds readme](https://github.com/sparrowwallet/sparrow/blob/master/docs/reproducible.md#other-requirements) already. However when trying to quickly build the binaries and follow the main README instructions, the last paragraph about "[m]ore detailed instructions on reproducing the binaries are provided" can be overlooked very easily. Because the paragraph is about the specific topic "reproducible builds" and not building the binaries from source in general.

# Why this pr is useful for the project:

- Browsing the sparrow issues, @alevchuk had the other requirements issue 8 days ago: #259
- I ran into this issue while building right now. 

# Conclusion

I conclude that adding these few lines to the main README, the reading flow of the building instructions stays clean (I like the current short form), but adds an important piece of information to keep the self builders trying and don't make the random user surrender during the build process.

With this added information, I was able to build the Sparrow binaries with the short building instructions from the main README, starting with a fresh install of the ubuntu minimal image.