### PR TITLE
Update kmp-tor-resource to `408.16.3` with fix for missing `LC_UUID` block on `macOS` compilations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'org-openjfx-javafxplugin'
     id 'org.beryx.jlink' version '3.1.1'
     id 'org.gradlex.extra-java-module-info' version '1.9'
-    id 'io.matthewnelson.kmp.tor.resource-filterjar' version '408.16.2'
+    id 'io.matthewnelson.kmp.tor.resource-filterjar' version '408.16.3'
 }
 
 def os = org.gradle.internal.os.OperatingSystem.current()
@@ -76,7 +76,7 @@ dependencies {
     implementation('co.nstant.in:cbor:0.9')
     implementation('org.openpnp:openpnp-capture-java:0.0.28-5')
     implementation("io.matthewnelson.kmp-tor:runtime:2.2.1")
-    implementation("io.matthewnelson.kmp-tor:resource-exec-tor-gpl:408.16.2")
+    implementation("io.matthewnelson.kmp-tor:resource-exec-tor-gpl:408.16.3")
     implementation('org.jetbrains.kotlinx:kotlinx-coroutines-javafx:1.10.1') {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-common'
     }


### PR DESCRIPTION
Fixes #1728 