### PR TITLE
Add optional OP_RETURN field to Send screen

### DIFF
--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/payment.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/payment.fxml
@@ -80,6 +80,18 @@
                 <Region style="-fx-pref-width: 5" />
                 <ToggleButton fx:id="maxButton" text="Max" onAction="#setMaxInput" />
             </Field>
+            <Field fx:id="opReturnField" text="OP_RETURN:">
+                <TextField fx:id="opReturn" promptText="Optional data (max 80 bytes)">
+                    <tooltip>
+                        <Tooltip text="Optional arbitrary data to embed in the transaction (max 80 bytes). The data will be stored in an OP_RETURN output with 0 value."/>
+                    </tooltip>
+                </TextField>
+                <Label fx:id="opReturnStatus" text="">
+                    <graphic>
+                        <Glyph fx:id="opReturnStatusGlyph" fontFamily="Font Awesome 5 Free Solid" fontSize="12" icon="CHECK_CIRCLE" />
+                    </graphic>
+                </Label>
+            </Field>
         </Fieldset>
     </Form>
     <Form GridPane.columnIndex="2" GridPane.rowIndex="0">


### PR DESCRIPTION
## Summary
- Adds an optional OP_RETURN field to each payment tab on the Send screen
- Allows users to embed arbitrary data (up to 80 bytes) in their Bitcoin transactions
- The OP_RETURN output has 0 value as required by the Bitcoin protocol

## Implementation Details
- New OP_RETURN text field added to the payment form (payment.fxml)
- Real-time byte count display with validation status indicator
- Validation for the 80-byte maximum limit with visual feedback
- OP_RETURN data is encoded as UTF-8
- Multiple payments can each have their own OP_RETURN data
- Existing OP_RETURN functionality (BIP47 notifications) is preserved and works alongside user-entered data

## Technical Changes
- **PaymentController.java**: Added FXML field declarations, getOpReturnData(), isValidOpReturn(), updateOpReturnStatus(), and clearOpReturn() methods
- **SendController.java**: Added getOpReturnsFromPaymentTabs() and areAllOpReturnsValid() methods, modified updateTransaction() to combine user-entered OP_RETURN data with existing opReturnsList
- **payment.fxml**: Added new OP_RETURN field with tooltip and status indicator

## Screenshots
The OP_RETURN field appears below the Amount field in each payment tab, with a status indicator showing the byte count and validation state.

## Test plan
- [ ] Verify the OP_RETURN field appears on the Send screen
- [ ] Test entering data and observing the byte count
- [ ] Test exceeding 80 bytes and verify validation error
- [ ] Create a transaction with OP_RETURN data and verify it's included in the transaction
- [ ] Test clearing the form and verify OP_RETURN field is cleared
- [ ] Test multiple payment tabs with different OP_RETURN data
- [ ] Verify BIP47 notification transactions still work correctly

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)