### PR TITLE
GHA: add gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -54,3 +54,10 @@ jobs:
           path: |
             build/jpackage/*
             !build/jpackage/Sparrow/
+
+  gradle_wrapper_validate:
+    name: "Validate Gradle Wrapper"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
This PR uses the `gradle/actions/wrapper-validation` GitHub Action to validate the Gradle wrapper files to make sure they have a valid SHA sum.