### PR TITLE
Add splash-screen during start-up

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/SparrowWalletPreloader.java
+++ b/src/main/java/com/sparrowwallet/sparrow/SparrowWalletPreloader.java
@@ -1,11 +1,46 @@
 package com.sparrowwallet.sparrow;
 
 import javafx.application.Preloader;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 
 public class SparrowWalletPreloader extends Preloader {
+
+    private Stage preloaderStage;
+    private Scene splashscreen;
+    public static final int SPLASHSCREEN_TIME_DELAY_MS = 2_000;
+
+    @Override
+    public void init() throws Exception {
+        FXMLLoader splashLoader = new FXMLLoader(AppServices.class.getResource("splashscreen.fxml"));
+        splashscreen = new Scene(splashLoader.load());
+    }
+
     @Override
     public void start(Stage stage) {
         com.sun.glass.ui.Application.GetApplication().setName("Sparrow");
+
+        preloaderStage = stage;
+        preloaderStage.setScene(splashscreen);
+        preloaderStage.initStyle(StageStyle.UNDECORATED);
+        preloaderStage.show();
+
+    }
+
+    @Override
+    public void handleStateChangeNotification(StateChangeNotification info) {
+        if (info.getType() == StateChangeNotification.Type.BEFORE_START) {
+
+            // put JavaFX-Application thread to sleep so that splashscreen gets the ability to show. Minimize or
+            // delete thread sleep time if time intensive work is done in the SparrowDesktop.init() method
+            try {
+                Thread.sleep(SPLASHSCREEN_TIME_DELAY_MS);
+            } catch (InterruptedException e) {
+                // Not critical if splashscreen is hidden to early
+            }
+            preloaderStage.hide();
+        }
     }
 }

--- a/src/main/resources/com/sparrowwallet/sparrow/splashscreen.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/splashscreen.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            prefHeight="400.0"
+            prefWidth="600.0">
+
+    <Label text="SplashScreen"/>
+
+</AnchorPane>


### PR DESCRIPTION
#### Description
It would be nice to have a short splash-screen before confronting the user with the GUI. As Sparrow hasn't much work to do before showing the GUI, this is only for user experience at this point. 

#### Work outstanding
- [ ] FXML design of the splash screen itself
- [ ] Decide if splash screen should be implemented in the Preloader like in the first commit or rather in the start() method of the GUI application - mainly due to both, Terminal and GUI, using the same Preloader right now.

Is a splash-screen something you might want to consider for Sparrow?