### PR TITLE
work around import of corrupt samourai wallet backup file

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/io/Samourai.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Samourai.java
@@ -73,6 +73,10 @@ public class Samourai implements KeystoreFileImport {
             return gson.fromJson(input, stringStringMap);
         } catch (JsonParseException e) {
             int closingBracket = input.indexOf('}');
+            if (closingBracket < 0) {
+                throw e;
+            }
+
             String fixedInput = input.substring(0, closingBracket + 1);
             return gson.fromJson(fixedInput, stringStringMap);
         }


### PR DESCRIPTION
There's a bug since latest Samourai Wallet releases that still exists in Ashigaru: the backup file is corrupted when saved and junk content is appended to it.

This PR works around it by, in case of JSONParseException, removing the content after the closing bracket.

I had to deal with this in a [ personal project](https://github.com/ottosch/brute-samourai/blob/master/src/samourai/samourai.go#L41) some time ago.