### PR TITLE
Sorted value column in Addresses

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/control/AddressTreeTable.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/AddressTreeTable.java
@@ -60,7 +60,7 @@ public class AddressTreeTable extends CoinTreeTable {
             return new ReadOnlyObjectWrapper<>(param.getValue().getValue().getValue());
         });
         amountCol.setCellFactory(p -> new CoinCell());
-        amountCol.setSortable(false);
+        amountCol.setSortable(true);
         getColumns().add(amountCol);
 
         ContextMenu contextMenu = new ContextMenu();


### PR DESCRIPTION
Unless there's a good reason to prevent sorting on the `Value` column, I think it's useful to be able to sort the wallet's addresses by value. 🤞 

<img width="863" alt="image" src="https://github.com/sparrowwallet/sparrow/assets/159790687/47c8277a-33b4-4ee8-a9a7-27d838a0e5c8">
