### PR TITLE
Add option to set flat fee of 1 sat/vbyte

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/FeeRatesSource.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/FeeRatesSource.java
@@ -35,6 +35,13 @@ public enum FeeRatesSource {
             String url = "https://bitcoinfees.earn.com/api/v1/fees/recommended";
             return getThreeTierFeeRates(defaultblockTargetFeeRates, url);
         }
+    },
+    STATIC_1_SAT_PER_VBYTE("Static: Always 1 sat/vB") {
+        @Override
+        public Map<Integer, Double> getBlockTargetFeeRates(Map<Integer, Double> defaultblockTargetFeeRates) {
+            String url = "https://raw.githubusercontent.com/sparrowwallet/sparrow/master/src/main/resources/com/sparrowwallet/sparrow/preferences/feeRatesSource-static-1-sat-per-vbyte.json";
+            return getThreeTierFeeRates(defaultblockTargetFeeRates, url);
+        }
     };
 
     private static final Logger log = LoggerFactory.getLogger(FeeRatesSource.class);

--- a/src/main/resources/com/sparrowwallet/sparrow/preferences/feeRatesSource-static-1-sat-per-vbyte.json
+++ b/src/main/resources/com/sparrowwallet/sparrow/preferences/feeRatesSource-static-1-sat-per-vbyte.json
@@ -1,0 +1,1 @@
+{"fastestFee":1,"halfHourFee":1,"hourFee":1,"minimumFee":1}

--- a/src/main/resources/com/sparrowwallet/sparrow/preferences/general.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/preferences/general.fxml
@@ -49,6 +49,7 @@
                             <FeeRatesSource fx:constant="ELECTRUM_SERVER" />
                             <FeeRatesSource fx:constant="MEMPOOL_SPACE" />
                             <FeeRatesSource fx:constant="BITCOINFEES_EARN_COM" />
+                            <FeeRatesSource fx:constant="STATIC_1_SAT_PER_VBYTE" />
                         </FXCollections>
                     </items>
                 </ComboBox>


### PR DESCRIPTION
As suggested by @dergigi in issue #321.

This pr contains the cheapest solution I could think of.

**Privacy concern**: It leaks application usage data to github, because it queries a static file from github.

The new static fee rate source option queries a raw json file from /src/main/resources/com/sparrowwallet/sparrow/preferences/feeRatesSource-static-1-sat-per-vbyte.json

If this solution doesn't meet the code quality standard of sparrow, maybe someone can use it as starter and solve the data source issue for the json more elegant.