### PR TITLE
Patch https://github.com/Toporin/SatochipApplet/issues/15

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/io/satochip/SatoCardApi.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/satochip/SatoCardApi.java
@@ -165,12 +165,25 @@ public class SatoCardApi extends CardApi {
             if(!psbtInput.isSigned()) {
                 WalletNode signingNode = signingNodes.get(psbtInput);
                 List<Keystore> keystores = wallet.getKeystores();
-                // recover full derivation path
-                Keystore keystore = keystores.get(0);
-                String basePath = keystore.getKeyDerivation().getDerivationPath();
-                String extendedPath = signingNode.getDerivationPath().substring(1);
-                String fullPath = basePath + extendedPath;
-
+                // recover derivation path from Satochip keystore
+                String fullPath = null;
+                for(int i = 0; i < keystores.size(); i++) {
+                    Keystore keystore = keystores.get(i);
+                    WalletModel walletModel = keystore.getWalletModel();
+                    if(walletModel == WalletModel.SATOCHIP) {
+                        String basePath = keystore.getKeyDerivation().getDerivationPath();
+                        String extendedPath = signingNode.getDerivationPath().substring(1);
+                        fullPath = basePath + extendedPath;
+                        break;
+                    }
+                }
+                if (fullPath == null) {
+                    // recover a default derivation path from first keystore
+                    Keystore keystore = keystores.get(0);
+                    String basePath = keystore.getKeyDerivation().getDerivationPath();
+                    String extendedPath = signingNode.getDerivationPath().substring(1);
+                    fullPath = basePath + extendedPath;
+                }
                 psbtInput.sign(new CardPSBTInputSigner(signingNode, fullPath));
             }
         }

--- a/src/main/java/com/sparrowwallet/sparrow/io/satochip/SatoCardApi.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/satochip/SatoCardApi.java
@@ -164,19 +164,12 @@ public class SatoCardApi extends CardApi {
         for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
             if(!psbtInput.isSigned()) {
                 WalletNode signingNode = signingNodes.get(psbtInput);
-                String fullPath = null;
                 List<Keystore> keystores = wallet.getKeystores();
-                for(int i = 0; i < keystores.size(); i++) {
-                    Keystore keystore = keystores.get(i);
-                    WalletModel walletModel = keystore.getWalletModel();
-                    if(walletModel == WalletModel.SATOCHIP) {
-                        String basePath = keystore.getKeyDerivation().getDerivationPath();
-                        String extendedPath = signingNode.getDerivationPath().substring(1);
-                        fullPath = basePath + extendedPath;
-                        keystore.getPubKey(signingNode);
-                        break;
-                    }
-                }
+                // recover full derivation path
+                Keystore keystore = keystores.get(0);
+                String basePath = keystore.getKeyDerivation().getDerivationPath();
+                String extendedPath = signingNode.getDerivationPath().substring(1);
+                String fullPath = basePath + extendedPath;
 
                 psbtInput.sign(new CardPSBTInputSigner(signingNode, fullPath));
             }


### PR DESCRIPTION
Null exception can be thrown when signing a multisig transaction from a Sparrow wallet reconstructed from a Bitcoin descriptor. This happens when the user did not configure any keystore with the corresponding Satochip card ('import' button). In this case, the 'fullpath' derivation path remains undefined, leading to the exception.