### PR TITLE
GHA package.yaml: run `gradle_wrapper_validate` before `build`

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -54,3 +54,10 @@ jobs:
           path: |
             build/jpackage/*
             !build/jpackage/Sparrow/
+
+  gradle_wrapper_validate:
+    name: "Validate Gradle Wrapper"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   build:
+    needs: gradle_wrapper_validate
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Add `needs: gradle_wrapper_validate` to `build` job.

Child of PR #1651 