### PR TITLE
Fix TLS certificate validation for Bitcoin RPC and public Electrum servers

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/TcpOverTlsTransport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/TcpOverTlsTransport.java
@@ -62,6 +62,12 @@ public class TcpOverTlsTransport extends TcpTransport {
 
     private TrustManager[] getTrustManagers(File crtFile) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
         if(crtFile == null) {
+            if(PublicElectrumServer.isPublicServer(server)) {
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                tmf.init((KeyStore) null);
+                return tmf.getTrustManagers();
+            }
+
             return new TrustManager[] {
                     new X509TrustManager() {
                         public X509Certificate[] getAcceptedIssuers() {
@@ -88,7 +94,10 @@ public class TcpOverTlsTransport extends TcpTransport {
             };
         }
 
-        Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(new FileInputStream(crtFile));
+        Certificate certificate;
+        try(FileInputStream fis = new FileInputStream(crtFile)) {
+            certificate = CertificateFactory.getInstance("X.509").generateCertificate(fis);
+        }
         if(certificate instanceof X509Certificate) {
             try {
                 X509Certificate x509Certificate = (X509Certificate)certificate;


### PR DESCRIPTION
- **BitcoindTransport**: Replace trust-all SSL factory with TOFU certificate pinning
- **TcpOverTlsTransport**: Use system CA trust managers for public Electrum servers