### PR TITLE
Add git pull & git submodule update --checkout

### DIFF
--- a/docs/reproducible.md
+++ b/docs/reproducible.md
@@ -94,6 +94,7 @@ git clone --recursive --branch "${GIT_TAG}" https://github.com/sparrowwallet/spa
 If you already have the sparrow repo cloned, fetch all new updates and checkout the release. For this, change into your local sparrow folder and execute:
 
 ```shell
+cd {yourPathToSparrow}/sparrow
 git pull --recurse-submodules
 git checkout "${GIT_TAG}"
 ```
@@ -107,6 +108,7 @@ git submodule update --checkout
 Thereafter, building should be straightforward. If not already done, change into the sparrow folder and run:
 
 ```shell
+cd {yourPathToSparrow}/sparrow  # if you aren't already in the sparrow folder
 ./gradlew jpackage
 ```
 

--- a/docs/reproducible.md
+++ b/docs/reproducible.md
@@ -79,16 +79,34 @@ sudo apt install -y rpm fakeroot binutils
 
 ### Building the binaries
 
-The project can cloned for a specific release tag as follows:
+First, assign a temporary variabel in your shell for the specific release you want to build. For the current one specify:
+
 ```shell
 GIT_TAG="1.7.0"
+```
+
+The project can then be initially cloned as follows:
+
+```shell
 git clone --recursive --branch "${GIT_TAG}" https://github.com/sparrowwallet/sparrow.git
 ```
 
-Thereafter, building should be straightforward:
+If you already have the sparrow repo cloned, fetch all new updates and checkout the release. For this, change into your local sparrow folder and execute:
 
 ```shell
-cd sparrow
+git pull --recurse-submodules
+git checkout "${GIT_TAG}"
+```
+
+Note - there is an additional step if you updated rather then intitally cloned the repo. This is due to the [drongo submodule](https://github.com/sparrowwallet/drongo/tree/master) which needs to be synchronized (back) to the commit state it had at the time of the release. Only then your build will be comparable to the provided one in the release section of Github. To synchronize, additionally run:
+
+```shell
+git submodule update --checkout
+```
+
+Thereafter, building should be straightforward. If not already done, change into the sparrow folder and run:
+
+```shell
 ./gradlew jpackage
 ```
 


### PR DESCRIPTION
Adds an additional guideline for people having the repo already cloned.

Further, the PR tries to mitigate the risk of failed reproducible builds due to wrong commit checked out at the drongo submodule, see problem description https://github.com/sparrowwallet/sparrow/issues/619#issuecomment-1228697555 or [https://stackoverflow.com/questions/1899792/why-is-git-submodule-not-updated-automatically-on-git-checkout](https://stackoverflow.com/questions/1899792/why-is-git-submodule-not-updated-automatically-on-git-checkout)

For reference of  `git submodule update --checkout` see [https://stackoverflow.com/a/41920893](https://stackoverflow.com/a/41920893)

For a permanent solution on the users side [https://stackoverflow.com/questions/4611512/is-there-a-way-to-make-git-pull-automatically-update-submodules](https://stackoverflow.com/questions/4611512/is-there-a-way-to-make-git-pull-automatically-update-submodules) provides additional hints.