### PR TITLE
Use language-independent SID for Windows Users group permission

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,7 +285,8 @@ if(os.linux) {
 
 tasks.register('addUserWritePermission', Exec) {
     if(os.windows) {
-        commandLine 'icacls', "$buildDir\\image\\legal", '/grant', 'Users:(OI)(CI)F', '/T'
+        def usersGroup = '*S-1-5-32-545' // Windows "Users" group SID (language-independent)
+        commandLine 'icacls', "$buildDir\\image\\legal", '/grant', "${usersGroup}:(OI)(CI)F", '/T'
     } else {
         commandLine 'chmod', '-R', 'u+w', "$buildDir/image/legal"
     }


### PR DESCRIPTION
When I tried building Sparrow in a Spanish Windows 10 system, the build failed in the task that sets write permissions for the user:
```
  > Task :addUserWritePermission FAILED
  Se procesaron correctamente 0 archivos; error al procesar 1 archivos
  Process 'command 'icacls'' finished with exit value 1332 (state: FAILED)
```
The failure occurred because the task used the group name `Users`, but in non-English systems it could be different (for example., `Usuarios` in Spanish), so Windows cannot find the group and the `icacls` command returns error `1332`.

This change replaces the group name with the SID `*S-1-5-32-545`, a constant that always identifies the local Users group regardless of Windows version or language.