### PR TITLE
show entire previous outpoint when possible

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/control/TransactionDiagram.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/TransactionDiagram.java
@@ -570,7 +570,7 @@ public class TransactionDiagram extends GridPane {
     }
 
     private String getInputDescription(BlockTransactionHashIndex input) {
-        return input.getLabel() != null && !input.getLabel().isEmpty() ? input.getLabel() : input.getHashAsString().substring(0, 8) + "..:" + input.getIndex();
+        return input.getLabel() != null && !input.getLabel().isEmpty() ? input.getLabel() : input.getHashAsString() + ":" + input.getIndex();
     }
 
     String getCoinValue(long amount) {

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/table/OutputTableCell.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/table/OutputTableCell.java
@@ -13,7 +13,13 @@ public class OutputTableCell extends TableCell {
     @Override
     public String formatCell() {
         if(entry instanceof UtxoEntry utxoEntry) {
-            return utxoEntry.getDescription();
+            String description = utxoEntry.getDescription();
+            int maxLength = WIDTH - 2;
+            if (description.length() > maxLength) {
+                return description.substring(0, maxLength - 2) + "..";
+            }
+
+            return description;
         }
 
         return "";

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/InputForm.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/InputForm.java
@@ -93,7 +93,7 @@ public class InputForm extends IndexedTransactionForm {
         }
 
         TransactionOutPoint outPoint = getTransactionInput().getOutpoint();
-        return outPoint.getHash().toString().substring(0, 8) + "..:" + outPoint.getIndex();
+        return outPoint.getHash().toString() + ":" + outPoint.getIndex();
     }
 
     @Override

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/HashIndexEntry.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/HashIndexEntry.java
@@ -51,7 +51,7 @@ public class HashIndexEntry extends Entry implements Comparable<HashIndexEntry> 
 
     public String getDescription() {
         return (type.equals(Type.INPUT) ? "Spent by input " : "Received from output ") +
-                getHashIndex().getHash().toString().substring(0, 8) + "..:" +
+                getHashIndex().getHash().toString() + ":" +
                 getHashIndex().getIndex() +
                 (getHashIndex().getHeight() <= 0 ? " (Unconfirmed)" : " on " + DateLabel.getShortDateFormat(getHashIndex().getDate()));
     }

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/TransactionHashIndexEntry.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/TransactionHashIndexEntry.java
@@ -23,9 +23,9 @@ public class TransactionHashIndexEntry extends HashIndexEntry {
     public String getDescription() {
         if(getType().equals(Type.INPUT)) {
             TransactionInput txInput = getBlockTransaction().getTransaction().getInputs().get((int)getHashIndex().getIndex());
-            return "Spent " + txInput.getOutpoint().getHash().toString().substring(0, 8) + "..:" + txInput.getOutpoint().getIndex();
+            return "Spent " + txInput.getOutpoint().getHash().toString() + ":" + txInput.getOutpoint().getIndex();
         } else {
-            return (getKeyPurpose().equals(KeyPurpose.RECEIVE) ? "Received to " : "Change to ") + getHashIndex().getHash().toString().substring(0, 8) + "..:" + getHashIndex().getIndex();
+            return (getKeyPurpose().equals(KeyPurpose.RECEIVE) ? "Received to " : "Change to ") + getHashIndex().getHash().toString() + ":" + getHashIndex().getIndex();
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/UtxoEntry.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/UtxoEntry.java
@@ -29,7 +29,7 @@ public class UtxoEntry extends HashIndexEntry {
 
     @Override
     public String getDescription() {
-        return getHashIndex().getHash().toString().substring(0, 8) + "..:" + getHashIndex().getIndex();
+        return getHashIndex().getHash().toString() + ":" + getHashIndex().getIndex();
     }
 
     @Override

--- a/src/main/resources/com/sparrowwallet/sparrow/transaction/transaction.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/transaction/transaction.css
@@ -35,3 +35,8 @@
 .change-warning-icon, .payment-warning-icon {
     -fx-text-fill: rgb(238, 210, 2);
 }
+
+.tree-cell > .label {
+    -fx-text-overflow: ellipsis;
+    -fx-white-space: nowrap;
+}

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/wallet.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/wallet.css
@@ -32,6 +32,8 @@
 .address-cell, .utxo-row.entry-cell {
     -fx-font-size: 13px;
     -fx-font-family: 'Fragment Mono Regular';
+    -fx-text-overflow: ellipsis;
+    -fx-white-space: nowrap;
 }
 
 .cell > .hyperlink {


### PR DESCRIPTION
Hello, I would like to propose changing how previous outpoints are displayed: instead of being cut in the 8th char, they would take as much space as possible, displaying ellipsis (with CSS text-overflow) if there isn't enough room. The exception would be tooltips, which seem to always fit the whole prevout nicely.

I dealt with maximum width on OutputTableCell::formatCell too, although I haven't tested it in practice (I think sparrow server isn't used anymore).

I'm open to further adjustments :+1: .

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b3afb979-7717-4654-b929-690eb1738c46" />

<img width="1229" height="402" alt="image" src="https://github.com/user-attachments/assets/b5edc23c-344e-48a4-813e-af5f74a95220" />

<img width="1047" height="1031" alt="image" src="https://github.com/user-attachments/assets/b598089c-3501-43f8-8503-52282955ed88" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b3f37c4b-8845-4aa1-a067-c941208fb9fb" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/82855301-e33d-4b08-8c34-05d03724f77e" />

<img width="1005" height="450" alt="image" src="https://github.com/user-attachments/assets/fbb02898-4dd5-4ced-b9a0-9429af15e45d" />
