### PR TITLE
logback vuln

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -360,7 +360,7 @@ extraJavaModuleInfo {
     module('json-simple-1.1.1.jar', 'json.simple', '1.1.1') {
         exports('org.json.simple')
     }
-    module('logback-classic-1.2.3.jar', 'logback.classic', '1.2.3') {
+    module('logback-classic-1.2.8.jar', 'logback.classic', '1.2.8') {
         exports('ch.qos.logback.classic')
         requires('org.slf4j')
         requires('logback.core')
@@ -572,7 +572,7 @@ extraJavaModuleInfo {
         requires('org.slf4j')
     }
     module('jnacl-1.0.0.jar', 'eu.neilalexander.jnacl', '1.0.0')
-    module('logback-core-1.2.3.jar', 'logback.core', '1.2.3') {
+    module('logback-core-1.2.8.jar', 'logback.core', '1.2.8') {
         requires('java.xml')
     }
     module('kotlin-stdlib-common-1.5.20.jar', 'org.jetbrains.kotlin.kotlin.stdlib.common', '1.5.20') {


### PR DESCRIPTION
Hi there, can close this PR and make an official one if mine is way off basis. But I saw this:

I see logback has a vuln, not exact, but similar to log4j: http://slf4j.org/log4shell.html 

"Logback does NOT offer a lookup mechanism at the message level. Thus, it is deemed safe with respect to CVE-2021-44228.

However, logback may make JNDI calls from within its configuration file. This was recently reported in LOGBACK-1591 as a vulnerability of lesser severity. In response, we have released logback version 1.2.8. Please upgrade."