### PR TITLE
Add SingleMainWindow=true to Sparrow.desktop

### DIFF
--- a/src/main/deploy/package/linux/Sparrow.desktop
+++ b/src/main/deploy/package/linux/Sparrow.desktop
@@ -8,3 +8,4 @@ Type=Application
 Categories=Finance;Network;
 MimeType=application/psbt;application/bitcoin-transaction;application/pgp-signature;x-scheme-handler/bitcoin;x-scheme-handler/auth47;x-scheme-handler/lightning
 StartupWMClass=Sparrow
+SingleMainWindow=true


### PR DESCRIPTION
This prevents desktop environments from displaying "New Window" as one of the right click actions in the side bar and application list when Sparrow is already running.

Closes #1436.