### PR TITLE
feat: add hide/unhide button next to transaction amounts

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/wallet/TransactionsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/TransactionsController.java
@@ -9,6 +9,7 @@ import com.sparrowwallet.sparrow.io.Config;
 import com.sparrowwallet.sparrow.io.WalletTransactions;
 import com.sparrowwallet.sparrow.net.ExchangeSource;
 import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
 import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.event.ActionEvent;
@@ -16,10 +17,12 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
 import javafx.scene.control.TextArea;
+import javafx.scene.control.Tooltip;
 import javafx.scene.control.TreeItem;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import org.controlsfx.control.MasterDetailPane;
+import org.controlsfx.glyphfont.Glyph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +70,9 @@ public class TransactionsController extends WalletFormController implements Init
     @FXML
     private Button exportCsv;
 
+    @FXML
+    private Button hideAmountsButton;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         EventManager.get().register(this);
@@ -99,6 +105,8 @@ public class TransactionsController extends WalletFormController implements Init
         transactionsMasterDetail.setShowDetailNode(Config.get().isShowLoadingLog());
         loadingLog.appendText("Wallet loading history for " + getWalletForm().getWallet().getFullDisplayName());
         loadingLog.setEditable(false);
+
+        updateHideAmountsButtonIcon(Config.get().isHideAmounts());
     }
 
     private void setTransactionCount(WalletTransactionsEntry walletTransactionsEntry) {
@@ -123,6 +131,21 @@ public class TransactionsController extends WalletFormController implements Init
             });
             exportService.start();
         }
+    }
+
+    public void toggleHideAmounts(ActionEvent event) {
+        boolean currentState = Config.get().isHideAmounts();
+        Config.get().setHideAmounts(!currentState);
+        EventManager.get().post(new HideAmountsStatusEvent(!currentState));
+        updateHideAmountsButtonIcon(!currentState);
+    }
+
+    private void updateHideAmountsButtonIcon(boolean isHidden) {
+        // Use EYE_SLASH unicode character (\uf070) when hidden, EYE when shown
+        Glyph glyph = new Glyph(FontAwesome5.FONT_NAME, isHidden ? '\uf070' : FontAwesome5.Glyph.EYE);
+        glyph.setFontSize(12);
+        hideAmountsButton.setGraphic(glyph);
+        hideAmountsButton.setTooltip(new Tooltip(isHidden ? "Show Amounts" : "Hide Amounts"));
     }
 
     private void logMessage(String logMessage) {
@@ -203,6 +226,7 @@ public class TransactionsController extends WalletFormController implements Init
         mempoolBalance.refresh();
         fiatBalance.refresh();
         fiatMempoolBalance.refresh();
+        updateHideAmountsButtonIcon(event.isHideAmounts());
     }
 
     @Subscribe

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/transactions.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/transactions.fxml
@@ -35,7 +35,16 @@
                 <Form GridPane.columnIndex="0" GridPane.rowIndex="0">
                     <Fieldset inputGrow="SOMETIMES" text="Transactions" styleClass="header">
                         <Field text="Balance:">
-                            <CopyableCoinLabel fx:id="balance"/><Region HBox.hgrow="ALWAYS"/><FiatLabel fx:id="fiatBalance" minWidth="110" />
+                            <CopyableCoinLabel fx:id="balance"/>
+                            <Button fx:id="hideAmountsButton" maxHeight="25" onAction="#toggleHideAmounts" translateY="-1" styleClass="icon-button">
+                                <graphic>
+                                    <Glyph fontFamily="Font Awesome 5 Free Solid" icon="EYE" fontSize="12" />
+                                </graphic>
+                                <tooltip>
+                                    <Tooltip text="Hide Amounts" />
+                                </tooltip>
+                            </Button>
+                            <Region HBox.hgrow="ALWAYS"/><FiatLabel fx:id="fiatBalance" minWidth="110" />
                         </Field>
                         <Field text="Mempool:">
                             <CopyableCoinLabel fx:id="mempoolBalance" /><Region HBox.hgrow="ALWAYS"/><FiatLabel fx:id="fiatMempoolBalance" minWidth="110" />


### PR DESCRIPTION
- Closes #1871 
- Follow up to https://github.com/sparrowwallet/sparrow/pull/1854 (16e73ebc3244e3ac89aa1cd4f4a535cbe2dc0ea2)

<img width="376" height="153" alt="image" src="https://github.com/user-attachments/assets/8147041a-1a4e-4301-9622-8ca96a697e49" />
<img width="376" height="153" alt="image" src="https://github.com/user-attachments/assets/b565fd2f-9baa-4db2-9315-f564e72f68d8" />
