### PR TITLE
GHA package.yaml: Update ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-20.04, ubuntu-22.04-arm, macos-13, macos-14]
+        os: [windows-2022, ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
ubuntu-20.04 is deprecated as of 2025-02-01. Brownouts are coming soon, and the image will be completely removed by 2025-04-01.

See: https://github.com/actions/runner-images/issues/11101