### PR TITLE
build.gradle: Update to JLink plugin 3.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'application'
     id 'org-openjfx-javafxplugin'
     id 'extra-java-module-info'
-    id 'org.beryx.jlink' version '2.26.0'
+    id 'org.beryx.jlink' version '3.0.1'
 }
 
 def sparrowVersion = '1.8.3'


### PR DESCRIPTION
This adds support for building with JDK 21 (when combined with https://github.com/sparrowwallet/drongo/pull/19 and https://github.com/sparrowwallet/drongo/pull/21)

I've confirmed this on macOS/aarch64 using Gradle 8.5 and Java (Temurin) 21.0.1 -- both installed with SDKMAN. Both `gradle run` and `gradle jpackage` seem to work correctly.