### PR TITLE
Bind embedded Electrum server to loopback only

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/cormorant/electrum/ElectrumServerRunnable.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/cormorant/electrum/ElectrumServerRunnable.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
@@ -69,7 +70,7 @@ public class ElectrumServerRunnable implements Runnable {
 
     private void openServerSocket() {
         try {
-            serverSocket = new ServerSocket(0);
+            serverSocket = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
         } catch(IOException e) {
             throw new RuntimeException("Cannot open electrum server port", e);
         }


### PR DESCRIPTION
## Summary
- Bind the embedded Electrum server socket to loopback (`127.0.0.1`) instead of all interfaces (`0.0.0.0`)
- Previously, other machines on the local network could connect and query wallet data