### PR TITLE
GHA package.yml: run on pull_request

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,6 +1,6 @@
 name: Package
 
-on: workflow_dispatch
+on: [workflow_dispatch, pull_request]
 
 permissions:
   contents: read


### PR DESCRIPTION
Run the package workflow on a pull request.  (Will still require approval via GitHub for external and/or first-time contributors)