### PR TITLE
Add mailmap file for Craig Raw addresses.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Craig Raw <craigraw@gmail.com> Craig Raw <craig@quirk.biz>
+Craig Raw <craigraw@gmail.com> craigraw <craigraw@gmail.com>


### PR DESCRIPTION
It's easier to make sense of projects when the committer history is consistent. Since email addresses often change over time the same user can appear under different commits confusing feature history. The mailmap file accommodates address changes maintaining committer name consistency.

I didn't see mailmap in commits, logs, or files in either the sparrow or sparrow-planning repositories. Here are the commands:

```
rg mailmap
git log --pickaxe-all --pickaxe-regex -S'mailmap' 
git log --oneline --regexp-ignore-case --grep='mailmap'
```

So a mailmap is attached.

It changes this

```
   821  Craig Raw <craigraw@gmail.com>
    64  Craig Raw <craig@quirk.biz>
    13  craigraw <craigraw@gmail.com>
     6  zeroleak <zeroleak@samourai.io>
     5  Haakon Nilsen <haakonn@gmail.com>
     2  Jimbo <wilson.jim.r@gmail.com>
     1  finab1 <57462610+finab1@users.noreply.github.com>
     1  RequestPrivacy <72392544+RequestPrivacy@users.noreply.github.com>
     1  Bitcoin Hodler <bitcoinhodler@safe-mail.net>
     1  Alazne Morales <86524177+alaznem@users.noreply.github.com>
     1  RequestPrivacy <github.cylindroconical@aleeas.com>
     1  Roman Zeyde <me@romanzey.de>
     1  Sasha Klein <sashafklein@gmail.com>
```

to this

```
   898  Craig Raw <craigraw@gmail.com>
     6  zeroleak <zeroleak@samourai.io>
     5  Haakon Nilsen <haakonn@gmail.com>
     2  Jimbo <wilson.jim.r@gmail.com>
     1  RequestPrivacy <github.cylindroconical@aleeas.com>
     1  Roman Zeyde <me@romanzey.de>
     1  Sasha Klein <sashafklein@gmail.com>
     1  finab1 <57462610+finab1@users.noreply.github.com>
     1  RequestPrivacy <72392544+RequestPrivacy@users.noreply.github.com>
     1  Bitcoin Hodler <bitcoinhodler@safe-mail.net>
     1  Grant Rettke <grant@wisdomandwonder.com>
     1  Alazne Morales <86524177+alaznem@users.noreply.github.com>
```