### PR TITLE
Update jzbar dependency to 0.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     implementation('com.github.hervegirod:fxsvgimage:1.1')
     implementation('com.sparrowwallet:toucan:0.9.0')
     implementation('com.jcraft:jzlib:1.1.3')
-    implementation('io.github.doblon8:jzbar:0.0.1')
+    implementation('io.github.doblon8:jzbar:0.2.1')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.10.0')
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.10.0')
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')


### PR DESCRIPTION
Tested successfully by @alvroble on macOS and by me on Linux and Windows.