### PR TITLE
GHA package.yml: fail-fast:false

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022, ubuntu-20.04, ubuntu-22.04-arm, macos-13, macos-14]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
With this setting, if a test on one matrix.os fails, the other tests will not be cancelled.