### PR TITLE
Update CaravanMultisig.java

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/io/CaravanMultisig.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/CaravanMultisig.java
@@ -28,7 +28,7 @@ public class CaravanMultisig implements WalletImport, WalletExport {
 
     @Override
     public String getName() {
-        return "Unchained or Caravan Multisig";
+        return "Caravan (Unchained Multisig)";
     }
 
     @Override
@@ -56,7 +56,7 @@ public class CaravanMultisig implements WalletImport, WalletExport {
                 Keystore keystore = new Keystore(extKey.name.length() > Keystore.MAX_LABEL_LENGTH ? extKey.name.substring(0, Keystore.MAX_LABEL_LENGTH) : extKey.name);
 
                 if("Unknown".equals(extKey.bip32Path)) {
-                    extKey.bip32Path = "m/45'/0/0/0";
+                    extKey.bip32Path = "m/0/0/0/0";
                 }
 
                 try {

--- a/src/main/java/com/sparrowwallet/sparrow/io/CaravanMultisig.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/CaravanMultisig.java
@@ -55,6 +55,10 @@ public class CaravanMultisig implements WalletImport, WalletExport {
             for(ExtPublicKey extKey : cf.extendedPublicKeys) {
                 Keystore keystore = new Keystore(extKey.name.length() > Keystore.MAX_LABEL_LENGTH ? extKey.name.substring(0, Keystore.MAX_LABEL_LENGTH) : extKey.name);
 
+                if("Unknown".equals(extKey.bip32Path)) {
+                    extKey.bip32Path = "m/0/0/0/0";
+                }
+                
                 try {
                     keystore.setKeyDerivation(new KeyDerivation(extKey.xfp, extKey.bip32Path));
                 } catch(NumberFormatException e) {

--- a/src/main/java/com/sparrowwallet/sparrow/io/CaravanMultisig.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/CaravanMultisig.java
@@ -55,10 +55,6 @@ public class CaravanMultisig implements WalletImport, WalletExport {
             for(ExtPublicKey extKey : cf.extendedPublicKeys) {
                 Keystore keystore = new Keystore(extKey.name.length() > Keystore.MAX_LABEL_LENGTH ? extKey.name.substring(0, Keystore.MAX_LABEL_LENGTH) : extKey.name);
 
-                if("Unknown".equals(extKey.bip32Path)) {
-                    extKey.bip32Path = "m/0/0/0/0";
-                }
-
                 try {
                     keystore.setKeyDerivation(new KeyDerivation(extKey.xfp, extKey.bip32Path));
                 } catch(NumberFormatException e) {


### PR DESCRIPTION
Sparrow currently makes an assumption about the derivation path to replace the `UNKNOWN` masked derivation path. This assumption is incorrect, and should be removed.