### PR TITLE
Enable JaCoCo code coverage reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'org-openjfx-javafxplugin'
     id 'extra-java-module-info'
     id 'org.beryx.jlink' version '2.26.0'
+    id 'jacoco'
 }
 
 def sparrowVersion = '1.7.8'
@@ -158,6 +159,15 @@ processResources {
 
 test {
     jvmArgs '--add-opens=java.base/java.io=com.google.gson'
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+}
+
+jacoco {
+    toolVersion = '0.8.10'
 }
 
 run {


### PR DESCRIPTION
Similar to the PR submitted to the `drongo` repo, this PR enables code coverage reports to help write new unit tests:

![Screenshot from 2023-06-29 23-57-50](https://github.com/sparrowwallet/sparrow/assets/100320/881248fc-73c8-4b4b-96d0-e6f4b1456117)
