### PR TITLE
Rename the passphrase label to salt

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/control/MnemonicKeystorePane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MnemonicKeystorePane.java
@@ -351,7 +351,7 @@ public class MnemonicKeystorePane extends TitledDescriptionPane {
 
             setAlignment(Pos.CENTER_LEFT);
             setSpacing(10);
-            Label passphraseLabel = new Label("Passphrase:");
+            Label passphraseLabel = new Label("Salt:");
             passphraseField = (CustomTextField) TextFields.createClearableTextField();
             passphraseProperty.bind(passphraseField.textProperty());
             passphraseField.setPromptText("Leave blank for none");


### PR DESCRIPTION
A minor UX improvement suggestion. I've been baffled while trying to import a BIP-39 wallet, thinking that "passphrase" was the password for the wallet file encryption at rest, so I was getting an unexpected set of addresses.