### PR TITLE
Satochip: Patch error 0x9C01 in cardBip32GetExtendedKey()

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/io/satochip/SatochipCommandSet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/satochip/SatochipCommandSet.java
@@ -347,8 +347,14 @@ public class SatochipCommandSet {
     public APDUResponse cardBip32GetExtendedKey(byte[] bytePath) {
         byte p1 = (byte) (bytePath.length / 4);
 
-        APDUCommand plainApdu = new APDUCommand(0xB0, INS_BIP32_GET_EXTENDED_KEY, p1, 0x40, bytePath);
-        return this.cardTransmit(plainApdu);
+        APDUCommand capdu = new APDUCommand(0xB0, INS_BIP32_GET_EXTENDED_KEY, p1, 0x40, bytePath);
+        APDUResponse rapdu = this.cardTransmit(capdu);
+        if(rapdu.getSw() == 0x9C01) {
+            // error 0X9C01: no memory available for key derivation => flush memory cache in card
+            capdu = new APDUCommand(0xB0, INS_BIP32_GET_EXTENDED_KEY, p1, 0x80, bytePath);
+            rapdu = this.cardTransmit(capdu);
+        }
+        return rapdu;
     }
 
     /*


### PR DESCRIPTION
This error occurs when the cache memory in the card is full. 
We need to flush the card cache by sending the same command with the p2 flag set to 0x80.