### PR TITLE
Update bitcoin.lukechilds.co to bitcoin.lu.ke

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/PublicElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/PublicElectrumServer.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 public enum PublicElectrumServer {
     BLOCKSTREAM_INFO("blockstream.info", "ssl://blockstream.info:700", Network.MAINNET),
     ELECTRUM_BLOCKSTREAM_INFO("electrum.blockstream.info", "ssl://electrum.blockstream.info:50002", Network.MAINNET),
-    LUKECHILDS_CO("bitcoin.lukechilds.co", "ssl://bitcoin.lukechilds.co:50002", Network.MAINNET),
+    LUKECHILDS_CO("bitcoin.lu.ke", "ssl://bitcoin.lu.ke:50002", Network.MAINNET),
     EMZY_DE("electrum.emzy.de", "ssl://electrum.emzy.de:50002", Network.MAINNET),
     BITAROO_NET("electrum.bitaroo.net", "ssl://electrum.bitaroo.net:50002", Network.MAINNET),
     TESTNET_ARANGUREN_ORG("testnet.aranguren.org", "ssl://testnet.aranguren.org:51002", Network.TESTNET);


### PR DESCRIPTION
I migrated my services over to a new domain, I'll still be keeping the old domain running so old versions of software using it keep working but it would be great to get my new domain in the latest versions.

Should I also update `LUKECHILDS_CO` to `LU_KE` or will that forget the setting for existing users?