### PR TITLE
fix: make password change atomic to prevent wallet DB corruption

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
@@ -162,13 +162,65 @@ public class DbPersistence implements Persistence {
 
     @Override
     public void updateWallet(Storage storage, Wallet wallet, ECKey encryptionPubKey) throws StorageException {
-        updatePassword(storage, encryptionPubKey);
+        String newPassword = getFilePassword(encryptionPubKey);
 
-        updateExecutor.execute(() -> {
+        if(dataSource != null && !Objects.equals(getDatasourcePassword(), newPassword)) {
+            // Password is changing: capture the current password now, then run the keystore-encryption
+            // flush and the H2 file re-encryption atomically on the executor.  This guarantees that any
+            // pending keystoreEncryptionChanged task (which is also queued on the executor) completes
+            // first, so seed/keystore rows are written under the OLD file password before the file
+            // encryption is changed – eliminating the crash-corruption window where the DB file is
+            // already unencrypted but the seed row still holds encrypted data.
+            String currentPassword = getDatasourcePassword();
+            updateExecutor.execute(() -> {
+                try {
+                    flushEncryptionKeystores(storage, wallet, currentPassword);
+                    updatePassword(storage, encryptionPubKey);
+                    update(storage, wallet, newPassword);
+                } catch(Exception e) {
+                    log.error("Error updating wallet db during password change", e);
+                }
+            });
+        } else {
+            updatePassword(storage, encryptionPubKey);
+            updateExecutor.execute(() -> {
+                try {
+                    update(storage, wallet, newPassword);
+                } catch(Exception e) {
+                    log.error("Error updating wallet db", e);
+                }
+            });
+        }
+    }
+
+    /**
+     * Synchronously writes any pending keystore/seed encryption changes to the DB using the supplied
+     * (current/old) file password, then clears them from the dirty map so {@link #update} does not
+     * process them a second time.  Must be called from the update executor thread before the file
+     * encryption is changed.
+     */
+    private void flushEncryptionKeystores(Storage storage, Wallet wallet, String currentPassword) throws StorageException {
+        DirtyPersistables dirtyPersistables = dirtyPersistablesMap.get(wallet);
+        if(dirtyPersistables == null || dirtyPersistables.encryptionKeystores.isEmpty()) {
+            return;
+        }
+
+        List<Keystore> keystoresToFlush = new ArrayList<>(dirtyPersistables.encryptionKeystores);
+        dirtyPersistables.encryptionKeystores.clear();
+
+        log.debug("Flushing " + keystoresToFlush.size() + " keystore encryption change(s) for " + wallet.getFullName() + " before file password change");
+
+        Jdbi jdbi = getJdbi(storage, currentPassword);
+        jdbi.useHandle(handle -> {
+            WalletDao walletDao = handle.attach(WalletDao.class);
             try {
-                update(storage, wallet, getFilePassword(encryptionPubKey));
-            } catch(Exception e) {
-                log.error("Error updating wallet db", e);
+                walletDao.setSchema(getSchema(wallet));
+                KeystoreDao keystoreDao = handle.attach(KeystoreDao.class);
+                for(Keystore keystore : keystoresToFlush) {
+                    keystoreDao.updateKeystoreEncryption(keystore);
+                }
+            } finally {
+                walletDao.setSchema(DEFAULT_SCHEMA);
             }
         });
     }


### PR DESCRIPTION
## Summary

Fixes #1961

When removing or changing a wallet password, the previous code called `updatePassword()` (which re-encrypts the H2 `.mv.db` file on disk) **synchronously on the calling thread**, then queued seed/keystore row updates on a background executor. If Sparrow was killed in the window between those two steps, the wallet ended up in a mixed state:

- the DB file was already unencrypted (or re-encrypted with the new key)
- but the seed row in `wallet_master.seed` still held `encryptedBytes` from the old password

On next open this produces: `Wallet was not encrypted, but seed is`

## Root cause

`DbPersistence.updateWallet()` — the file encryption change and the seed/keystore DB row update were **not atomic**:

```java
// BEFORE (broken)
updatePassword(storage, encryptionPubKey);   // synchronous — H2 file re-encrypted NOW
updateExecutor.execute(() -> {               // async — seed rows updated LATER (crash window)
    update(storage, wallet, ...);
});
```

Additionally, `keystoreEncryptionChanged()` itself queues the dirty keystores onto the same executor, so the seed rows weren't even guaranteed to be in the dirty map yet when `updatePassword()` ran.

## Fix

When the file password is actually changing, defer `updatePassword()` onto the executor **after** a new `flushEncryptionKeystores()` step. Because the executor is single-threaded and FIFO, this guarantees ordering:

1. `keystoreEncryptionChanged` task → `encryptionKeystores` populated in dirty map
2. `flushEncryptionKeystores()` → seed/keystore rows written with **old** file password
3. `updatePassword()` → H2 file encryption changed
4. `update()` → remaining dirty fields flushed with new password

There is now no crash window where file and row state can diverge. The no-password-change path is unchanged.

## Testing

1. Create an encrypted software wallet with a seed
2. Open wallet settings → change to no password → immediately kill Sparrow after confirming
3. Restart → wallet should open cleanly with no password required