### PR TITLE
add StartupWMClass to linux .desktop file

### DIFF
--- a/src/main/deploy/package/linux/Sparrow.desktop
+++ b/src/main/deploy/package/linux/Sparrow.desktop
@@ -7,3 +7,4 @@ Terminal=false
 Type=Application
 Categories=Finance;Network;
 MimeType=application/psbt;application/bitcoin-transaction;x-scheme-handler/bitcoin;x-scheme-handler/auth47;x-scheme-handler/lightning
+StartupWMClass=Sparrow


### PR DESCRIPTION
As the title says I added this so that when you add Sparrow to your application dash bar and open a new window, it is now associated with the already present application icon and a temp icon is not generated in the dash.