### PR TITLE
Add a RAW QR option to QRDisplayDialog

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -771,7 +771,8 @@ public class AppController implements Initializable {
                 byte[] txBytes = transaction.bitcoinSerialize();
                 UR ur = UR.fromBytes(txBytes);
                 BBQR bbqr = new BBQR(BBQRType.TXN, txBytes);
-                QRDisplayDialog qrDisplayDialog = new QRDisplayDialog(ur, bbqr, false, false, false);
+                String txHex = Utils.bytesToHex(txBytes);
+                QRDisplayDialog qrDisplayDialog = new QRDisplayDialog(ur, bbqr, txHex, false, false, false);
                 qrDisplayDialog.initOwner(rootStack.getScene().getWindow());
                 qrDisplayDialog.showAndWait();
             } catch(Exception e) {
@@ -873,7 +874,7 @@ public class AppController implements Initializable {
             byte[] psbtBytes = transactionTabData.getPsbt().getForExport().serialize();
             CryptoPSBT cryptoPSBT = new CryptoPSBT(psbtBytes);
             BBQR bbqr = new BBQR(BBQRType.PSBT, psbtBytes);
-            QRDisplayDialog qrDisplayDialog = new QRDisplayDialog(cryptoPSBT.toUR(), bbqr, false, true, false);
+            QRDisplayDialog qrDisplayDialog = new QRDisplayDialog(cryptoPSBT.toUR(), bbqr, null, false, true, false);
             qrDisplayDialog.initOwner(rootStack.getScene().getWindow());
             qrDisplayDialog.show();
         }

--- a/src/main/java/com/sparrowwallet/sparrow/control/DescriptorQRDisplayDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/DescriptorQRDisplayDialog.java
@@ -10,7 +10,7 @@ import javafx.scene.control.Button;
 
 public class DescriptorQRDisplayDialog extends QRDisplayDialog {
     public DescriptorQRDisplayDialog(String walletName, String outputDescriptor, UR ur, BBQR bbqr, boolean selectBbqrButton) {
-        super(ur, bbqr, false, false, selectBbqrButton);
+        super(ur, bbqr, null, false, false, selectBbqrButton);
 
         DialogPane dialogPane = getDialogPane();
         final ButtonType pdfButtonType = new javafx.scene.control.ButtonType("Save PDF...", ButtonBar.ButtonData.HELP_2);

--- a/src/main/java/com/sparrowwallet/sparrow/control/FileKeystoreExportPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/FileKeystoreExportPane.java
@@ -157,7 +157,7 @@ public class FileKeystoreExportPane extends TitledDescriptionPane {
                 if(exporter instanceof Bip129) {
                     UR ur = UR.fromBytes(baos.toByteArray());
                     BBQR bbqr = new BBQR(BBQRType.UNICODE, baos.toByteArray());
-                    qrDisplayDialog = new QRDisplayDialog(ur, bbqr, false, true, false);
+                    qrDisplayDialog = new QRDisplayDialog(ur, bbqr, null, false, true, false);
                 } else {
                     qrDisplayDialog = new QRDisplayDialog(baos.toString(StandardCharsets.UTF_8));
                 }

--- a/src/main/java/com/sparrowwallet/sparrow/control/FileWalletExportPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/FileWalletExportPane.java
@@ -171,7 +171,7 @@ public class FileWalletExportPane extends TitledDescriptionPane {
                 } else if(exporter instanceof Bip129 || exporter instanceof WalletLabels) {
                     UR ur = UR.fromBytes(outputStream.toByteArray());
                     BBQR bbqr = new BBQR(BBQRType.UNICODE, outputStream.toByteArray());
-                    qrDisplayDialog = new QRDisplayDialog(ur, bbqr, false, false, false);
+                    qrDisplayDialog = new QRDisplayDialog(ur, bbqr, null, false, false, false);
                 } else if(exporter instanceof Descriptor) {
                     boolean addBbqrOption = exportWallet.getKeystores().stream().anyMatch(keystore -> keystore.getWalletModel().showBbqr());
                     boolean selectBbqrOption = exportWallet.getKeystores().stream().allMatch(keystore -> keystore.getWalletModel().selectBbqr());
@@ -182,7 +182,7 @@ public class FileWalletExportPane extends TitledDescriptionPane {
                 } else if(exporter.getClass().equals(ColdcardMultisig.class)) {
                     UR ur = UR.fromBytes(outputStream.toByteArray());
                     BBQR bbqr = new BBQR(BBQRType.UNICODE, outputStream.toByteArray());
-                    qrDisplayDialog = new QRDisplayDialog(ur, bbqr, false, false, true);
+                    qrDisplayDialog = new QRDisplayDialog(ur, bbqr, null, false, false, true);
                 } else {
                     qrDisplayDialog = new QRDisplayDialog(outputStream.toString(StandardCharsets.UTF_8));
                 }

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -988,7 +988,7 @@ public class HeadersController extends TransactionFormController implements Init
 
         CryptoPSBT cryptoPSBT = new CryptoPSBT(psbtBytes);
         BBQR bbqr = addBbqrOption ? new BBQR(BBQRType.PSBT, psbtBytes) : null;
-        QRDisplayDialog qrDisplayDialog = new QRDisplayDialog(cryptoPSBT.toUR(), bbqr, addLegacyEncodingOption, true, selectBbqrOption);
+        QRDisplayDialog qrDisplayDialog = new QRDisplayDialog(cryptoPSBT.toUR(), bbqr, null, addLegacyEncodingOption, true, selectBbqrOption);
         qrDisplayDialog.initOwner(toggleButton.getScene().getWindow());
         Optional<ButtonType> optButtonType = qrDisplayDialog.showAndWait();
         if(optButtonType.isPresent() && optButtonType.get().getButtonData() == ButtonBar.ButtonData.OK_DONE) {
@@ -1358,7 +1358,8 @@ public class HeadersController extends TransactionFormController implements Init
             byte[] txBytes = transaction.bitcoinSerialize();
             UR ur = UR.fromBytes(txBytes);
             BBQR bbqr = new BBQR(BBQRType.TXN, txBytes);
-            QRDisplayDialog qrDisplayDialog = new QRDisplayDialog(ur, bbqr, false, false, false);
+            String txHex = Utils.bytesToHex(txBytes);
+            QRDisplayDialog qrDisplayDialog = new QRDisplayDialog(ur, bbqr, txHex, false, false, false);
             qrDisplayDialog.initOwner(showTransactionButton.getScene().getWindow());
             qrDisplayDialog.showAndWait();
         } catch (Exception exception) {

--- a/src/main/resources/com/sparrowwallet/sparrow/app.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/app.css
@@ -107,3 +107,8 @@
     -fx-background-color: linear-gradient(to bottom, derive(-fx-text-box-border, -20%), derive(-fx-text-box-border, -30%)), linear-gradient(to bottom, derive(gold, 30%), gold);
     -fx-background-insets: 0, 1;
 }
+
+.root .list-item:disabled,
+.root .list-cell:disabled {
+    -fx-opacity: 0.5;
+}

--- a/src/main/resources/com/sparrowwallet/sparrow/darktheme.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/darktheme.css
@@ -151,6 +151,10 @@ HorizontalHeaderColumn > TableColumnHeader.column-header.table-column{
     -fx-border-color: #626367;
 }
 
+.root .list-cell:disabled {
+    -fx-opacity: 0.5;
+}
+
 .root .tab-pane > .tab-header-area > .headers-region {
     -fx-color: derive(-fx-base, 40%);
     -fx-mark-color: ladder(-fx-base, white 30%, derive(-fx-base,-63%) 31%);


### PR DESCRIPTION
This PR replaces the default toggle UR/BBQr behavior in the show QR dialog window with a drop down menu. The drop down menu offers UR, BBQr and RAW as options. 

RAW is useful when using sparrow as signer for watch only wallet apps (like Blue Wallet) that only support broadcasting transaction QRs with raw hex encoding.

<img width="669" height="860" alt="image13025_clean" src="https://github.com/user-attachments/assets/5262f375-c6ab-40ab-af59-e669037644f8" />
