### PR TITLE
GHA package.yaml: Add explicit job name

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   build:
+    name: build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
* ~~Change job label from `build` to `jpackage`~~
* Add a `name` attribute setting name with matrix.os

This matches the format of `package-nix.yaml` in PR #1648 to keep them similar assuming it is merged as is.
