### PR TITLE
Add optional challenge-response for wallet encryption

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ processResources {
 
 test {
     useJUnitPlatform()
-    jvmArgs = ["--add-opens=java.base/java.io=ALL-UNNAMED", "--enable-native-access=ALL-UNNAMED"]
+    jvmArgs = ["--add-opens=java.base/java.io=ALL-UNNAMED", "--add-opens=java.base/java.math=ALL-UNNAMED", "--enable-native-access=ALL-UNNAMED"]
 }
 
 application {
@@ -162,6 +162,7 @@ application {
                                  "--add-opens=javafx.graphics/javafx.scene.input=com.sparrowwallet.sparrow",
                                  "--add-opens=java.base/java.net=com.sparrowwallet.sparrow",
                                  "--add-opens=java.base/java.io=com.google.gson",
+                                 "--add-opens=java.base/java.math=com.sparrowwallet.drongo",
                                  "--add-opens=java.smartcardio/sun.security.smartcardio=com.sparrowwallet.sparrow",
                                  "--add-reads=kotlin.stdlib=kotlinx.coroutines.core",
                                  "--add-reads=org.flywaydb.core=java.desktop"]
@@ -212,6 +213,7 @@ jlink {
                    "--add-opens=javafx.graphics/com.sun.javafx.application=com.sparrowwallet.sparrow",
                    "--add-opens=java.base/java.net=com.sparrowwallet.sparrow",
                    "--add-opens=java.base/java.io=com.google.gson",
+                   "--add-opens=java.base/java.math=com.sparrowwallet.drongo",
                    "--add-opens=java.smartcardio/sun.security.smartcardio=com.sparrowwallet.sparrow",
                    "--add-reads=com.sparrowwallet.merged.module=java.desktop",
                    "--add-reads=com.sparrowwallet.merged.module=java.sql",

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -1205,7 +1205,7 @@ public class AppController implements Initializable {
 
                 SecureString password = optionalPassword.get();
                 if(storage.isChallengeResponseEnabled()) {
-                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                 }
                 Storage.LoadWalletService loadWalletService = new Storage.LoadWalletService(storage, password);
                 loadWalletService.setOnSucceeded(workerStateEvent -> {
@@ -1404,7 +1404,7 @@ public class AppController implements Initializable {
             } else {
                 if(dlg.isYubikeyEnabled()) {
                     storage.setChallengeResponseEnabled(true);
-                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                 }
                 keyDerivationService = new Storage.KeyDerivationService(storage, password.get());
                 keyDerivationService.setOnSucceeded(workerStateEvent -> {
@@ -2346,7 +2346,7 @@ public class AppController implements Initializable {
                 Optional<SecureString> password = dlg.showAndWait();
                 if(password.isPresent()) {
                     if(storage.isChallengeResponseEnabled()) {
-                        storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                        storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                     }
                     keyDerivationService = new Storage.KeyDerivationService(storage, password.get(), true);
                     keyDerivationService.setOnSucceeded(workerStateEvent -> {

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -1194,7 +1194,7 @@ public class AppController implements Initializable {
             } else {
                 WalletPasswordDialog dlg = new WalletPasswordDialog(storage.getWalletName(null), WalletPasswordDialog.PasswordRequirement.LOAD);
                 if(storage.isChallengeResponseEnabled()) {
-                    dlg.setHeaderText("Enter the wallet password (leave empty if none).\nYubiKey touch will be required after unlocking.");
+                    dlg.setHeaderText("Enter the wallet password (leave empty if none).\nSecurity key touch will be required after unlocking.");
                     dlg.setAllowEmptyPassword(true);
                 }
                 dlg.initOwner(rootStack.getScene().getWindow());
@@ -1231,7 +1231,7 @@ public class AppController implements Initializable {
                         password.clear();
                     }
                 });
-                EventManager.get().post(new StorageEvent(storage.getWalletId(null), TimedEvent.Action.START, storage.isChallengeResponseEnabled() ? "Touch your YubiKey..." : "Decrypting wallet..."));
+                EventManager.get().post(new StorageEvent(storage.getWalletId(null), TimedEvent.Action.START, storage.isChallengeResponseEnabled() ? "Touch your security key..." : "Decrypting wallet..."));
                 loadWalletService.start();
             }
         } catch(Exception e) {

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -1193,6 +1193,10 @@ public class AppController implements Initializable {
                 loadWalletService.start();
             } else {
                 WalletPasswordDialog dlg = new WalletPasswordDialog(storage.getWalletName(null), WalletPasswordDialog.PasswordRequirement.LOAD);
+                if(storage.isChallengeResponseEnabled()) {
+                    dlg.setHeaderText("Enter the wallet password (leave empty if none).\nYubiKey touch will be required after unlocking.");
+                    dlg.setAllowEmptyPassword(true);
+                }
                 dlg.initOwner(rootStack.getScene().getWindow());
                 Optional<SecureString> optionalPassword = dlg.showAndWait();
                 if(optionalPassword.isEmpty()) {
@@ -1200,6 +1204,9 @@ public class AppController implements Initializable {
                 }
 
                 SecureString password = optionalPassword.get();
+                if(storage.isChallengeResponseEnabled()) {
+                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                }
                 Storage.LoadWalletService loadWalletService = new Storage.LoadWalletService(storage, password);
                 loadWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(storage.getWalletId(null), TimedEvent.Action.END, "Done"));
@@ -1224,7 +1231,7 @@ public class AppController implements Initializable {
                         password.clear();
                     }
                 });
-                EventManager.get().post(new StorageEvent(storage.getWalletId(null), TimedEvent.Action.START, "Decrypting wallet..."));
+                EventManager.get().post(new StorageEvent(storage.getWalletId(null), TimedEvent.Action.START, storage.isChallengeResponseEnabled() ? "Touch your YubiKey..." : "Decrypting wallet..."));
                 loadWalletService.start();
             }
         } catch(Exception e) {
@@ -1378,7 +1385,7 @@ public class AppController implements Initializable {
         dlg.initOwner(rootStack.getScene().getWindow());
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
-            if(password.get().length() == 0) {
+            if(password.get().length() == 0 && !dlg.isYubikeyEnabled()) {
                 try {
                     storage.setEncryptionPubKey(Storage.NO_PASSWORD_KEY);
                     storage.saveWallet(wallet);
@@ -1395,6 +1402,10 @@ public class AppController implements Initializable {
                     log.error("Error saving imported wallet", e);
                 }
             } else {
+                if(dlg.isYubikeyEnabled()) {
+                    storage.setChallengeResponseEnabled(true);
+                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                }
                 keyDerivationService = new Storage.KeyDerivationService(storage, password.get());
                 keyDerivationService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(Storage.getWalletFile(wallet.getName()).getAbsolutePath(), TimedEvent.Action.END, "Done"));
@@ -2329,8 +2340,14 @@ public class AppController implements Initializable {
             if(selectedWalletForm.getMasterWallet().isEncrypted()) {
                 WalletPasswordDialog dlg = new WalletPasswordDialog(selectedWalletForm.getWallet().getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
                 dlg.initOwner(rootStack.getScene().getWindow());
+                if(storage.isChallengeResponseEnabled()) {
+                    dlg.setAllowEmptyPassword(true);
+                }
                 Optional<SecureString> password = dlg.showAndWait();
                 if(password.isPresent()) {
+                    if(storage.isChallengeResponseEnabled()) {
+                        storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    }
                     keyDerivationService = new Storage.KeyDerivationService(storage, password.get(), true);
                     keyDerivationService.setOnSucceeded(workerStateEvent -> {
                         EventManager.get().post(new StorageEvent(selectedWalletForm.getWalletId(), TimedEvent.Action.END, "Done"));

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -1211,7 +1211,7 @@ public class AppController implements Initializable {
                 });
                 loadWalletService.start();
             } else {
-                WalletPasswordDialog dlg = new WalletPasswordDialog(storage.getWalletName(null), WalletPasswordDialog.PasswordRequirement.LOAD);
+                WalletPasswordDialog dlg = new WalletPasswordDialog(storage.getWalletName(null), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
                 dlg.initOwner(rootStack.getScene().getWindow());
                 Optional<SecureString> optionalPassword = dlg.showAndWait();
                 if(optionalPassword.isEmpty()) {
@@ -1234,7 +1234,7 @@ public class AppController implements Initializable {
                             Platform.runLater(() -> openWalletFile(file, forceSameWindow));
                         }
                     } else {
-                        if(exception instanceof StorageException) {
+                        if(exception instanceof StorageException || exception instanceof KeyCrypterException) {
                             showErrorDialog("Error Opening Wallet", exception.getMessage());
                         } else if(!attemptImportWallet(file, password)) {
                             log.error("Error Opening Wallet", exception);
@@ -1243,7 +1243,7 @@ public class AppController implements Initializable {
                         password.clear();
                     }
                 });
-                EventManager.get().post(new StorageEvent(storage.getWalletId(null), TimedEvent.Action.START, "Decrypting wallet..."));
+                EventManager.get().post(new StorageEvent(storage.getWalletId(null), TimedEvent.Action.START, storage.isChallengeResponseEnabled() ? "Touch your security key..." : "Decrypting wallet..."));
                 loadWalletService.start();
             }
         } catch(Exception e) {
@@ -1410,7 +1410,7 @@ public class AppController implements Initializable {
         dlg.initOwner(rootStack.getScene().getWindow());
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
-            if(password.get().length() == 0) {
+            if(password.get().length() == 0 && !dlg.isYubikeyEnabled()) {
                 try {
                     storage.setEncryptionPubKey(Storage.NO_PASSWORD_KEY);
                     storage.saveWallet(wallet);
@@ -1427,6 +1427,9 @@ public class AppController implements Initializable {
                     log.error("Error saving imported wallet", e);
                 }
             } else {
+                if(dlg.isYubikeyEnabled()) {
+                    storage.setChallengeResponseEnabled(true);
+                }
                 keyDerivationService = new Storage.KeyDerivationService(storage, password.get());
                 keyDerivationService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(Storage.getWalletFile(wallet.getName()).getAbsolutePath(), TimedEvent.Action.END, "Done"));
@@ -2459,7 +2462,7 @@ public class AppController implements Initializable {
         if(optButtonType.isPresent() && optButtonType.get() == ButtonType.YES) {
             Storage storage = selectedWalletForm.getStorage();
             if(selectedWalletForm.getMasterWallet().isEncrypted()) {
-                WalletPasswordDialog dlg = new WalletPasswordDialog(selectedWalletForm.getWallet().getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+                WalletPasswordDialog dlg = new WalletPasswordDialog(selectedWalletForm.getWallet().getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
                 dlg.initOwner(rootStack.getScene().getWindow());
                 Optional<SecureString> password = dlg.showAndWait();
                 if(password.isPresent()) {

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -893,9 +893,9 @@ public class AppServices {
         provider.setOnWaitingForTouch(() -> {
             Platform.runLater(() -> {
                 touchAlert[0] = new Alert(Alert.AlertType.INFORMATION);
-                touchAlert[0].setTitle("YubiKey");
-                touchAlert[0].setHeaderText("Touch your YubiKey");
-                touchAlert[0].setContentText("Waiting for YubiKey touch to complete authentication...");
+                touchAlert[0].setTitle("Challenge-Response");
+                touchAlert[0].setHeaderText("Touch your security key");
+                touchAlert[0].setContentText("Waiting for security key touch to complete authentication...");
                 touchAlert[0].getButtonTypes().setAll(ButtonType.CANCEL);
                 touchAlert[0].getDialogPane().getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
                 setStageIcon(touchAlert[0].getDialogPane().getScene().getWindow());

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -886,6 +886,32 @@ public class AppServices {
         return getInteractionServices().showAlert(title, content, alertType, graphic, buttons);
     }
 
+    public static com.sparrowwallet.lark.yubikey.YubiKeyHmacProvider createYubiKeyProvider() {
+        com.sparrowwallet.lark.yubikey.YubiKeyHmacProvider provider = new com.sparrowwallet.lark.yubikey.YubiKeyHmacProvider();
+        javafx.scene.control.Alert[] touchAlert = new javafx.scene.control.Alert[1];
+        provider.setOnWaitingForTouch(() -> {
+            javafx.application.Platform.runLater(() -> {
+                touchAlert[0] = new javafx.scene.control.Alert(javafx.scene.control.Alert.AlertType.INFORMATION);
+                touchAlert[0].setTitle("YubiKey");
+                touchAlert[0].setHeaderText("Touch your YubiKey");
+                touchAlert[0].setContentText("Waiting for YubiKey touch to complete authentication...");
+                touchAlert[0].getButtonTypes().setAll(javafx.scene.control.ButtonType.CANCEL);
+                touchAlert[0].getDialogPane().getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
+                setStageIcon(touchAlert[0].getDialogPane().getScene().getWindow());
+                moveToActiveWindowScreen(touchAlert[0]);
+                touchAlert[0].show();
+            });
+        });
+        provider.setOnComplete(() -> {
+            javafx.application.Platform.runLater(() -> {
+                if(touchAlert[0] != null) {
+                    touchAlert[0].close();
+                }
+            });
+        });
+        return provider;
+    }
+
     public static void setStageIcon(Window window) {
         Stage stage = (Stage)window;
         stage.getIcons().add(getWindowIcon());
@@ -1105,9 +1131,15 @@ public class AppServices {
                     Storage storage = AppServices.get().getOpenWallets().get(wallet);
                     Wallet copy = wallet.copy();
                     WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+                    if(storage.isChallengeResponseEnabled()) {
+                        dlg.setAllowEmptyPassword(true);
+                    }
                     dlg.initOwner(getActiveWindow());
                     Optional<SecureString> password = dlg.showAndWait();
                     if(password.isPresent()) {
+                        if(storage.isChallengeResponseEnabled()) {
+                            storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                        }
                         Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(storage, password.get(), true);
                         keyDerivationService.setOnSucceeded(workerStateEvent -> {
                             EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -16,6 +16,7 @@ import com.sparrowwallet.drongo.wallet.*;
 import com.sparrowwallet.sparrow.control.DialogImage;
 import com.sparrowwallet.sparrow.control.WalletPasswordDialog;
 import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
+import com.sparrowwallet.lark.yubikey.YubiKeyHmacProvider;
 import com.sparrowwallet.sparrow.net.Auth47;
 import com.sparrowwallet.drongo.protocol.BlockHeader;
 import com.sparrowwallet.drongo.protocol.ScriptType;
@@ -886,16 +887,16 @@ public class AppServices {
         return getInteractionServices().showAlert(title, content, alertType, graphic, buttons);
     }
 
-    public static com.sparrowwallet.lark.yubikey.YubiKeyHmacProvider createYubiKeyProvider() {
-        com.sparrowwallet.lark.yubikey.YubiKeyHmacProvider provider = new com.sparrowwallet.lark.yubikey.YubiKeyHmacProvider();
-        javafx.scene.control.Alert[] touchAlert = new javafx.scene.control.Alert[1];
+    public static YubiKeyHmacProvider createYubiKeyProvider() {
+        YubiKeyHmacProvider provider = new YubiKeyHmacProvider();
+        Alert[] touchAlert = new Alert[1];
         provider.setOnWaitingForTouch(() -> {
-            javafx.application.Platform.runLater(() -> {
-                touchAlert[0] = new javafx.scene.control.Alert(javafx.scene.control.Alert.AlertType.INFORMATION);
+            Platform.runLater(() -> {
+                touchAlert[0] = new Alert(Alert.AlertType.INFORMATION);
                 touchAlert[0].setTitle("YubiKey");
                 touchAlert[0].setHeaderText("Touch your YubiKey");
                 touchAlert[0].setContentText("Waiting for YubiKey touch to complete authentication...");
-                touchAlert[0].getButtonTypes().setAll(javafx.scene.control.ButtonType.CANCEL);
+                touchAlert[0].getButtonTypes().setAll(ButtonType.CANCEL);
                 touchAlert[0].getDialogPane().getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
                 setStageIcon(touchAlert[0].getDialogPane().getScene().getWindow());
                 moveToActiveWindowScreen(touchAlert[0]);
@@ -903,7 +904,7 @@ public class AppServices {
             });
         });
         provider.setOnComplete(() -> {
-            javafx.application.Platform.runLater(() -> {
+            Platform.runLater(() -> {
                 if(touchAlert[0] != null) {
                     touchAlert[0].close();
                 }
@@ -1138,7 +1139,7 @@ public class AppServices {
                     Optional<SecureString> password = dlg.showAndWait();
                     if(password.isPresent()) {
                         if(storage.isChallengeResponseEnabled()) {
-                            storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                            storage.setChallengeResponseProvider(createYubiKeyProvider());
                         }
                         Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(storage, password.get(), true);
                         keyDerivationService.setOnSucceeded(workerStateEvent -> {

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -16,6 +16,7 @@ import com.sparrowwallet.drongo.wallet.*;
 import com.sparrowwallet.sparrow.control.DialogImage;
 import com.sparrowwallet.sparrow.control.WalletPasswordDialog;
 import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
+import com.sparrowwallet.lark.yubikey.YubiKeyHmacProvider;
 import com.sparrowwallet.sparrow.net.Auth47;
 import com.sparrowwallet.drongo.protocol.BlockHeader;
 import com.sparrowwallet.drongo.protocol.ScriptType;
@@ -71,6 +72,7 @@ import java.util.*;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -576,6 +578,9 @@ public class AppServices {
 
     public static void initialize(Application application) {
         INSTANCE = new AppServices(application, new DefaultInteractionServices());
+        //Registered once so every wallet unlock path derives with challenge-response when the wallet requires it.
+        //Only for the desktop UI, since the prompt is a JavaFX dialog.
+        Storage.setChallengeResponseProviderFactory(AppServices::createYubiKeyProvider);
     }
 
     public static void initialize(Application application, InteractionServices interactionServices) {
@@ -946,6 +951,44 @@ public class AppServices {
         return getInteractionServices().showAlert(title, content, alertType, graphic, buttons);
     }
 
+    public static YubiKeyHmacProvider createYubiKeyProvider() {
+        YubiKeyHmacProvider provider = new YubiKeyHmacProvider();
+        Alert[] touchAlert = new Alert[1];
+        AtomicBoolean completed = new AtomicBoolean();
+        provider.setOnWaitingForTouch(() -> {
+            Platform.runLater(() -> {
+                if(completed.get()) {
+                    return;
+                }
+
+                touchAlert[0] = new Alert(Alert.AlertType.INFORMATION);
+                touchAlert[0].setTitle("Challenge-Response");
+                touchAlert[0].setHeaderText("Touch your security key");
+                touchAlert[0].setContentText("Waiting for security key touch to complete authentication...");
+                touchAlert[0].getButtonTypes().setAll(ButtonType.CANCEL);
+                //Closing the prompt aborts the wait rather than leaving the user until the device times out
+                touchAlert[0].setOnHidden(event -> {
+                    if(!completed.get()) {
+                        provider.cancel();
+                    }
+                });
+                touchAlert[0].getDialogPane().getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
+                setStageIcon(touchAlert[0].getDialogPane().getScene().getWindow());
+                moveToActiveWindowScreen(touchAlert[0]);
+                touchAlert[0].show();
+            });
+        });
+        provider.setOnComplete(() -> {
+            completed.set(true);
+            Platform.runLater(() -> {
+                if(touchAlert[0] != null) {
+                    touchAlert[0].close();
+                }
+            });
+        });
+        return provider;
+    }
+
     public static void setStageIcon(Window window) {
         Stage stage = (Stage)window;
         stage.getIcons().add(getWindowIcon());
@@ -1164,7 +1207,7 @@ public class AppServices {
                 if(wallet.isEncrypted()) {
                     Storage storage = AppServices.get().getOpenWallets().get(wallet);
                     Wallet copy = wallet.copy();
-                    WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+                    WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
                     dlg.initOwner(getActiveWindow());
                     Optional<SecureString> password = dlg.showAndWait();
                     if(password.isPresent()) {

--- a/src/main/java/com/sparrowwallet/sparrow/control/FileWalletExportPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/FileWalletExportPane.java
@@ -129,7 +129,7 @@ public class FileWalletExportPane extends TitledDescriptionPane {
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
                 if(storage.isChallengeResponseEnabled()) {
-                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                 }
                 final String walletId = storage.getWalletId(wallet);
                 String walletPassword = password.get().asString();

--- a/src/main/java/com/sparrowwallet/sparrow/control/FileWalletExportPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/FileWalletExportPane.java
@@ -120,13 +120,20 @@ public class FileWalletExportPane extends TitledDescriptionPane {
     private void exportWallet(File file) {
         if(wallet.isEncrypted() && exporter.walletExportRequiresDecryption()) {
             Wallet copy = wallet.copy();
+            Storage storage = AppServices.get().getOpenWallets().get(wallet);
             WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
             dlg.initOwner(buttonBox.getScene().getWindow());
+            if(storage.isChallengeResponseEnabled()) {
+                dlg.setAllowEmptyPassword(true);
+            }
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                final String walletId = AppServices.get().getOpenWallets().get(wallet).getWalletId(wallet);
+                if(storage.isChallengeResponseEnabled()) {
+                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                }
+                final String walletId = storage.getWalletId(wallet);
                 String walletPassword = password.get().asString();
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get());
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(walletId, TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/control/FileWalletExportPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/FileWalletExportPane.java
@@ -120,13 +120,14 @@ public class FileWalletExportPane extends TitledDescriptionPane {
     private void exportWallet(File file) {
         if(wallet.isEncrypted() && exporter.walletExportRequiresDecryption()) {
             Wallet copy = wallet.copy();
-            WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+            Storage storage = AppServices.get().getOpenWallets().get(wallet);
+            WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
             dlg.initOwner(buttonBox.getScene().getWindow());
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                final String walletId = AppServices.get().getOpenWallets().get(wallet).getWalletId(wallet);
+                final String walletId = storage.getWalletId(wallet);
                 String walletPassword = password.get().asString();
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get());
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(walletId, TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/control/MessageSignDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MessageSignDialog.java
@@ -714,9 +714,15 @@ public class MessageSignDialog extends Dialog<ButtonBar.ButtonData> {
 
         WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
         dlg.initOwner(getDialogPane().getScene().getWindow());
+        if(storage.isChallengeResponseEnabled()) {
+            dlg.setAllowEmptyPassword(true);
+        }
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
-            Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(walletNode.getWallet().copy(), password.get());
+            if(storage.isChallengeResponseEnabled()) {
+                storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+            }
+            Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(walletNode.getWallet().copy(), password.get(), storage);
             decryptWalletService.setOnSucceeded(workerStateEvent -> {
                 EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));
                 Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/control/MessageSignDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MessageSignDialog.java
@@ -720,7 +720,7 @@ public class MessageSignDialog extends Dialog<ButtonBar.ButtonData> {
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
             if(storage.isChallengeResponseEnabled()) {
-                storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
             }
             Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(walletNode.getWallet().copy(), password.get(), storage);
             decryptWalletService.setOnSucceeded(workerStateEvent -> {

--- a/src/main/java/com/sparrowwallet/sparrow/control/MessageSignDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MessageSignDialog.java
@@ -755,11 +755,11 @@ public class MessageSignDialog extends Dialog<ButtonBar.ButtonData> {
             return;
         }
 
-        WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+        WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
         dlg.initOwner(getDialogPane().getScene().getWindow());
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
-            Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(walletNode.getWallet().copy(), password.get());
+            Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(walletNode.getWallet().copy(), password.get(), storage);
             decryptWalletService.setOnSucceeded(workerStateEvent -> {
                 EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));
                 Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
@@ -108,6 +108,12 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
                     passwordConfirm.setManaged(false);
                     backupExisting.setVisible(true);
                     addingPassword = false;
+                } else if(newValue.isEmpty() && yubikey.isSelected()) {
+                    okButton.setText("Set YubiKey");
+                    passwordConfirm.setVisible(false);
+                    passwordConfirm.setManaged(false);
+                    backupExisting.setVisible(false);
+                    addingPassword = true;
                 } else {
                     okButton.setText("Set Password");
                     passwordConfirm.setVisible(true);

--- a/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
@@ -37,7 +37,7 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
         this.backupExisting = new CheckBox("Backup existing wallet first");
         this.changePassword = new CheckBox("Change password");
         this.deleteBackups = new CheckBox("Delete any backups");
-        this.yubikey = new CheckBox("Require YubiKey for unlock");
+        this.yubikey = new CheckBox("Require challenge-response for unlock");
 
         final DialogPane dialogPane = getDialogPane();
         setTitle("Wallet Password" + (walletName != null ? " - " + walletName : ""));
@@ -109,7 +109,7 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
                     backupExisting.setVisible(true);
                     addingPassword = false;
                 } else if(newValue.isEmpty() && yubikey.isSelected()) {
-                    okButton.setText("Set YubiKey");
+                    okButton.setText("Set Challenge-Response");
                     passwordConfirm.setVisible(false);
                     passwordConfirm.setManaged(false);
                     backupExisting.setVisible(false);
@@ -124,7 +124,7 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
             });
             yubikey.selectedProperty().addListener((observable, oldValue, newValue) -> {
                 if(newValue && password.getText().isEmpty()) {
-                    okButton.setText("Set YubiKey");
+                    okButton.setText("Set Challenge-Response");
                     passwordConfirm.setVisible(false);
                     passwordConfirm.setManaged(false);
                     backupExisting.setVisible(false);

--- a/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
@@ -22,7 +22,9 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
     private final CheckBox backupExisting;
     private final CheckBox changePassword;
     private final CheckBox deleteBackups;
+    private final CheckBox yubikey;
     private boolean addingPassword;
+    private boolean allowEmptyPassword;
 
     public WalletPasswordDialog(String walletName, PasswordRequirement requirement) {
         this(walletName, requirement, false);
@@ -35,6 +37,7 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
         this.backupExisting = new CheckBox("Backup existing wallet first");
         this.changePassword = new CheckBox("Change password");
         this.deleteBackups = new CheckBox("Delete any backups");
+        this.yubikey = new CheckBox("Require YubiKey for unlock");
 
         final DialogPane dialogPane = getDialogPane();
         setTitle("Wallet Password" + (walletName != null ? " - " + walletName : ""));
@@ -72,6 +75,11 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
             deleteBackups.setSelected(true);
         }
 
+        if(requirement == PasswordRequirement.UPDATE_NEW || requirement == PasswordRequirement.UPDATE_EMPTY || requirement == PasswordRequirement.UPDATE_CHANGE) {
+            yubikey.managedProperty().bind(yubikey.visibleProperty());
+            content.getChildren().add(yubikey);
+        }
+
         dialogPane.setContent(content);
 
         ValidationSupport validationSupport = new ValidationSupport();
@@ -84,7 +92,7 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
         dialogPane.getButtonTypes().addAll(okButtonType);
         Button okButton = (Button) dialogPane.lookupButton(okButtonType);
         okButton.setPrefWidth(130);
-        BooleanBinding isInvalid = Bindings.createBooleanBinding(() -> (requirement == PasswordRequirement.LOAD && password.getText().isEmpty()) || (passwordConfirm.isVisible() && !password.getText().equals(passwordConfirm.getText())), password.textProperty(), passwordConfirm.textProperty());
+        BooleanBinding isInvalid = Bindings.createBooleanBinding(() -> (requirement == PasswordRequirement.LOAD && password.getText().isEmpty() && !allowEmptyPassword) || (passwordConfirm.isVisible() && !password.getText().equals(passwordConfirm.getText())), password.textProperty(), passwordConfirm.textProperty());
         okButton.disableProperty().bind(isInvalid);
 
         if(requirement != PasswordRequirement.UPDATE_NEW && requirement != PasswordRequirement.UPDATE_CHANGE) {
@@ -94,7 +102,7 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
 
         if(requirement == PasswordRequirement.UPDATE_NEW || requirement == PasswordRequirement.UPDATE_EMPTY || requirement == PasswordRequirement.UPDATE_CHANGE) {
             password.textProperty().addListener((observable, oldValue, newValue) -> {
-                if(newValue.isEmpty()) {
+                if(newValue.isEmpty() && !yubikey.isSelected()) {
                     okButton.setText("No Password");
                     passwordConfirm.setVisible(false);
                     passwordConfirm.setManaged(false);
@@ -106,6 +114,17 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
                     passwordConfirm.setManaged(true);
                     backupExisting.setVisible(false);
                     addingPassword = true;
+                }
+            });
+            yubikey.selectedProperty().addListener((observable, oldValue, newValue) -> {
+                if(newValue && password.getText().isEmpty()) {
+                    okButton.setText("Set Password");
+                    passwordConfirm.setVisible(false);
+                    passwordConfirm.setManaged(false);
+                    addingPassword = true;
+                } else if(!newValue && password.getText().isEmpty()) {
+                    okButton.setText("No Password");
+                    addingPassword = false;
                 }
             });
         }
@@ -127,6 +146,15 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
 
     public boolean isDeleteBackups() {
         return (addingPassword || isChangePassword()) && deleteBackups.isSelected();
+    }
+
+    public boolean isYubikeyEnabled() {
+        return yubikey.isSelected();
+    }
+
+    public void setAllowEmptyPassword(boolean allow) {
+        this.allowEmptyPassword = allow;
+        password.textProperty().setValue(password.getText());
     }
 
     public enum PasswordRequirement {

--- a/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
@@ -118,12 +118,14 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
             });
             yubikey.selectedProperty().addListener((observable, oldValue, newValue) -> {
                 if(newValue && password.getText().isEmpty()) {
-                    okButton.setText("Set Password");
+                    okButton.setText("Set YubiKey");
                     passwordConfirm.setVisible(false);
                     passwordConfirm.setManaged(false);
+                    backupExisting.setVisible(false);
                     addingPassword = true;
                 } else if(!newValue && password.getText().isEmpty()) {
                     okButton.setText("No Password");
+                    backupExisting.setVisible(true);
                     addingPassword = false;
                 }
             });

--- a/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/WalletPasswordDialog.java
@@ -2,9 +2,12 @@ package com.sparrowwallet.sparrow.control;
 
 import com.sparrowwallet.drongo.SecureString;
 import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.io.Storage;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.scene.control.*;
 import javafx.scene.layout.VBox;
 import org.controlsfx.control.textfield.CustomPasswordField;
@@ -22,10 +25,23 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
     private final CheckBox backupExisting;
     private final CheckBox changePassword;
     private final CheckBox deleteBackups;
+    private final CheckBox yubikey;
     private boolean addingPassword;
+    private final BooleanProperty allowEmptyPassword = new SimpleBooleanProperty(false);
 
     public WalletPasswordDialog(String walletName, PasswordRequirement requirement) {
         this(walletName, requirement, false);
+    }
+
+    //Applies the challenge-response requirement recorded in the wallet, so an unlock dialog cannot be built without it
+    public WalletPasswordDialog(String walletName, PasswordRequirement requirement, Storage storage) {
+        this(walletName, requirement, false);
+
+        if(storage != null && storage.isChallengeResponseEnabled() && requirement == PasswordRequirement.LOAD) {
+            setAllowEmptyPassword(true);
+            setHeaderText((walletName != null ? "Enter the password for " + walletName : "Enter the wallet password")
+                    + " (leave empty if none).\nSecurity key touch will be required.");
+        }
     }
 
     public WalletPasswordDialog(String walletName, PasswordRequirement requirement, boolean suggestChangePassword) {
@@ -35,6 +51,8 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
         this.backupExisting = new CheckBox("Backup existing wallet first");
         this.changePassword = new CheckBox("Change password");
         this.deleteBackups = new CheckBox("Delete any backups");
+        this.yubikey = new CheckBox("Require challenge-response for unlock");
+        this.yubikey.setTooltip(new Tooltip("The wallet file can only be opened with this security key.\nIf it is lost, reset or reprogrammed, the wallet cannot be recovered from this file."));
 
         final DialogPane dialogPane = getDialogPane();
         setTitle("Wallet Password" + (walletName != null ? " - " + walletName : ""));
@@ -72,6 +90,11 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
             deleteBackups.setSelected(true);
         }
 
+        if(requirement == PasswordRequirement.UPDATE_NEW || requirement == PasswordRequirement.UPDATE_EMPTY || requirement == PasswordRequirement.UPDATE_CHANGE) {
+            yubikey.managedProperty().bind(yubikey.visibleProperty());
+            content.getChildren().add(yubikey);
+        }
+
         dialogPane.setContent(content);
 
         ValidationSupport validationSupport = new ValidationSupport();
@@ -84,7 +107,7 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
         dialogPane.getButtonTypes().addAll(okButtonType);
         Button okButton = (Button) dialogPane.lookupButton(okButtonType);
         okButton.setPrefWidth(130);
-        BooleanBinding isInvalid = Bindings.createBooleanBinding(() -> (requirement == PasswordRequirement.LOAD && password.getText().isEmpty()) || (passwordConfirm.isVisible() && !password.getText().equals(passwordConfirm.getText())), password.textProperty(), passwordConfirm.textProperty());
+        BooleanBinding isInvalid = Bindings.createBooleanBinding(() -> (requirement == PasswordRequirement.LOAD && password.getText().isEmpty() && !allowEmptyPassword.get()) || (passwordConfirm.isVisible() && !password.getText().equals(passwordConfirm.getText())), password.textProperty(), passwordConfirm.textProperty(), allowEmptyPassword);
         okButton.disableProperty().bind(isInvalid);
 
         if(requirement != PasswordRequirement.UPDATE_NEW && requirement != PasswordRequirement.UPDATE_CHANGE) {
@@ -94,18 +117,37 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
 
         if(requirement == PasswordRequirement.UPDATE_NEW || requirement == PasswordRequirement.UPDATE_EMPTY || requirement == PasswordRequirement.UPDATE_CHANGE) {
             password.textProperty().addListener((observable, oldValue, newValue) -> {
-                if(newValue.isEmpty()) {
+                if(newValue.isEmpty() && !yubikey.isSelected()) {
                     okButton.setText("No Password");
                     passwordConfirm.setVisible(false);
                     passwordConfirm.setManaged(false);
                     backupExisting.setVisible(true);
                     addingPassword = false;
+                } else if(newValue.isEmpty() && yubikey.isSelected()) {
+                    okButton.setText("Set Challenge-Response");
+                    passwordConfirm.setVisible(false);
+                    passwordConfirm.setManaged(false);
+                    backupExisting.setVisible(false);
+                    addingPassword = true;
                 } else {
                     okButton.setText("Set Password");
                     passwordConfirm.setVisible(true);
                     passwordConfirm.setManaged(true);
                     backupExisting.setVisible(false);
                     addingPassword = true;
+                }
+            });
+            yubikey.selectedProperty().addListener((observable, oldValue, newValue) -> {
+                if(newValue && password.getText().isEmpty()) {
+                    okButton.setText("Set Challenge-Response");
+                    passwordConfirm.setVisible(false);
+                    passwordConfirm.setManaged(false);
+                    backupExisting.setVisible(false);
+                    addingPassword = true;
+                } else if(!newValue && password.getText().isEmpty()) {
+                    okButton.setText("No Password");
+                    backupExisting.setVisible(true);
+                    addingPassword = false;
                 }
             });
         }
@@ -127,6 +169,18 @@ public class WalletPasswordDialog extends Dialog<SecureString> {
 
     public boolean isDeleteBackups() {
         return (addingPassword || isChangePassword()) && deleteBackups.isSelected();
+    }
+
+    public boolean isYubikeyEnabled() {
+        return yubikey.isSelected();
+    }
+
+    public void setYubikeyEnabled(boolean enabled) {
+        yubikey.setSelected(enabled);
+    }
+
+    public void setAllowEmptyPassword(boolean allow) {
+        this.allowEmptyPassword.set(allow);
     }
 
     public enum PasswordRequirement {

--- a/src/main/java/com/sparrowwallet/sparrow/io/Persistence.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Persistence.java
@@ -1,6 +1,7 @@
 package com.sparrowwallet.sparrow.io;
 
 import com.sparrowwallet.drongo.crypto.AsymmetricKeyDeriver;
+import com.sparrowwallet.drongo.crypto.ChallengeResponseProvider;
 import com.sparrowwallet.drongo.crypto.ECKey;
 import com.sparrowwallet.drongo.wallet.Wallet;
 
@@ -20,6 +21,9 @@ public interface Persistence {
     ECKey getEncryptionKey(CharSequence password) throws IOException, StorageException;
     AsymmetricKeyDeriver getKeyDeriver();
     void setKeyDeriver(AsymmetricKeyDeriver keyDeriver);
+    default boolean isChallengeResponseEnabled() { return false; }
+    default void setChallengeResponseEnabled(boolean enabled) {}
+    default void setChallengeResponseProvider(ChallengeResponseProvider provider) {}
     PersistenceType getType();
     boolean isEncrypted(File walletFile) throws IOException;
     String getWalletId(Storage storage, Wallet wallet);

--- a/src/main/java/com/sparrowwallet/sparrow/io/Persistence.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Persistence.java
@@ -1,6 +1,7 @@
 package com.sparrowwallet.sparrow.io;
 
 import com.sparrowwallet.drongo.crypto.AsymmetricKeyDeriver;
+import com.sparrowwallet.drongo.crypto.ChallengeResponseProvider;
 import com.sparrowwallet.drongo.crypto.ECKey;
 import com.sparrowwallet.drongo.wallet.Wallet;
 
@@ -20,6 +21,8 @@ public interface Persistence {
     ECKey getEncryptionKey(CharSequence password) throws IOException, StorageException;
     AsymmetricKeyDeriver getKeyDeriver();
     void setKeyDeriver(AsymmetricKeyDeriver keyDeriver);
+    default boolean isChallengeResponseEnabled() { return false; }
+    default void setChallengeResponseEnabled(boolean enabled) {}
     PersistenceType getType();
     boolean isEncrypted(File walletFile) throws IOException;
     String getWalletId(Storage storage, Wallet wallet);

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -372,6 +372,18 @@ public class Storage {
         persistence.setKeyDeriver(keyDeriver);
     }
 
+    public boolean isChallengeResponseEnabled() {
+        return persistence.isChallengeResponseEnabled();
+    }
+
+    public void setChallengeResponseEnabled(boolean enabled) {
+        persistence.setChallengeResponseEnabled(enabled);
+    }
+
+    public void setChallengeResponseProvider(ChallengeResponseProvider provider) {
+        persistence.setChallengeResponseProvider(provider);
+    }
+
     public PersistenceType getType() {
         return persistence.getType();
     }
@@ -764,10 +776,16 @@ public class Storage {
     public static class DecryptWalletService extends Service<Wallet> {
         private final Wallet wallet;
         private final SecureString password;
+        private final Storage storage;
 
         public DecryptWalletService(Wallet wallet, SecureString password) {
+            this(wallet, password, null);
+        }
+
+        public DecryptWalletService(Wallet wallet, SecureString password, Storage storage) {
             this.wallet = wallet;
             this.password = password;
+            this.storage = storage;
         }
 
         @Override
@@ -775,7 +793,15 @@ public class Storage {
             return new Task<>() {
                 protected Wallet call() throws IOException, StorageException {
                     try {
-                        wallet.decrypt(password);
+                        if(storage != null && storage.isChallengeResponseEnabled()) {
+                            ECKey encryptionFullKey = storage.getEncryptionKey(password);
+                            Key key = new Key(encryptionFullKey.getPrivKeyBytes(), storage.getKeyDeriver().getSalt(), EncryptionType.Deriver.ARGON2);
+                            wallet.decrypt(key);
+                            key.clear();
+                            encryptionFullKey.clear();
+                        } else {
+                            wallet.decrypt(password);
+                        }
                         return wallet;
                     } finally {
                         password.clear();

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -32,10 +32,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class Storage {
     private static final Logger log = LoggerFactory.getLogger(Storage.class);
+    private static volatile Supplier<ChallengeResponseProvider> challengeResponseProviderFactory;
+
     public static final ECKey NO_PASSWORD_KEY = ECKey.fromPublicOnly(ECKey.fromPrivate(Utils.hexToBytes("885e5a09708a167ea356a252387aa7c4893d138d632e296df8fbf5c12798bd28")));
 
     private static final DateTimeFormatter BACKUP_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
@@ -356,6 +359,24 @@ public class Storage {
 
     void setKeyDeriver(AsymmetricKeyDeriver keyDeriver) {
         persistence.setKeyDeriver(keyDeriver);
+    }
+
+    public boolean isChallengeResponseEnabled() {
+        return persistence.isChallengeResponseEnabled();
+    }
+
+    public void setChallengeResponseEnabled(boolean enabled) {
+        persistence.setChallengeResponseEnabled(enabled);
+    }
+
+    public static void setChallengeResponseProviderFactory(Supplier<ChallengeResponseProvider> factory) {
+        challengeResponseProviderFactory = factory;
+    }
+
+    //Returns a fresh provider for a single derivation, or null if no provider is registered
+    public static ChallengeResponseProvider createChallengeResponseProvider() {
+        Supplier<ChallengeResponseProvider> factory = challengeResponseProviderFactory;
+        return factory == null ? null : factory.get();
     }
 
     public PersistenceType getType() {
@@ -845,10 +866,12 @@ public class Storage {
     public static class DecryptWalletService extends Service<Wallet> {
         private final Wallet wallet;
         private final SecureString password;
+        private final Storage storage;
 
-        public DecryptWalletService(Wallet wallet, SecureString password) {
+        public DecryptWalletService(Wallet wallet, SecureString password, Storage storage) {
             this.wallet = wallet;
             this.password = password;
+            this.storage = storage;
         }
 
         @Override
@@ -856,7 +879,24 @@ public class Storage {
             return new Task<>() {
                 protected Wallet call() throws IOException, StorageException {
                     try {
-                        wallet.decrypt(password);
+                        if(storage != null && storage.isChallengeResponseEnabled()) {
+                            ECKey encryptionFullKey = storage.getEncryptionKey(password);
+                            if(!ECKey.fromPublicOnly(encryptionFullKey).equals(storage.getEncryptionPubKey())) {
+                                throw new InvalidPasswordException("Incorrect password for wallet " + wallet.getName());
+                            }
+
+                            Key key = null;
+                            try {
+                                key = new Key(encryptionFullKey.getPrivKeyBytes(), storage.getKeyDeriver().getSalt(), EncryptionType.Deriver.ARGON2);
+                                wallet.decrypt(key);
+                            } finally {
+                                if(key != null) {
+                                    key.clear();
+                                }
+                            }
+                        } else {
+                            wallet.decrypt(password);
+                        }
                         return wallet;
                     } finally {
                         password.clear();

--- a/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
@@ -577,7 +577,7 @@ public class DbPersistence implements Persistence {
             return alreadyDerivedKey;
         } else if(password == null) {
             return null;
-        } else if(password.equals("")) {
+        } else if(password.equals("") && challengeResponseProvider == null) {
             return Storage.NO_PASSWORD_KEY;
         }
 

--- a/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
@@ -584,6 +584,7 @@ public class DbPersistence implements Persistence {
         AsymmetricKeyDeriver deriver = getKeyDeriver(walletFile);
         if(challengeResponseProvider != null) {
             deriver = new ChallengeResponseKeyDeriver(deriver, challengeResponseProvider);
+            challengeResponseProvider = null;
         }
         return deriver.deriveECKey(password);
     }

--- a/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
@@ -3,10 +3,7 @@ package com.sparrowwallet.sparrow.io.db;
 import com.google.common.eventbus.Subscribe;
 import com.sparrowwallet.drongo.IOUtils;
 import com.sparrowwallet.drongo.Utils;
-import com.sparrowwallet.drongo.crypto.Argon2KeyDeriver;
-import com.sparrowwallet.drongo.crypto.AsymmetricKeyDeriver;
-import com.sparrowwallet.drongo.crypto.ECKey;
-import com.sparrowwallet.drongo.crypto.InvalidPasswordException;
+import com.sparrowwallet.drongo.crypto.*;
 import com.sparrowwallet.drongo.protocol.Sha256Hash;
 import com.sparrowwallet.drongo.wallet.*;
 import com.sparrowwallet.sparrow.EventManager;
@@ -52,6 +49,8 @@ public class DbPersistence implements Persistence {
     private static final int H2_ENCRYPT_SALT_LENGTH_BYTES = 8;
     private static final int SALT_LENGTH_BYTES = 16;
     public static final byte[] HEADER_MAGIC_1 = "SPRW1\n".getBytes(StandardCharsets.UTF_8);
+    public static final byte[] HEADER_MAGIC_2 = "SPRW2\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte FLAG_CHALLENGE_RESPONSE = 0x01;
     private static final String H2_USER = "sa";
     private static final String H2_PASSWORD = "";
     public static final String MIGRATION_RESOURCES_DIR = "com/sparrowwallet/sparrow/sql/";
@@ -59,6 +58,8 @@ public class DbPersistence implements Persistence {
 
     private HikariDataSource dataSource;
     private AsymmetricKeyDeriver keyDeriver;
+    private boolean challengeResponseEnabled;
+    private ChallengeResponseProvider challengeResponseProvider;
 
     private Wallet masterWallet;
     private final Map<Wallet, DirtyPersistables> dirtyPersistablesMap = new HashMap<>();
@@ -497,8 +498,20 @@ public class DbPersistence implements Persistence {
             dataSource.close();
         }
 
-        ByteBuffer header = ByteBuffer.allocate(HEADER_MAGIC_1.length + SALT_LENGTH_BYTES);
-        header.put(HEADER_MAGIC_1);
+        byte[] magic;
+        int extraBytes = 0;
+        if(challengeResponseEnabled) {
+            magic = HEADER_MAGIC_2;
+            extraBytes = 1;
+        } else {
+            magic = HEADER_MAGIC_1;
+        }
+
+        ByteBuffer header = ByteBuffer.allocate(magic.length + extraBytes + SALT_LENGTH_BYTES);
+        header.put(magic);
+        if(challengeResponseEnabled) {
+            header.put(FLAG_CHALLENGE_RESPONSE);
+        }
         header.put(keyDeriver.getSalt());
         header.flip();
 
@@ -568,8 +581,11 @@ public class DbPersistence implements Persistence {
             return Storage.NO_PASSWORD_KEY;
         }
 
-        AsymmetricKeyDeriver keyDeriver = getKeyDeriver(walletFile);
-        return keyDeriver.deriveECKey(password);
+        AsymmetricKeyDeriver deriver = getKeyDeriver(walletFile);
+        if(challengeResponseProvider != null) {
+            deriver = new ChallengeResponseKeyDeriver(deriver, challengeResponseProvider);
+        }
+        return deriver.deriveECKey(password);
     }
 
     @Override
@@ -580,6 +596,21 @@ public class DbPersistence implements Persistence {
     @Override
     public void setKeyDeriver(AsymmetricKeyDeriver keyDeriver) {
         this.keyDeriver = keyDeriver;
+    }
+
+    @Override
+    public boolean isChallengeResponseEnabled() {
+        return challengeResponseEnabled;
+    }
+
+    @Override
+    public void setChallengeResponseEnabled(boolean enabled) {
+        this.challengeResponseEnabled = enabled;
+    }
+
+    @Override
+    public void setChallengeResponseProvider(ChallengeResponseProvider provider) {
+        this.challengeResponseProvider = provider;
     }
 
     private AsymmetricKeyDeriver getKeyDeriver(File walletFile) throws IOException {
@@ -596,7 +627,15 @@ public class DbPersistence implements Persistence {
 
             if(walletFile != null && walletFile.exists()) {
                 try(InputStream inputStream = new FileInputStream(walletFile)) {
-                    inputStream.skip(H2_ENCRYPT_HEADER.length + H2_ENCRYPT_SALT_LENGTH_BYTES + HEADER_MAGIC_1.length);
+                    inputStream.skip(H2_ENCRYPT_HEADER.length + H2_ENCRYPT_SALT_LENGTH_BYTES);
+                    byte[] magic = new byte[HEADER_MAGIC_1.length];
+                    inputStream.read(magic, 0, magic.length);
+
+                    if(Arrays.equals(HEADER_MAGIC_2, magic)) {
+                        int flags = inputStream.read();
+                        challengeResponseEnabled = (flags & FLAG_CHALLENGE_RESPONSE) != 0;
+                    }
+
                     inputStream.read(salt, 0, salt.length);
                 }
             } else {
@@ -619,7 +658,17 @@ public class DbPersistence implements Persistence {
         byte[] header = new byte[H2_ENCRYPT_HEADER.length];
         try(InputStream inputStream = new FileInputStream(walletFile)) {
             inputStream.read(header, 0, H2_ENCRYPT_HEADER.length);
-            return Arrays.equals(H2_ENCRYPT_HEADER, header);
+            if(Arrays.equals(H2_ENCRYPT_HEADER, header)) {
+                inputStream.skip(H2_ENCRYPT_SALT_LENGTH_BYTES);
+                byte[] magic = new byte[HEADER_MAGIC_1.length];
+                inputStream.read(magic, 0, magic.length);
+                if(Arrays.equals(HEADER_MAGIC_2, magic)) {
+                    int flags = inputStream.read();
+                    challengeResponseEnabled = (flags & FLAG_CHALLENGE_RESPONSE) != 0;
+                }
+                return true;
+            }
+            return false;
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/db/DbPersistence.java
@@ -5,11 +5,15 @@ import com.sparrowwallet.drongo.IOUtils;
 import com.sparrowwallet.drongo.Utils;
 import com.sparrowwallet.drongo.crypto.Argon2KeyDeriver;
 import com.sparrowwallet.drongo.crypto.AsymmetricKeyDeriver;
+import com.sparrowwallet.drongo.crypto.ChallengeResponseKeyDeriver;
+import com.sparrowwallet.drongo.crypto.ChallengeResponseProvider;
 import com.sparrowwallet.drongo.crypto.ECKey;
 import com.sparrowwallet.drongo.crypto.InvalidPasswordException;
+import com.sparrowwallet.drongo.crypto.KeyCrypterException;
 import com.sparrowwallet.drongo.protocol.Sha256Hash;
 import com.sparrowwallet.drongo.wallet.*;
 import com.sparrowwallet.sparrow.EventManager;
+import com.sparrowwallet.sparrow.SparrowWallet;
 import com.sparrowwallet.sparrow.event.*;
 import com.sparrowwallet.sparrow.io.*;
 import com.sparrowwallet.sparrow.wallet.*;
@@ -64,6 +68,8 @@ public class DbPersistence implements Persistence {
     private static final int H2_ENCRYPT_SALT_LENGTH_BYTES = 8;
     private static final int SALT_LENGTH_BYTES = 16;
     public static final byte[] HEADER_MAGIC_1 = "SPRW1\n".getBytes(StandardCharsets.UTF_8);
+    public static final byte[] HEADER_MAGIC_2 = "SPRW2\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte FLAG_CHALLENGE_RESPONSE = 0x01;
     private static final String H2_USER = "sa";
     private static final String H2_PASSWORD = "";
     public static final String MIGRATION_RESOURCES_DIR = "com/sparrowwallet/sparrow/sql/";
@@ -84,6 +90,7 @@ public class DbPersistence implements Persistence {
 
     private HikariDataSource dataSource;
     private AsymmetricKeyDeriver keyDeriver;
+    private Boolean challengeResponseEnabled;
 
     private Wallet masterWallet;
     private final Map<Wallet, DirtyPersistables> dirtyPersistablesMap = new HashMap<>();
@@ -628,8 +635,21 @@ public class DbPersistence implements Persistence {
             dataSource.close();
         }
 
-        ByteBuffer header = ByteBuffer.allocate(HEADER_MAGIC_1.length + SALT_LENGTH_BYTES);
-        header.put(HEADER_MAGIC_1);
+        boolean challengeResponse = isChallengeResponseEnabled();
+        byte[] magic;
+        int extraBytes = 0;
+        if(challengeResponse) {
+            magic = HEADER_MAGIC_2;
+            extraBytes = 1;
+        } else {
+            magic = HEADER_MAGIC_1;
+        }
+
+        ByteBuffer header = ByteBuffer.allocate(magic.length + extraBytes + SALT_LENGTH_BYTES);
+        header.put(magic);
+        if(challengeResponse) {
+            header.put(FLAG_CHALLENGE_RESPONSE);
+        }
         header.put(keyDeriver.getSalt());
         header.flip();
 
@@ -738,12 +758,19 @@ public class DbPersistence implements Persistence {
             return alreadyDerivedKey;
         } else if(password == null) {
             return null;
-        } else if(password.equals("")) {
+        } else if(password.equals("") && !requiresChallengeResponse(walletFile)) {
             return Storage.NO_PASSWORD_KEY;
         }
 
-        AsymmetricKeyDeriver keyDeriver = getKeyDeriver(walletFile);
-        return keyDeriver.deriveECKey(password);
+        AsymmetricKeyDeriver deriver = getKeyDeriver(walletFile);
+        if(requiresChallengeResponse(walletFile)) {
+            ChallengeResponseProvider provider = Storage.createChallengeResponseProvider();
+            if(provider == null) {
+                throw new KeyCrypterException("This wallet requires a challenge-response device, which is not available here.");
+            }
+            deriver = new ChallengeResponseKeyDeriver(deriver, provider);
+        }
+        return deriver.deriveECKey(password);
     }
 
     @Override
@@ -754,6 +781,28 @@ public class DbPersistence implements Persistence {
     @Override
     public void setKeyDeriver(AsymmetricKeyDeriver keyDeriver) {
         this.keyDeriver = keyDeriver;
+    }
+
+    //Reads the wallet header if the requirement is not yet known, so derivation never depends on an earlier isEncrypted call
+    private boolean requiresChallengeResponse(File walletFile) throws IOException {
+        if(challengeResponseEnabled == null && walletFile != null && walletFile.exists() && hasEncryptHeader(walletFile)) {
+            try(InputStream inputStream = new FileInputStream(walletFile)) {
+                inputStream.skipNBytes(H2_ENCRYPT_HEADER.length + H2_ENCRYPT_SALT_LENGTH_BYTES);
+                challengeResponseEnabled = readChallengeResponseFlag(inputStream, walletFile);
+            }
+        }
+
+        return isChallengeResponseEnabled();
+    }
+
+    @Override
+    public boolean isChallengeResponseEnabled() {
+        return Boolean.TRUE.equals(challengeResponseEnabled);
+    }
+
+    @Override
+    public void setChallengeResponseEnabled(boolean enabled) {
+        this.challengeResponseEnabled = enabled;
     }
 
     private AsymmetricKeyDeriver getKeyDeriver(File walletFile) throws IOException {
@@ -770,8 +819,11 @@ public class DbPersistence implements Persistence {
 
             if(walletFile != null && walletFile.exists()) {
                 try(InputStream inputStream = new FileInputStream(walletFile)) {
-                    inputStream.skip(H2_ENCRYPT_HEADER.length + H2_ENCRYPT_SALT_LENGTH_BYTES + HEADER_MAGIC_1.length);
-                    inputStream.read(salt, 0, salt.length);
+                    inputStream.skipNBytes(H2_ENCRYPT_HEADER.length + H2_ENCRYPT_SALT_LENGTH_BYTES);
+                    challengeResponseEnabled = readChallengeResponseFlag(inputStream, walletFile);
+                    if(inputStream.readNBytes(salt, 0, salt.length) < salt.length) {
+                        throw new EOFException("Truncated header in wallet file " + walletFile.getName());
+                    }
                 }
             } else {
                 SecureRandom secureRandom = new SecureRandom();
@@ -790,15 +842,43 @@ public class DbPersistence implements Persistence {
             return getDatasourcePassword() != null;
         }
 
-        return hasEncryptHeader(walletFile);
+        if(!hasEncryptHeader(walletFile)) {
+            return false;
+        }
+
+        //Read here so the challenge-response requirement is known before the password prompt
+        try(InputStream inputStream = new FileInputStream(walletFile)) {
+            inputStream.skipNBytes(H2_ENCRYPT_HEADER.length + H2_ENCRYPT_SALT_LENGTH_BYTES);
+            challengeResponseEnabled = readChallengeResponseFlag(inputStream, walletFile);
+        }
+
+        return true;
     }
 
+    //Does not modify any state, so it is safe to call on a file that has been re-encrypted but not yet given a wallet header
     private boolean hasEncryptHeader(File walletFile) throws IOException {
-        byte[] header = new byte[H2_ENCRYPT_HEADER.length];
         try(InputStream inputStream = new FileInputStream(walletFile)) {
-            inputStream.read(header, 0, H2_ENCRYPT_HEADER.length);
-            return Arrays.equals(H2_ENCRYPT_HEADER, header);
+            return Arrays.equals(H2_ENCRYPT_HEADER, inputStream.readNBytes(H2_ENCRYPT_HEADER.length));
         }
+    }
+
+    //Reads the wallet header magic from a stream positioned at it, leaving the stream positioned at the salt
+    boolean readChallengeResponseFlag(InputStream inputStream, File walletFile) throws IOException {
+        if(!Arrays.equals(HEADER_MAGIC_2, inputStream.readNBytes(HEADER_MAGIC_1.length))) {
+            return false;
+        }
+
+        int flags = inputStream.read();
+        if(flags < 0) {
+            throw new EOFException("Truncated header in wallet file " + walletFile.getName());
+        }
+
+        //Fail rather than ignore a flag this version does not understand, so a later requirement cannot be silently dropped
+        if((flags & ~FLAG_CHALLENGE_RESPONSE) != 0) {
+            throw new IOException("Wallet file " + walletFile.getName() + " requires a newer version of " + SparrowWallet.APP_NAME);
+        }
+
+        return (flags & FLAG_CHALLENGE_RESPONSE) != 0;
     }
 
     @Override

--- a/src/main/java/com/sparrowwallet/sparrow/paynym/PayNymController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/paynym/PayNymController.java
@@ -369,9 +369,15 @@ public class PayNymController {
                 if(optButtonType.isPresent() && optButtonType.get() == ButtonType.YES) {
                     WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
                     dlg.initOwner(payNymName.getScene().getWindow());
+                    if(storage.isChallengeResponseEnabled()) {
+                        dlg.setAllowEmptyPassword(true);
+                    }
                     Optional<SecureString> password = dlg.showAndWait();
                     if(password.isPresent()) {
-                        Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get());
+                        if(storage.isChallengeResponseEnabled()) {
+                            storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                        }
+                        Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                         decryptWalletService.setOnSucceeded(workerStateEvent -> {
                             EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));
                             Wallet decryptedWallet = decryptWalletService.getValue();
@@ -511,9 +517,15 @@ public class PayNymController {
         if(wallet.isEncrypted()) {
             WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
             dlg.initOwner(payNymName.getScene().getWindow());
+            if(storage.isChallengeResponseEnabled()) {
+                dlg.setAllowEmptyPassword(true);
+            }
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get());
+                if(storage.isChallengeResponseEnabled()) {
+                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                }
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/paynym/PayNymController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/paynym/PayNymController.java
@@ -375,7 +375,7 @@ public class PayNymController {
                     Optional<SecureString> password = dlg.showAndWait();
                     if(password.isPresent()) {
                         if(storage.isChallengeResponseEnabled()) {
-                            storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                            storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                         }
                         Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                         decryptWalletService.setOnSucceeded(workerStateEvent -> {
@@ -523,7 +523,7 @@ public class PayNymController {
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
                 if(storage.isChallengeResponseEnabled()) {
-                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                 }
                 Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {

--- a/src/main/java/com/sparrowwallet/sparrow/paynym/PayNymController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/paynym/PayNymController.java
@@ -367,11 +367,11 @@ public class PayNymController {
                 requestingPassword = true;
                 Optional<ButtonType> optButtonType = AppServices.showAlertDialog("Link contacts?", "Some contacts were found that may be already linked. Link these contacts? Your password is required to check.", Alert.AlertType.CONFIRMATION, ButtonType.NO, ButtonType.YES);
                 if(optButtonType.isPresent() && optButtonType.get() == ButtonType.YES) {
-                    WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+                    WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
                     dlg.initOwner(payNymName.getScene().getWindow());
                     Optional<SecureString> password = dlg.showAndWait();
                     if(password.isPresent()) {
-                        Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get());
+                        Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                         decryptWalletService.setOnSucceeded(workerStateEvent -> {
                             EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));
                             Wallet decryptedWallet = decryptWalletService.getValue();
@@ -509,11 +509,11 @@ public class PayNymController {
         Wallet wallet = walletTransaction.getWallet();
         Storage storage = AppServices.get().getOpenWallets().get(wallet);
         if(wallet.isEncrypted()) {
-            WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+            WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
             dlg.initOwner(payNymName.getScene().getWindow());
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get());
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/MasterActionListBox.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/MasterActionListBox.java
@@ -97,7 +97,7 @@ public class MasterActionListBox extends ActionListBox {
     private static void openLoadedWallet(Storage storage, Wallet wallet) {
         if(SparrowTerminal.get().isLocked(storage)) {
             if(storage.isChallengeResponseEnabled()) {
-                showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+                showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
                 return;
             }
 

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/MasterActionListBox.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/MasterActionListBox.java
@@ -96,6 +96,11 @@ public class MasterActionListBox extends ActionListBox {
 
     private static void openLoadedWallet(Storage storage, Wallet wallet) {
         if(SparrowTerminal.get().isLocked(storage)) {
+            if(storage.isChallengeResponseEnabled()) {
+                showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+                return;
+            }
+
             String walletId = storage.getWalletId(wallet);
 
             TextInputDialogBuilder builder = new TextInputDialogBuilder().setTitle("Wallet Password");

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/MasterActionListBox.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/MasterActionListBox.java
@@ -96,6 +96,11 @@ public class MasterActionListBox extends ActionListBox {
 
     private static void openLoadedWallet(Storage storage, Wallet wallet) {
         if(SparrowTerminal.get().isLocked(storage)) {
+            if(storage.isChallengeResponseEnabled()) {
+                showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
+                return;
+            }
+
             String walletId = storage.getWalletId(wallet);
 
             TextInputDialogBuilder builder = new TextInputDialogBuilder().setTitle("Wallet Password");

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/LoadWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/LoadWallet.java
@@ -57,6 +57,12 @@ public class LoadWallet implements Runnable {
                     loadWalletService.start();
                 });
             } else {
+                if(storage.isChallengeResponseEnabled()) {
+                    SparrowTerminal.get().getGui().removeWindow(loadingDialog);
+                    showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+                    return;
+                }
+
                 TextInputDialogBuilder builder = new TextInputDialogBuilder().setTitle("Wallet Password");
                 builder.setDescription("Enter the password for\n" + storage.getWalletName(null));
                 builder.setPasswordInput(true);

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/LoadWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/LoadWallet.java
@@ -59,7 +59,7 @@ public class LoadWallet implements Runnable {
             } else {
                 if(storage.isChallengeResponseEnabled()) {
                     SparrowTerminal.get().getGui().removeWindow(loadingDialog);
-                    showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+                    showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
                     return;
                 }
 

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/LoadWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/LoadWallet.java
@@ -57,6 +57,12 @@ public class LoadWallet implements Runnable {
                     loadWalletService.start();
                 });
             } else {
+                if(storage.isChallengeResponseEnabled()) {
+                    SparrowTerminal.get().getGui().removeWindow(loadingDialog);
+                    showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
+                    return;
+                }
+
                 TextInputDialogBuilder builder = new TextInputDialogBuilder().setTitle("Wallet Password");
                 builder.setDescription("Enter the password for\n" + storage.getWalletName(null));
                 builder.setPasswordInput(true);

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/SettingsDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/SettingsDialog.java
@@ -127,6 +127,11 @@ public class SettingsDialog extends WalletDialog {
     private void showSeed() {
         Wallet wallet = getWalletForm().getWallet().copy();
         if(wallet.isEncrypted()) {
+            if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
+                showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+                return;
+            }
+
             Wallet copy = wallet.copy();
             String walletId = getWalletForm().getWalletId();
 
@@ -173,6 +178,11 @@ public class SettingsDialog extends WalletDialog {
 
     private void saveWallet(boolean changePassword, boolean suggestChangePassword) {
         WalletForm walletForm = getWalletForm();
+        if(walletForm.getStorage().isChallengeResponseEnabled()) {
+            showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+            return;
+        }
+
         ECKey existingPubKey = walletForm.getStorage().getEncryptionPubKey();
 
         PasswordRequirement requirement;

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/SettingsDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/SettingsDialog.java
@@ -128,7 +128,7 @@ public class SettingsDialog extends WalletDialog {
         Wallet wallet = getWalletForm().getWallet().copy();
         if(wallet.isEncrypted()) {
             if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
-                showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+                showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
                 return;
             }
 
@@ -179,7 +179,7 @@ public class SettingsDialog extends WalletDialog {
     private void saveWallet(boolean changePassword, boolean suggestChangePassword) {
         WalletForm walletForm = getWalletForm();
         if(walletForm.getStorage().isChallengeResponseEnabled()) {
-            showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+            showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
             return;
         }
 

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/SettingsDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/SettingsDialog.java
@@ -127,6 +127,11 @@ public class SettingsDialog extends WalletDialog {
     private void showSeed() {
         Wallet wallet = getWalletForm().getWallet().copy();
         if(wallet.isEncrypted()) {
+            if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
+                showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
+                return;
+            }
+
             Wallet copy = wallet.copy();
             String walletId = getWalletForm().getWalletId();
 
@@ -173,6 +178,11 @@ public class SettingsDialog extends WalletDialog {
     //Returns true if the wallet save was initiated, and false if it was abandoned without any change to the wallet or its storage
     private boolean saveWallet(boolean changePassword, boolean suggestChangePassword) {
         WalletForm walletForm = getWalletForm();
+        if(walletForm.getStorage().isChallengeResponseEnabled()) {
+            showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
+            return false;
+        }
+
         ECKey existingPubKey = walletForm.getStorage().getEncryptionPubKey();
 
         PasswordRequirement requirement;

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/WalletDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/WalletDialog.java
@@ -70,7 +70,7 @@ public class WalletDialog extends DialogWindow {
     protected void addAccount(Wallet masterWallet, StandardAccount standardAccount, Runnable postAddition) {
         if(masterWallet.isEncrypted()) {
             if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
-                showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+                showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
                 return;
             }
 

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/WalletDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/WalletDialog.java
@@ -69,6 +69,11 @@ public class WalletDialog extends DialogWindow {
 
     protected void addAccount(Wallet masterWallet, StandardAccount standardAccount, Runnable postAddition) {
         if(masterWallet.isEncrypted()) {
+            if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
+                showErrorDialog("YubiKey Required", "This wallet requires a YubiKey for authentication, which is not supported in terminal mode.");
+                return;
+            }
+
             String walletId = getWalletForm().getWalletId();
 
             TextInputDialogBuilder builder = new TextInputDialogBuilder().setTitle("Wallet Password");

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/WalletDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/wallet/WalletDialog.java
@@ -69,6 +69,11 @@ public class WalletDialog extends DialogWindow {
 
     protected void addAccount(Wallet masterWallet, StandardAccount standardAccount, Runnable postAddition) {
         if(masterWallet.isEncrypted()) {
+            if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
+                showErrorDialog("Challenge-Response Required", "This wallet requires a challenge-response device for authentication, which is not supported in terminal mode.");
+                return;
+            }
+
             String walletId = getWalletForm().getWalletId();
 
             TextInputDialogBuilder builder = new TextInputDialogBuilder().setTitle("Wallet Password");

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -1112,11 +1112,18 @@ public class HeadersController extends TransactionFormController implements Init
         String walletId = headersForm.getAvailableWallets().get(headersForm.getSigningWallet()).getWalletId(headersForm.getSigningWallet());
 
         if(copy.isEncrypted()) {
+            Storage storage = headersForm.getAvailableWallets().get(headersForm.getSigningWallet());
             WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
             dlg.initOwner(signButton.getScene().getWindow());
+            if(storage.isChallengeResponseEnabled()) {
+                dlg.setAllowEmptyPassword(true);
+            }
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get());
+                if(storage.isChallengeResponseEnabled()) {
+                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                }
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(walletId, TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -1121,7 +1121,7 @@ public class HeadersController extends TransactionFormController implements Init
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
                 if(storage.isChallengeResponseEnabled()) {
-                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                 }
                 Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -1230,11 +1230,12 @@ public class HeadersController extends TransactionFormController implements Init
         String walletId = headersForm.getAvailableWallets().get(headersForm.getSigningWallet()).getWalletId(headersForm.getSigningWallet());
 
         if(copy.isEncrypted()) {
-            WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+            Storage storage = headersForm.getAvailableWallets().get(headersForm.getSigningWallet());
+            WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
             dlg.initOwner(signButton.getScene().getWindow());
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get());
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(walletId, TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
@@ -433,9 +433,15 @@ public class KeystoreController extends WalletFormController implements Initiali
         if(copy.isEncrypted()) {
             WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
             dlg.initOwner(viewSeedButton.getScene().getWindow());
+            if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
+                dlg.setAllowEmptyPassword(true);
+            }
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get());
+                if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
+                    getWalletForm().getStorage().setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                }
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get(), getWalletForm().getStorage());
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(getWalletForm().getWalletId(), TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
@@ -439,7 +439,7 @@ public class KeystoreController extends WalletFormController implements Initiali
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
                 if(getWalletForm().getStorage().isChallengeResponseEnabled()) {
-                    getWalletForm().getStorage().setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    getWalletForm().getStorage().setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                 }
                 Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get(), getWalletForm().getStorage());
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
@@ -498,11 +498,11 @@ public class KeystoreController extends WalletFormController implements Initiali
         Wallet copy = getWalletForm().getWallet().copy();
 
         if(copy.isEncrypted()) {
-            WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+            WalletPasswordDialog dlg = new WalletPasswordDialog(copy.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, getWalletForm().getStorage());
             dlg.initOwner(viewSeedButton.getScene().getWindow());
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get());
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(copy, password.get(), getWalletForm().getStorage());
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(getWalletForm().getWalletId(), TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1201,7 +1201,7 @@ public class SendController extends WalletFormController implements Initializabl
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
                 if(storage.isChallengeResponseEnabled()) {
-                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                 }
                 Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1195,9 +1195,15 @@ public class SendController extends WalletFormController implements Initializabl
         if(wallet.isEncrypted()) {
             WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
             dlg.initOwner(paymentTabs.getScene().getWindow());
+            if(storage.isChallengeResponseEnabled()) {
+                dlg.setAllowEmptyPassword(true);
+            }
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get());
+                if(storage.isChallengeResponseEnabled()) {
+                    storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                }
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1229,11 +1229,11 @@ public class SendController extends WalletFormController implements Initializabl
         Wallet wallet = getWalletForm().getWallet();
         Storage storage = AppServices.get().getOpenWallets().get(wallet);
         if(wallet.isEncrypted()) {
-            WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+            WalletPasswordDialog dlg = new WalletPasswordDialog(wallet.getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
             dlg.initOwner(paymentTabs.getScene().getWindow());
             Optional<SecureString> password = dlg.showAndWait();
             if(password.isPresent()) {
-                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get());
+                Storage.DecryptWalletService decryptWalletService = new Storage.DecryptWalletService(wallet.copy(), password.get(), storage);
                 decryptWalletService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(storage.getWalletId(wallet), TimedEvent.Action.END, "Done"));
                     Wallet decryptedWallet = decryptWalletService.getValue();

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsController.java
@@ -978,10 +978,14 @@ public class SettingsController extends WalletFormController implements Initiali
                     apply.setDisable(false);
                 }
             } else {
-                if(dlg.isYubikeyEnabled()) {
+                if(requirement == WalletPasswordDialog.PasswordRequirement.UPDATE_SET) {
+                    if(walletForm.getStorage().isChallengeResponseEnabled()) {
+                        walletForm.getStorage().setChallengeResponseProvider(AppServices.createYubiKeyProvider());
+                    }
+                } else if(dlg.isYubikeyEnabled()) {
                     walletForm.getStorage().setChallengeResponseEnabled(true);
                     walletForm.getStorage().setChallengeResponseProvider(AppServices.createYubiKeyProvider());
-                } else if(walletForm.getStorage().isChallengeResponseEnabled()) {
+                } else {
                     walletForm.getStorage().setChallengeResponseEnabled(false);
                     walletForm.getStorage().setChallengeResponseProvider(null);
                 }

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsController.java
@@ -533,11 +533,17 @@ public class SettingsController extends WalletFormController implements Initiali
     }
 
     private void rederiveAndReplaceEncryptedWallet(Wallet editedWallet) {
+        Storage storage = walletForm.getStorage();
         WalletPasswordDialog dlg = new WalletPasswordDialog(walletForm.getWallet().getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
         dlg.initOwner(apply.getScene().getWindow());
+        if(storage.isChallengeResponseEnabled()) {
+            dlg.setAllowEmptyPassword(true);
+        }
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
-            Storage storage = walletForm.getStorage();
+            if(storage.isChallengeResponseEnabled()) {
+                storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+            }
             Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(storage, password.get(), true);
             keyDerivationService.setOnSucceeded(workerStateEvent -> {
                 EventManager.get().post(new StorageEvent(getWalletForm().getWalletId(), TimedEvent.Action.END, "Done"));
@@ -649,8 +655,14 @@ public class SettingsController extends WalletFormController implements Initiali
                 String walletId = walletForm.getWalletId();
                 WalletPasswordDialog dlg = new WalletPasswordDialog(masterWallet.getName(), WalletPasswordDialog.PasswordRequirement.LOAD);
                 dlg.initOwner(addAccount.getScene().getWindow());
+                if(walletForm.getStorage().isChallengeResponseEnabled()) {
+                    dlg.setAllowEmptyPassword(true);
+                }
                 Optional<SecureString> password = dlg.showAndWait();
                 if(password.isPresent()) {
+                    if(walletForm.getStorage().isChallengeResponseEnabled()) {
+                        walletForm.getStorage().setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    }
                     Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(walletForm.getStorage(), password.get(), true);
                     keyDerivationService.setOnSucceeded(workerStateEvent -> {
                         EventManager.get().post(new StorageEvent(walletId, TimedEvent.Action.END, "Done"));
@@ -954,7 +966,7 @@ public class SettingsController extends WalletFormController implements Initiali
                 }
             }
 
-            if(password.get().length() == 0 && requirement != WalletPasswordDialog.PasswordRequirement.UPDATE_SET) {
+            if(password.get().length() == 0 && !dlg.isYubikeyEnabled() && requirement != WalletPasswordDialog.PasswordRequirement.UPDATE_SET) {
                 try {
                     walletForm.getStorage().setEncryptionPubKey(Storage.NO_PASSWORD_KEY);
                     walletForm.saveAndRefresh();
@@ -966,6 +978,13 @@ public class SettingsController extends WalletFormController implements Initiali
                     apply.setDisable(false);
                 }
             } else {
+                if(dlg.isYubikeyEnabled()) {
+                    walletForm.getStorage().setChallengeResponseEnabled(true);
+                    walletForm.getStorage().setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                } else if(walletForm.getStorage().isChallengeResponseEnabled()) {
+                    walletForm.getStorage().setChallengeResponseEnabled(false);
+                    walletForm.getStorage().setChallengeResponseProvider(null);
+                }
                 Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(walletForm.getStorage(), password.get());
                 keyDerivationService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(walletForm.getWalletId(), TimedEvent.Action.END, "Done"));

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsController.java
@@ -542,7 +542,7 @@ public class SettingsController extends WalletFormController implements Initiali
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
             if(storage.isChallengeResponseEnabled()) {
-                storage.setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                storage.setChallengeResponseProvider(AppServices.createYubiKeyProvider());
             }
             Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(storage, password.get(), true);
             keyDerivationService.setOnSucceeded(workerStateEvent -> {
@@ -661,7 +661,7 @@ public class SettingsController extends WalletFormController implements Initiali
                 Optional<SecureString> password = dlg.showAndWait();
                 if(password.isPresent()) {
                     if(walletForm.getStorage().isChallengeResponseEnabled()) {
-                        walletForm.getStorage().setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                        walletForm.getStorage().setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                     }
                     Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(walletForm.getStorage(), password.get(), true);
                     keyDerivationService.setOnSucceeded(workerStateEvent -> {
@@ -980,7 +980,7 @@ public class SettingsController extends WalletFormController implements Initiali
             } else {
                 if(dlg.isYubikeyEnabled()) {
                     walletForm.getStorage().setChallengeResponseEnabled(true);
-                    walletForm.getStorage().setChallengeResponseProvider(com.sparrowwallet.sparrow.AppServices.createYubiKeyProvider());
+                    walletForm.getStorage().setChallengeResponseProvider(AppServices.createYubiKeyProvider());
                 } else if(walletForm.getStorage().isChallengeResponseEnabled()) {
                     walletForm.getStorage().setChallengeResponseEnabled(false);
                     walletForm.getStorage().setChallengeResponseProvider(null);

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsController.java
@@ -575,11 +575,11 @@ public class SettingsController extends WalletFormController implements Initiali
     }
 
     private void rederiveAndReplaceEncryptedWallet(Wallet editedWallet) {
-        WalletPasswordDialog dlg = new WalletPasswordDialog(walletForm.getWallet().getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+        Storage storage = walletForm.getStorage();
+        WalletPasswordDialog dlg = new WalletPasswordDialog(walletForm.getWallet().getMasterName(), WalletPasswordDialog.PasswordRequirement.LOAD, storage);
         dlg.initOwner(apply.getScene().getWindow());
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
-            Storage storage = walletForm.getStorage();
             Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(storage, password.get(), true);
             keyDerivationService.setOnSucceeded(workerStateEvent -> {
                 EventManager.get().post(new StorageEvent(getWalletForm().getWalletId(), TimedEvent.Action.END, "Done"));
@@ -689,7 +689,7 @@ public class SettingsController extends WalletFormController implements Initiali
         if(masterWallet.getKeystores().stream().anyMatch(ks -> ks.getSource() == KeystoreSource.SW_SEED)) {
             if(masterWallet.isEncrypted()) {
                 String walletId = walletForm.getWalletId();
-                WalletPasswordDialog dlg = new WalletPasswordDialog(masterWallet.getName(), WalletPasswordDialog.PasswordRequirement.LOAD);
+                WalletPasswordDialog dlg = new WalletPasswordDialog(masterWallet.getName(), WalletPasswordDialog.PasswordRequirement.LOAD, walletForm.getStorage());
                 dlg.initOwner(addAccount.getScene().getWindow());
                 Optional<SecureString> password = dlg.showAndWait();
                 if(password.isPresent()) {
@@ -1022,6 +1022,12 @@ public class SettingsController extends WalletFormController implements Initiali
 
     //Returns true if the wallet save was initiated, and false if it was abandoned without any change to the wallet or its storage
     private boolean saveWallet(boolean changePassword, boolean suggestChangePassword) {
+        return saveWallet(changePassword, suggestChangePassword, null);
+    }
+
+    //onDerivationFailed runs if the key derivation fails after this method has already returned true, which a
+    //challenge-response device makes routine since the user can cancel the touch or let it time out
+    private boolean saveWallet(boolean changePassword, boolean suggestChangePassword, Runnable onDerivationFailed) {
         ECKey existingPubKey = walletForm.getStorage().getEncryptionPubKey();
 
         WalletPasswordDialog.PasswordRequirement requirement;
@@ -1044,10 +1050,25 @@ public class SettingsController extends WalletFormController implements Initiali
             }
         }
 
+        boolean challengeResponseWasEnabled = walletForm.getStorage().isChallengeResponseEnabled();
         WalletPasswordDialog dlg = new WalletPasswordDialog(null, requirement, suggestChangePassword);
+        dlg.setYubikeyEnabled(challengeResponseWasEnabled);
         dlg.initOwner(apply.getScene().getWindow());
         Optional<SecureString> password = dlg.showAndWait();
         if(password.isPresent()) {
+            if(requirement != WalletPasswordDialog.PasswordRequirement.UPDATE_SET && challengeResponseWasEnabled != dlg.isYubikeyEnabled()) {
+                String title = dlg.isYubikeyEnabled() ? "Require Challenge-Response?" : "Remove Challenge-Response?";
+                String message = dlg.isYubikeyEnabled() ?
+                        "This wallet file will only open with this security key. If it is lost, reset or reprogrammed, the wallet cannot be recovered from this file. Ok to proceed?" :
+                        "This wallet will no longer require a security key to open, and the password alone will be enough. Ok to proceed?";
+                Optional<ButtonType> optChallengeResponse = AppServices.showWarningDialog(title, message, ButtonType.CANCEL, ButtonType.OK);
+                if(optChallengeResponse.isEmpty() || optChallengeResponse.get().equals(ButtonType.CANCEL)) {
+                    password.get().clear();
+                    revert.setDisable(false);
+                    apply.setDisable(false);
+                    return false;
+                }
+            }
             if(dlg.isBackupExisting()) {
                 try {
                     walletForm.saveBackup();
@@ -1060,9 +1081,11 @@ public class SettingsController extends WalletFormController implements Initiali
                 }
             }
 
-            if(password.get().length() == 0 && requirement != WalletPasswordDialog.PasswordRequirement.UPDATE_SET) {
+            if(password.get().length() == 0 && !dlg.isYubikeyEnabled() && requirement != WalletPasswordDialog.PasswordRequirement.UPDATE_SET) {
                 try {
                     walletForm.getStorage().setEncryptionPubKey(Storage.NO_PASSWORD_KEY);
+                    //An unencrypted wallet has no challenge-response requirement, so the flag must not stay set
+                    walletForm.getStorage().setChallengeResponseEnabled(false);
                     walletForm.saveAndRefresh();
                     EventManager.get().post(new RequestOpenWalletsEvent());
                 } catch (IOException | StorageException e) {
@@ -1072,6 +1095,10 @@ public class SettingsController extends WalletFormController implements Initiali
                     apply.setDisable(false);
                 }
             } else {
+                //UPDATE_SET only verifies the existing password, so the current challenge-response setting is retained
+                if(requirement != WalletPasswordDialog.PasswordRequirement.UPDATE_SET) {
+                    walletForm.getStorage().setChallengeResponseEnabled(dlg.isYubikeyEnabled());
+                }
                 Storage.KeyDerivationService keyDerivationService = new Storage.KeyDerivationService(walletForm.getStorage(), password.get());
                 keyDerivationService.setOnSucceeded(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(walletForm.getWalletId(), TimedEvent.Action.END, "Done"));
@@ -1104,14 +1131,26 @@ public class SettingsController extends WalletFormController implements Initiali
                                 }
                             }
 
-                            //If a new password is not provided, re-encrypt with the existing key rather than leaving the wallet decrypted for the session
-                            if(!saveWallet(true, false)) {
-                                masterWallet.encrypt(key);
-                                for(Wallet childWallet : masterWallet.getChildWallets()) {
-                                    if(!childWallet.isNested()) {
-                                        childWallet.encrypt(key);
+                            //If a new password is not provided, or deriving it fails, re-encrypt with the existing
+                            //key rather than leaving the wallet decrypted for the session
+                            byte[] existingKeyBytes = encryptionFullKey.getPrivKeyBytes();
+                            byte[] existingSalt = walletForm.getStorage().getKeyDeriver().getSalt();
+                            Runnable reEncrypt = () -> {
+                                Key existingKey = new Key(Arrays.copyOf(existingKeyBytes, existingKeyBytes.length), existingSalt, EncryptionType.Deriver.ARGON2);
+                                try {
+                                    masterWallet.encrypt(existingKey);
+                                    for(Wallet childWallet : masterWallet.getChildWallets()) {
+                                        if(!childWallet.isNested()) {
+                                            childWallet.encrypt(existingKey);
+                                        }
                                     }
+                                } finally {
+                                    existingKey.clear();
                                 }
+                            };
+
+                            if(!saveWallet(true, false, reEncrypt)) {
+                                reEncrypt.run();
                             }
                             return;
                         }
@@ -1142,6 +1181,11 @@ public class SettingsController extends WalletFormController implements Initiali
                 });
                 keyDerivationService.setOnFailed(workerStateEvent -> {
                     EventManager.get().post(new StorageEvent(walletForm.getWalletId(), TimedEvent.Action.END, "Failed"));
+                    //The wallet file was not rewritten, so the in memory setting must go back to what the file says
+                    walletForm.getStorage().setChallengeResponseEnabled(challengeResponseWasEnabled);
+                    if(onDerivationFailed != null) {
+                        onDerivationFailed.run();
+                    }
                     AppServices.showErrorDialog("Error saving wallet", keyDerivationService.getException().getMessage());
                     revert.setDisable(false);
                     apply.setDisable(false);

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/WalletController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/WalletController.java
@@ -50,6 +50,7 @@ public class WalletController extends WalletFormController implements Initializa
     private ToggleGroup walletMenu;
 
     private BorderPane lockPane;
+    private Label lockLabel;
 
     private CustomPasswordField passwordField;
 
@@ -156,6 +157,13 @@ public class WalletController extends WalletFormController implements Initializa
         });
     }
 
+    private void updateLockLabel() {
+        if(lockLabel != null) {
+            lockLabel.setText(walletForm.getStorage().isChallengeResponseEnabled() ?
+                    "Enter password to unlock (leave empty if none).\nSecurity key touch will be required." : "Enter password to unlock:");
+        }
+    }
+
     private void initializeLockScreen() {
         lockPane = new BorderPane();
         lockPane.setUserData(Function.LOCK);
@@ -165,7 +173,9 @@ public class WalletController extends WalletFormController implements Initializa
         Glyph lock = new Glyph("FontAwesome", FontAwesome.Glyph.LOCK);
         lock.setFontSize(80);
         vBox.getChildren().add(lock);
-        Label label = new Label("Enter password to unlock:");
+        Label label = new Label();
+        lockLabel = label;
+        updateLockLabel();
         label.managedProperty().bind(label.visibleProperty());
         label.visibleProperty().bind(walletEncryptedProperty);
         passwordField = new ViewPasswordField();
@@ -257,6 +267,8 @@ public class WalletController extends WalletFormController implements Initializa
                 initializeLockScreen();
             }
 
+            //Re-read here, since the setting may have changed since the lock screen was built
+            updateLockLabel();
             getWalletForm().setLocked(true);
             lockPane.setViewOrder(-1);
         }

--- a/src/test/java/com/sparrowwallet/sparrow/io/db/DbPersistenceChallengeResponseTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/db/DbPersistenceChallengeResponseTest.java
@@ -1,0 +1,98 @@
+package com.sparrowwallet.sparrow.io.db;
+
+import com.sparrowwallet.drongo.crypto.ChallengeResponseProvider;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.crypto.KeyCrypterException;
+import com.sparrowwallet.sparrow.io.Storage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class DbPersistenceChallengeResponseTest {
+    private static ChallengeResponseProvider fixedResponse(byte fill) {
+        byte[] response = new byte[20];
+        Arrays.fill(response, fill);
+        return challenge -> Arrays.copyOf(response, response.length);
+    }
+
+    @AfterEach
+    public void clearFactory() {
+        Storage.setChallengeResponseProviderFactory(null);
+    }
+
+    @Test
+    public void anEmptyPasswordOnAChallengeResponseWalletStillDerivesAKey() throws IOException {
+        Storage.setChallengeResponseProviderFactory(() -> fixedResponse((byte)0x5a));
+        DbPersistence persistence = new DbPersistence();
+        persistence.setChallengeResponseEnabled(true);
+
+        ECKey key = persistence.getEncryptionKey("");
+
+        //Returning the no password key here would open the wallet without the device
+        Assertions.assertNotEquals(Storage.NO_PASSWORD_KEY, key);
+    }
+
+    @Test
+    public void anEmptyPasswordWithoutChallengeResponseIsStillTheNoPasswordKey() throws IOException {
+        DbPersistence persistence = new DbPersistence();
+
+        Assertions.assertEquals(Storage.NO_PASSWORD_KEY, persistence.getEncryptionKey(""));
+    }
+
+    @Test
+    public void derivationFailsRatherThanSkippingTheDeviceWhenNoProviderIsRegistered() {
+        DbPersistence persistence = new DbPersistence();
+        persistence.setChallengeResponseEnabled(true);
+
+        Assertions.assertThrows(KeyCrypterException.class, () -> persistence.getEncryptionKey("password"));
+    }
+
+    @Test
+    public void theResponseChangesTheDerivedKey() throws IOException {
+        DbPersistence withoutDevice = new DbPersistence();
+        ECKey plain = withoutDevice.getEncryptionKey("password");
+
+        Storage.setChallengeResponseProviderFactory(() -> fixedResponse((byte)0x11));
+        DbPersistence withDevice = new DbPersistence();
+        withDevice.setKeyDeriver(withoutDevice.getKeyDeriver());
+        withDevice.setChallengeResponseEnabled(true);
+
+        Assertions.assertNotEquals(plain, withDevice.getEncryptionKey("password"));
+    }
+
+    @Test
+    public void aDifferentResponseGivesADifferentKey() throws IOException {
+        DbPersistence first = new DbPersistence();
+        Storage.setChallengeResponseProviderFactory(() -> fixedResponse((byte)0x01));
+        first.setChallengeResponseEnabled(true);
+        ECKey firstKey = first.getEncryptionKey("password");
+
+        DbPersistence second = new DbPersistence();
+        second.setKeyDeriver(first.getKeyDeriver());
+        Storage.setChallengeResponseProviderFactory(() -> fixedResponse((byte)0x02));
+        second.setChallengeResponseEnabled(true);
+
+        Assertions.assertNotEquals(firstKey, second.getEncryptionKey("password"));
+    }
+
+    @Test
+    public void aFreshProviderIsUsedForEachDerivation() throws IOException {
+        int[] created = {0};
+        Storage.setChallengeResponseProviderFactory(() -> {
+            created[0]++;
+            return fixedResponse((byte)0x33);
+        });
+        DbPersistence persistence = new DbPersistence();
+        persistence.setChallengeResponseEnabled(true);
+
+        ECKey first = persistence.getEncryptionKey("password");
+        ECKey second = persistence.getEncryptionKey("password");
+
+        //A provider consumed once would leave the retry deriving without the device
+        Assertions.assertEquals(2, created[0]);
+        Assertions.assertEquals(first, second);
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/io/db/DbPersistenceHeaderTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/db/DbPersistenceHeaderTest.java
@@ -1,0 +1,113 @@
+package com.sparrowwallet.sparrow.io.db;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class DbPersistenceHeaderTest {
+    private static final byte[] MAGIC_1 = "SPRW1\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] MAGIC_2 = "SPRW2\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte FLAG_CHALLENGE_RESPONSE = 0x01;
+    private static final int SALT_LENGTH_BYTES = 16;
+    private static final File WALLET_FILE = new File("test.db");
+
+    private static byte[] salt() {
+        byte[] salt = new byte[SALT_LENGTH_BYTES];
+        for(int i = 0; i < salt.length; i++) {
+            salt[i] = (byte)(0xf0 + i);
+        }
+        return salt;
+    }
+
+    //Mirrors the layout written by writeBinaryHeader, from the wallet header magic onwards
+    private static byte[] header(boolean challengeResponse, byte[] salt) {
+        byte[] magic = challengeResponse ? MAGIC_2 : MAGIC_1;
+        byte[] out = new byte[magic.length + (challengeResponse ? 1 : 0) + salt.length];
+        System.arraycopy(magic, 0, out, 0, magic.length);
+        int offset = magic.length;
+        if(challengeResponse) {
+            out[offset++] = FLAG_CHALLENGE_RESPONSE;
+        }
+        System.arraycopy(salt, 0, out, offset, salt.length);
+        return out;
+    }
+
+    private static boolean readFlag(byte[] bytes, byte[] saltOut) throws IOException {
+        DbPersistence persistence = new DbPersistence();
+        try(InputStream inputStream = new ByteArrayInputStream(bytes)) {
+            boolean flag = persistence.readChallengeResponseFlag(inputStream, WALLET_FILE);
+            if(saltOut != null) {
+                Assertions.assertEquals(saltOut.length, inputStream.readNBytes(saltOut, 0, saltOut.length));
+            }
+            return flag;
+        }
+    }
+
+    @Test
+    public void sprw1HeaderReportsNoChallengeResponseAndKeepsSaltOffset() throws IOException {
+        byte[] salt = salt();
+        byte[] read = new byte[SALT_LENGTH_BYTES];
+
+        Assertions.assertFalse(readFlag(header(false, salt), read));
+        Assertions.assertArrayEquals(salt, read);
+    }
+
+    @Test
+    public void sprw2HeaderReportsChallengeResponseAndKeepsSaltOffset() throws IOException {
+        byte[] salt = salt();
+        byte[] read = new byte[SALT_LENGTH_BYTES];
+
+        Assertions.assertTrue(readFlag(header(true, salt), read));
+        Assertions.assertArrayEquals(salt, read);
+    }
+
+    @Test
+    public void sprw2HeaderWithClearedFlagReportsNoChallengeResponse() throws IOException {
+        byte[] salt = salt();
+        byte[] bytes = header(true, salt);
+        bytes[MAGIC_2.length] = 0x00;
+
+        byte[] read = new byte[SALT_LENGTH_BYTES];
+        Assertions.assertFalse(readFlag(bytes, read));
+        Assertions.assertArrayEquals(salt, read);
+    }
+
+    @Test
+    public void unknownFlagBitsAreRejectedRatherThanIgnored() {
+        //A later version may add a flag that changes how the wallet must be opened, so it must not be silently dropped
+        byte[] bytes = header(true, salt());
+        bytes[MAGIC_2.length] = 0x02;
+
+        Assertions.assertThrows(IOException.class, () -> readFlag(bytes, null));
+    }
+
+    @Test
+    public void unknownFlagBitsAlongsideChallengeResponseAreAlsoRejected() {
+        byte[] bytes = header(true, salt());
+        bytes[MAGIC_2.length] = (byte)0x03;
+
+        Assertions.assertThrows(IOException.class, () -> readFlag(bytes, null));
+    }
+
+    @Test
+    public void truncatedSprw2HeaderIsRejectedRatherThanReadAsEnabled() {
+        //A file ending right after the magic must not be read as challenge-response enabled
+        Assertions.assertThrows(EOFException.class, () -> readFlag(MAGIC_2.clone(), null));
+    }
+
+    @Test
+    public void truncatedMagicIsTreatedAsLegacyHeader() throws IOException {
+        Assertions.assertFalse(readFlag(new byte[] {'S', 'P', 'R'}, null));
+    }
+
+    @Test
+    public void emptyHeaderIsTreatedAsLegacyHeader() throws IOException {
+        Assertions.assertFalse(readFlag(new byte[0], null));
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional challenge-response second factor for wallet encryption, addressing #1896.

When enabled the wallet encryption key becomes `SHA256(argon2DerivedKey || HMAC_SHA1(argon2Salt))`. Both password plus challenge-response and challenge-response only (no password) are supported. A new `SPRW2` wallet header records the requirement so it is known before the password prompt.

Backed by YubiKey slot 2 and any device speaking the same protocol. The UI is vendor neutral.

## Dependencies

- sparrowwallet/drongo#41 — key derivation interfaces
- sparrowwallet/lark#4 — HMAC-SHA1 USB implementation

The `drongo` and `lark` submodule pointers are deliberately not bumped here, as they would point at fork commits. CI will not compile until those land and the pointers move.

## Design

**Header.** `SPRW2` adds a flags byte between the magic and the salt, bit 0 meaning challenge-response is required. Unrecognized flag bits are rejected rather than ignored. An older Sparrow reads an `SPRW2` file as an invalid password rather than opening it.

**Provider wiring.** The provider comes from a factory registered once at desktop startup and is obtained inside `DbPersistence` when the header says it is required, so no unlock path can skip the second factor by omitting an injection. Terminal mode registers no factory and reports the requirement as unsupported.

**Failure handling.** A device error surfaces with its own message rather than as an unsupported file format. A wrong password is still reported as a wrong password. Dismissing the touch prompt interrupts the wait. A failed derive while enabling or disabling restores the in-memory state to match the file.

## Security properties

- The challenge is the wallet's Argon2 salt, stored in the header and never rotated, so the response is a static secret for that wallet. If slot 2 requires no button press, anything with USB access can obtain it. Inherent to HMAC-SHA1 challenge-response.
- Enabling binds the file to that device. There is no second-device registration or recovery export, so losing or reprogramming the key makes the file unopenable. The dialog warns and asks for confirmation before enabling or removing.
- The flags byte is unauthenticated. Altering it derives a key that fails to open the file: denial of service, not bypass.

## Tests

`DbPersistenceHeaderTest` covers the header parse: `SPRW1` and `SPRW2` both leaving the stream at the correct salt offset, set and cleared flags, rejection of unrecognized bits, and rejection of a file truncated after the magic.

`DbPersistenceChallengeResponseTest` covers the derivation decisions against a stub provider: that an empty password on a challenge-response wallet does not return the no-password key, that it still does on an ordinary wallet, that derivation fails rather than proceeding without a device when no provider is registered, that the response changes the derived key, and that a fresh provider is obtained per derivation so a retry after a failed touch is not silently downgraded.

Composite build against current master of all three repos compiles and passes, 862 tests.

Manually exercised with a YubiKey: password-only wallet, enabling challenge-response, opening with password plus touch, challenge-response only, changing the password on an enabled wallet, device absent, and touch timeout.

Challenge padding follows `ykman`, so a slot programmed for variable-length challenges resolves the challenge boundary correctly. Details on sparrowwallet/lark#4.
