### PR TITLE
.gitmodules: Sanitize.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "drongo"]
 	path = drongo
-	url = ../../sparrowwallet/drongo.git
+	url = ../drongo.git
 [submodule "lark"]
 	path = lark
-	url = ../../sparrowwallet/lark.git
+	url = ../lark.git


### PR DESCRIPTION
This makes the git submodules work even if the top level project was cloned in a directory named something else than 'sparrowwallet'.