### PR TITLE
Add delay to RatesService startup (fixes #12760)

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -78,6 +78,7 @@ public class AppServices {
     private static final int RATES_PERIOD_SECS = 5 * 60;
     private static final int VERSION_CHECK_PERIOD_HOURS = 24;
     private static final int CONNECTION_DELAY_SECS = 2;
+    private static final int RATES_STARTUP_DELAY_SECS = 5;
     private static final ExchangeSource DEFAULT_EXCHANGE_SOURCE = ExchangeSource.COINGECKO;
     private static final Currency DEFAULT_FIAT_CURRENCY = Currency.getInstance("USD");
     private static final String TOR_DEFAULT_PROXY_CIRCUIT_ID = "default";
@@ -356,7 +357,7 @@ public class AppServices {
                 exchangeSource == null ? DEFAULT_EXCHANGE_SOURCE : exchangeSource,
                 currency == null ? DEFAULT_FIAT_CURRENCY : currency);
         //Delay startup on first run
-        ratesService.setDelay(Duration.seconds(CONNECTION_DELAY_SECS));
+        ratesService.setDelay(Duration.seconds(RATES_STARTUP_DELAY_SECS));
         ratesService.setPeriod(Duration.seconds(RATES_PERIOD_SECS));
         ratesService.setRestartOnFailure(true);
 

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -78,7 +78,8 @@ public class AppServices {
     private static final int RATES_PERIOD_SECS = 5 * 60;
     private static final int VERSION_CHECK_PERIOD_HOURS = 24;
     private static final int CONNECTION_DELAY_SECS = 2;
-    private static final int RATES_STARTUP_DELAY_SECS = 5;
+    private static final int RATES_STARTUP_DELAY_SECS_DEFAULT = 2;
+    private static final int RATES_STARTUP_DELAY_SECS_WINDOWS = 5;
     private static final ExchangeSource DEFAULT_EXCHANGE_SOURCE = ExchangeSource.COINGECKO;
     private static final Currency DEFAULT_FIAT_CURRENCY = Currency.getInstance("USD");
     private static final String TOR_DEFAULT_PROXY_CIRCUIT_ID = "default";
@@ -357,7 +358,20 @@ public class AppServices {
                 exchangeSource == null ? DEFAULT_EXCHANGE_SOURCE : exchangeSource,
                 currency == null ? DEFAULT_FIAT_CURRENCY : currency);
         //Delay startup on first run
-        ratesService.setDelay(Duration.seconds(RATES_STARTUP_DELAY_SECS));
+        switch(org.controlsfx.tools.Platform.getCurrent())
+        {
+            case WINDOWS:
+                //Windows needs more time (5 Seconds)
+                ratesService.setDelay(Duration.seconds(RATES_STARTUP_DELAY_SECS_WINDOWS));
+                break;
+            case OSX:
+            case UNIX:
+            case UNKNOWN:
+            default:
+                //Other platforms seem ok with 2 Seconds
+                ratesService.setDelay(Duration.seconds(RATES_STARTUP_DELAY_SECS_DEFAULT));
+                break;
+        }
         ratesService.setPeriod(Duration.seconds(RATES_PERIOD_SECS));
         ratesService.setRestartOnFailure(true);
 

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -355,6 +355,8 @@ public class AppServices {
         ExchangeSource.RatesService ratesService = new ExchangeSource.RatesService(
                 exchangeSource == null ? DEFAULT_EXCHANGE_SOURCE : exchangeSource,
                 currency == null ? DEFAULT_FIAT_CURRENCY : currency);
+        //Delay startup on first run
+        ratesService.setDelay(Duration.seconds(CONNECTION_DELAY_SECS));
         ratesService.setPeriod(Duration.seconds(RATES_PERIOD_SECS));
         ratesService.setRestartOnFailure(true);
 


### PR DESCRIPTION
this is to address #1276 - I noticed that adding a startup delay to the ratesService caused to problem to go away, which leads me to believe that is some sort of concurrency issue. Please review as Java is not my primary language - there may be a better / more "correct" way to address the issue