### PR TITLE
Add Migrate UTXOs feature to Tools menu

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -1525,12 +1525,19 @@ public class AppController implements Initializable {
         }
     }
 
+    private MigrateUtxosDialog migrateUtxosDialog;
+
     public void migrateUtxos(ActionEvent event) {
+        if(migrateUtxosDialog != null && migrateUtxosDialog.isShowing()) {
+            migrateUtxosDialog.getDialogPane().getScene().getWindow().requestFocus();
+            return;
+        }
         WalletForm selectedWalletForm = getSelectedWalletForm();
         if(selectedWalletForm != null && selectedWalletForm.getWallet().isValid()) {
             Wallet wallet = selectedWalletForm.getWallet();
-            MigrateUtxosDialog dialog = new MigrateUtxosDialog(wallet, AppServices.get().getOpenWallets(), rootStack.getScene().getWindow());
-            dialog.show();
+            migrateUtxosDialog = new MigrateUtxosDialog(wallet, AppServices.get().getOpenWallets(), rootStack.getScene().getWindow());
+            migrateUtxosDialog.setOnCloseRequest(e -> migrateUtxosDialog = null);
+            migrateUtxosDialog.show();
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -196,6 +196,9 @@ public class AppController implements Initializable {
     private MenuItem sendToMany;
 
     @FXML
+    private MenuItem migrateUtxos;
+
+    @FXML
     private MenuItem sweepPrivateKey;
 
     @FXML
@@ -437,6 +440,7 @@ public class AppController implements Initializable {
         searchWallet.disableProperty().bind(exportWallet.disableProperty());
         refreshWallet.disableProperty().bind(Bindings.or(exportWallet.disableProperty(), Bindings.or(serverToggle.disableProperty(), AppServices.onlineProperty().not())));
         sendToMany.disableProperty().bind(exportWallet.disableProperty());
+        migrateUtxos.disableProperty().bind(exportWallet.disableProperty());
         sweepPrivateKey.disableProperty().bind(Bindings.or(serverToggle.disableProperty(), AppServices.onlineProperty().not()));
         showPayNym.setDisable(true);
 
@@ -1518,6 +1522,15 @@ public class AppController implements Initializable {
                     Platform.runLater(() -> EventManager.get().post(new SendPaymentsEvent(wallet, payments)));
                 }
             });
+        }
+    }
+
+    public void migrateUtxos(ActionEvent event) {
+        WalletForm selectedWalletForm = getSelectedWalletForm();
+        if(selectedWalletForm != null && selectedWalletForm.getWallet().isValid()) {
+            Wallet wallet = selectedWalletForm.getWallet();
+            MigrateUtxosDialog dialog = new MigrateUtxosDialog(wallet, AppServices.get().getOpenWallets(), rootStack.getScene().getWindow());
+            dialog.show();
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -693,7 +693,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             return;
         }
 
-        applyLabelsToDestWallets();
         manageTable.setItems(FXCollections.observableArrayList(migrationRows));
         updateManageSummary();
         showManagePhase();
@@ -918,7 +917,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             checkConfirmations();
             manageTable.refresh();
         });
-
         List<MigrationRow> ready = migrationRows.stream()
                 .filter(r -> r.getStatus() == MigrationStatus.SIGNED && r.targetBlock > 0 && height >= r.targetBlock)
                 .toList();
@@ -945,9 +943,28 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         }
     }
 
+    private void broadcastNextReady() {
+        // Resume flow: one at a time, wait for confirmation before next
+        boolean anyBroadcast = migrationRows.stream().anyMatch(r -> r.getStatus() == MigrationStatus.BROADCAST);
+        if(anyBroadcast) {
+            return;
+        }
+
+        Integer currentHeight = AppServices.getCurrentBlockHeight();
+        if(currentHeight == null) {
+            return;
+        }
+
+        migrationRows.stream()
+                .filter(r -> r.getStatus() == MigrationStatus.SIGNED && r.targetBlock > 0 && currentHeight >= r.targetBlock)
+                .findFirst()
+                .ifPresent(row -> Platform.runLater(() -> autoBroadcast(row)));
+    }
+
     @Subscribe
     public void walletHistoryChanged(WalletHistoryChangedEvent event) {
         Platform.runLater(() -> {
+            applyLabelsToDestTxos(event.getWallet());
             checkConfirmations();
             manageTable.refresh();
         });
@@ -987,6 +1004,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         if(changed) {
             updateManageSummary();
             saveMigrationState();
+            broadcastNextReady();
             checkMigrationComplete();
         }
     }
@@ -1377,40 +1395,42 @@ public class MigrateUtxosDialog extends Dialog<Void> {
 
     // === Label propagation to destination wallet ===
 
-    private void applyLabelsToDestWallets() {
-        Set<Wallet> modifiedWallets = new HashSet<>();
+    private void applyLabelsToDestTxos(Wallet changedWallet) {
+        boolean changed = false;
         for(MigrationRow mr : migrationRows) {
-            if(mr.destWalletNode == null || mr.label == null || mr.label.isEmpty()) {
+            if(mr.destWallet == null || mr.destWallet != changedWallet) {
                 continue;
             }
-            String baseLabel = stripLabelSuffix(mr.label);
-            if(baseLabel.isEmpty()) {
+            String label = mr.label;
+            if(label == null || label.isEmpty()) {
                 continue;
             }
-            if(mr.destWalletNode.getLabel() == null || mr.destWalletNode.getLabel().isEmpty()) {
-                mr.destWalletNode.setLabel(baseLabel);
-                if(mr.destWallet != null) {
-                    modifiedWallets.add(mr.destWallet);
+            Sha256Hash txId = mr.psbt.getTransaction().getTxId();
+
+            // Label the BlockTransaction
+            BlockTransaction blockTx = mr.destWallet.getTransactions().get(txId);
+            if(blockTx != null && (blockTx.getLabel() == null || blockTx.getLabel().isEmpty())) {
+                blockTx.setLabel(label);
+                changed = true;
+                log.debug("Applied label '{}' to dest tx {}", label, txId);
+            }
+
+            // Label the received UTXO
+            if(mr.destWalletNode != null) {
+                for(BlockTransactionHashIndex txo : mr.destWalletNode.getTransactionOutputs()) {
+                    if(txo.getHash().equals(txId) && (txo.getLabel() == null || txo.getLabel().isEmpty())) {
+                        txo.setLabel(label);
+                        changed = true;
+                        log.debug("Applied label '{}' to dest utxo {}:{}", label, txId, txo.getIndex());
+                    }
                 }
-                log.debug("Applied label '{}' to dest node {}", baseLabel, mr.destWalletNode.getDerivationPath());
             }
         }
-        for(Wallet w : modifiedWallets) {
-            EventManager.get().post(new WalletDataChangedEvent(w));
+        if(changed) {
+            EventManager.get().post(new WalletDataChangedEvent(changedWallet));
         }
     }
 
-    private static String stripLabelSuffix(String label) {
-        if(label == null) {
-            return "";
-        }
-        for(String suffix : List.of(" (received)", " (change)", " (sent)")) {
-            if(label.endsWith(suffix)) {
-                return label.substring(0, label.length() - suffix.length());
-            }
-        }
-        return label;
-    }
 
     // === Persistence ===
 
@@ -1504,8 +1524,15 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             }
 
             if(!migrationRows.isEmpty()) {
-                applyLabelsToDestWallets();
+                // Apply labels to dest wallets for txs that arrived while app was closed
+                Set<Wallet> destWallets = migrationRows.stream()
+                        .map(mr -> mr.destWallet).filter(Objects::nonNull)
+                        .collect(Collectors.toSet());
+                for(Wallet dw : destWallets) {
+                    applyLabelsToDestTxos(dw);
+                }
                 checkConfirmations();
+                broadcastNextReady();
                 manageTable.setItems(FXCollections.observableArrayList(migrationRows));
                 updateManageSummary();
                 showManagePhase();

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -438,11 +438,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         TableColumn<MigrationRow, String> labelCol = new TableColumn<>("Label");
         labelCol.setCellValueFactory(cd -> new SimpleStringProperty(cd.getValue().label));
 
-        TableColumn<MigrationRow, MigrationStatus> statusCol = new TableColumn<>("Status");
-        statusCol.setCellValueFactory(cd -> cd.getValue().statusProperty());
-        statusCol.setCellFactory(col -> new StatusCell());
-        statusCol.setStyle(ALIGN_CENTER);
-
         TableColumn<MigrationRow, String> targetBlockCol = new TableColumn<>("Target Block");
         targetBlockCol.setCellValueFactory(cd -> {
             MigrationRow row = cd.getValue();
@@ -461,7 +456,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         actionCol.setStyle(ALIGN_CENTER);
         actionCol.setMinWidth(ACTION_BTN_WIDTH + 20);
 
-        table.getColumns().addAll(utxoCol, destCol, valueCol, feeCol, labelCol, statusCol, targetBlockCol, actionCol);
+        table.getColumns().addAll(utxoCol, destCol, valueCol, feeCol, labelCol, targetBlockCol, actionCol);
 
         // Double-click on row to view transaction details
         table.setRowFactory(tv -> {

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -13,6 +13,8 @@ import com.sparrowwallet.sparrow.event.PSBTFinalizedEvent;
 import com.sparrowwallet.sparrow.event.ViewPSBTEvent;
 import com.sparrowwallet.sparrow.event.ViewTransactionEvent;
 import com.google.common.eventbus.Subscribe;
+import com.sparrowwallet.drongo.OutputDescriptor;
+import com.sparrowwallet.drongo.wallet.KeystoreSource;
 import com.sparrowwallet.sparrow.io.Storage;
 import com.sparrowwallet.sparrow.net.ElectrumServer;
 import javafx.application.Platform;
@@ -385,6 +387,23 @@ public class MigrateUtxosDialog extends Dialog<Void> {
 
         TableColumn<MigrationRow, String> destCol = new TableColumn<>("Dest. Address");
         destCol.setCellValueFactory(cd -> new SimpleStringProperty(cd.getValue().destAddress));
+        destCol.setCellFactory(col -> {
+            TableCell<MigrationRow, String> cell = new TableCell<>() {
+                @Override
+                protected void updateItem(String item, boolean empty) {
+                    super.updateItem(item, empty);
+                    setText(empty || item == null ? null : item);
+                }
+            };
+            cell.setOnMouseClicked(event -> {
+                if(event.getClickCount() == 2 && !cell.isEmpty() && cell.getItem() != null) {
+                    QRDisplayDialog qrDialog = new QRDisplayDialog(cell.getItem());
+                    qrDialog.initOwner(getDialogPane().getScene().getWindow());
+                    qrDialog.showAndWait();
+                }
+            });
+            return cell;
+        });
 
         TableColumn<MigrationRow, String> valueCol = new TableColumn<>("Value (sats)");
         valueCol.setCellValueFactory(cd -> new SimpleStringProperty(String.format("%,d", cd.getValue().value)));
@@ -459,35 +478,32 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                     saveMigrationState();
                 }
             });
-
-            tableRow.itemProperty().addListener((obs, oldItem, newItem) -> {
-                contextMenu.getItems().clear();
-                if(newItem == null) {
-                    tableRow.setContextMenu(null);
-                    return;
-                }
-                MigrationStatus status = newItem.getStatus();
-                if(status == MigrationStatus.UNSIGNED) {
-                    tableRow.setContextMenu(null);
-                } else if(status == MigrationStatus.SIGNED) {
-                    contextMenu.getItems().addAll(viewItem, redoItem);
-                    tableRow.setContextMenu(contextMenu);
-                } else {
-                    contextMenu.getItems().add(viewItem);
-                    tableRow.setContextMenu(contextMenu);
+            MenuItem verifyItem = new MenuItem("Verify address on device");
+            verifyItem.setOnAction(e -> {
+                MigrationRow row = tableRow.getItem();
+                if(row != null) {
+                    verifyDestAddressOnDevice(row);
                 }
             });
 
-            // Also update context menu when status changes
             tableRow.setOnMousePressed(e -> {
                 if(e.isSecondaryButtonDown() && !tableRow.isEmpty()) {
                     MigrationRow row = tableRow.getItem();
                     contextMenu.getItems().clear();
-                    if(row != null && row.getStatus() != MigrationStatus.UNSIGNED) {
+                    if(row == null) {
+                        tableRow.setContextMenu(null);
+                        return;
+                    }
+                    if(row.getStatus() != MigrationStatus.UNSIGNED) {
                         contextMenu.getItems().add(viewItem);
                         if(row.getStatus() == MigrationStatus.SIGNED) {
                             contextMenu.getItems().add(redoItem);
                         }
+                    }
+                    if(isDestWalletHardware(row)) {
+                        contextMenu.getItems().add(verifyItem);
+                    }
+                    if(!contextMenu.getItems().isEmpty()) {
                         tableRow.setContextMenu(contextMenu);
                     } else {
                         tableRow.setContextMenu(null);
@@ -638,6 +654,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                         row.getUtxo().getLabel() != null ? row.getUtxo().getLabel() : "",
                         row.getDestAddress(), row.getFeeRate(), fee, psbt
                 );
+                mr.destWallet = wd.wallet();
+                mr.destWalletNode = row.getDestWalletNode();
                 migrationRows.add(mr);
             } catch(Exception e) {
                 errors++;
@@ -1107,6 +1125,29 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         }
     }
 
+    // === Hardware wallet address verification ===
+
+    private boolean isDestWalletHardware(MigrationRow row) {
+        if(row.destWallet == null) {
+            return false;
+        }
+        return row.destWallet.getKeystores().stream().anyMatch(ks ->
+                ks.getSource().equals(KeystoreSource.HW_USB) || ks.getSource().equals(KeystoreSource.SW_WATCH));
+    }
+
+    private void verifyDestAddressOnDevice(MigrationRow row) {
+        if(row.destWallet == null || row.destWalletNode == null) {
+            AppServices.showErrorDialog("Cannot verify", "Destination wallet information is not available for this transaction.");
+            return;
+        }
+
+        OutputDescriptor addressDescriptor = OutputDescriptor.getOutputDescriptor(row.destWallet,
+                row.destWalletNode.getKeyPurpose(), row.destWalletNode.getIndex());
+        DeviceDisplayAddressDialog dlg = new DeviceDisplayAddressDialog(row.destWallet, addressDescriptor);
+        dlg.initOwner(getDialogPane().getScene().getWindow());
+        dlg.showAndWait();
+    }
+
     // === Persistence ===
 
     private File getMigrationFile() {
@@ -1237,6 +1278,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         double feeRate;
         final long fee;
         final PSBT psbt;
+        Wallet destWallet;
+        WalletNode destWalletNode;
         private final SimpleObjectProperty<MigrationStatus> status = new SimpleObjectProperty<>(MigrationStatus.UNSIGNED);
 
         public MigrationRow(String utxoId, long value, String label, String destAddress, double feeRate, long fee, PSBT psbt) {

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -1,0 +1,1436 @@
+package com.sparrowwallet.sparrow.control;
+
+import com.sparrowwallet.drongo.KeyPurpose;
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.protocol.*;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.wallet.*;
+import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.EventManager;
+import com.sparrowwallet.sparrow.TabData;
+import com.sparrowwallet.sparrow.TransactionTabData;
+import com.sparrowwallet.sparrow.event.PSBTFinalizedEvent;
+import com.sparrowwallet.sparrow.event.ViewPSBTEvent;
+import com.sparrowwallet.sparrow.event.ViewTransactionEvent;
+import com.google.common.eventbus.Subscribe;
+import com.sparrowwallet.sparrow.io.Storage;
+import com.sparrowwallet.sparrow.net.ElectrumServer;
+import javafx.application.Platform;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.*;
+import javafx.scene.control.cell.CheckBoxTableCell;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.stage.FileChooser;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+import javafx.util.StringConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.*;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class MigrateUtxosDialog extends Dialog<Void> {
+    private static final Logger log = LoggerFactory.getLogger(MigrateUtxosDialog.class);
+
+    private static final String ALIGN_RIGHT = "-fx-alignment: CENTER-RIGHT;";
+    private static final String ALIGN_CENTER = "-fx-alignment: CENTER;";
+
+    private final Wallet sourceWallet;
+    private final Window ownerWindow;
+
+    // Setup phase UI
+    private final VBox setupPane;
+    private final TableView<UtxoRow> setupTable;
+    private final ComboBox<WalletDestination> destWalletCombo;
+    private final TextField feeRateField;
+    private final ToggleGroup feeStrategyGroup;
+    private final TextField minFeeField;
+    private final TextField maxFeeField;
+    private final HBox randomRangeBox;
+    private final HBox fixedFeeBox;
+    private final Label setupSummaryLabel;
+
+    // Manage phase UI
+    private final VBox managePane;
+    private final TableView<MigrationRow> manageTable;
+    private final Label manageSummaryLabel;
+
+    // State
+    private final List<MigrationRow> migrationRows = new ArrayList<>();
+
+    public MigrateUtxosDialog(Wallet sourceWallet, Map<Wallet, Storage> openWallets, Window owner) {
+        this.sourceWallet = sourceWallet;
+        this.ownerWindow = owner;
+
+        final DialogPane dialogPane = getDialogPane();
+        setTitle("Migrate UTXOs");
+        dialogPane.getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
+        dialogPane.setStyle("-fx-font-size: 13px;");
+        // Center column headers
+        Platform.runLater(() -> dialogPane.getScene().getRoot().setStyle(
+                dialogPane.getScene().getRoot().getStyle() +
+                "; -fx-alignment: CENTER;"));
+        dialogPane.getStylesheets().add("data:text/css," +
+                ".table-view .column-header .label { -fx-alignment: CENTER; }");
+        dialogPane.setHeaderText("Migrate UTXOs individually to a destination wallet.\nEach UTXO becomes a separate transaction for privacy.");
+
+        // === SETUP PHASE ===
+        setupPane = new VBox(10);
+        setupPane.setPadding(new Insets(10));
+
+        // Destination wallet selector
+        List<WalletDestination> destinations = buildDestinationList(sourceWallet, openWallets);
+        HBox destBox = new HBox(10);
+        destBox.setAlignment(Pos.CENTER_LEFT);
+        destWalletCombo = new ComboBox<>(FXCollections.observableArrayList(destinations));
+        destWalletCombo.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(WalletDestination wd) {
+                return wd == null ? "" : wd.displayName();
+            }
+
+            @Override
+            public WalletDestination fromString(String s) {
+                return null;
+            }
+        });
+        destWalletCombo.setPrefWidth(350);
+        if(destinations.isEmpty()) {
+            destWalletCombo.setPromptText("Open a destination wallet first");
+            destWalletCombo.setDisable(true);
+        }
+        destBox.getChildren().addAll(new Label("Destination:"), destWalletCombo);
+
+        // Fee strategy
+        HBox feeBox = new HBox(10);
+        feeBox.setAlignment(Pos.CENTER_LEFT);
+        feeStrategyGroup = new ToggleGroup();
+        RadioButton fixedRadio = new RadioButton("Fixed");
+        fixedRadio.setToggleGroup(feeStrategyGroup);
+        fixedRadio.setUserData("fixed");
+        fixedRadio.setSelected(true);
+        RadioButton manualRadio = new RadioButton("Manual per-tx");
+        manualRadio.setToggleGroup(feeStrategyGroup);
+        manualRadio.setUserData("manual");
+        RadioButton randomRadio = new RadioButton("Random range");
+        randomRadio.setToggleGroup(feeStrategyGroup);
+        randomRadio.setUserData("random");
+        feeBox.getChildren().addAll(new Label("Fee strategy:"), fixedRadio, manualRadio, randomRadio);
+
+        // Fixed fee rate input
+        fixedFeeBox = new HBox(10);
+        fixedFeeBox.setAlignment(Pos.CENTER_LEFT);
+        feeRateField = new TextField("1.0");
+        feeRateField.setPrefWidth(80);
+        fixedFeeBox.getChildren().addAll(new Label("Fee rate (sat/vB):"), feeRateField);
+
+        // Random range input
+        randomRangeBox = new HBox(10);
+        randomRangeBox.setAlignment(Pos.CENTER_LEFT);
+        minFeeField = new TextField("0.5");
+        minFeeField.setPrefWidth(60);
+        maxFeeField = new TextField("4.0");
+        maxFeeField.setPrefWidth(60);
+        Button randomizeButton = new Button("Randomize");
+        randomRangeBox.getChildren().addAll(new Label("Min (sat/vB):"), minFeeField, new Label("Max:"), maxFeeField, randomizeButton);
+        randomRangeBox.setVisible(false);
+        randomRangeBox.setManaged(false);
+
+        // Setup table
+        setupTable = createSetupTable();
+
+        // Buttons row
+        HBox selectButtons = new HBox(10);
+        selectButtons.setAlignment(Pos.CENTER_LEFT);
+        Button selectAllBtn = new Button("Select All");
+        Button deselectAllBtn = new Button("Deselect All");
+        selectAllBtn.setOnAction(e -> setupTable.getItems().forEach(r -> r.selectedProperty().set(true)));
+        deselectAllBtn.setOnAction(e -> setupTable.getItems().forEach(r -> r.selectedProperty().set(false)));
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        Button importPsbtsBtn = new Button("Import PSBTs");
+        importPsbtsBtn.setOnAction(e -> importSignedPsbts());
+        Button createPsbtsBtn = new Button("Create PSBTs");
+        createPsbtsBtn.setStyle("-fx-font-weight: bold;");
+        createPsbtsBtn.setDisable(true);
+        selectButtons.getChildren().addAll(selectAllBtn, deselectAllBtn, spacer, importPsbtsBtn, createPsbtsBtn);
+
+        setupSummaryLabel = new Label("");
+        setupSummaryLabel.setStyle("-fx-font-weight: bold;");
+
+        setupPane.getChildren().addAll(destBox, feeBox, fixedFeeBox, randomRangeBox, setupTable, selectButtons, setupSummaryLabel);
+        VBox.setVgrow(setupTable, Priority.ALWAYS);
+
+        // === MANAGE PHASE ===
+        managePane = new VBox(10);
+        managePane.setPadding(new Insets(10));
+        managePane.setVisible(false);
+        managePane.setManaged(false);
+
+        manageTable = createManageTable();
+
+        manageSummaryLabel = new Label("");
+        manageSummaryLabel.setStyle("-fx-font-weight: bold;");
+
+        HBox manageButtons = new HBox(10);
+        manageButtons.setAlignment(Pos.CENTER_LEFT);
+        Button clearBtn = new Button("Clear");
+        clearBtn.setOnAction(e -> clearMigration());
+        Button exportAllBtn = new Button("Export All PSBTs");
+        exportAllBtn.setOnAction(e -> exportAllPsbts());
+        Region spacer2 = new Region();
+        HBox.setHgrow(spacer2, Priority.ALWAYS);
+        Button broadcastAllBtn = new Button("Broadcast All Signed");
+        broadcastAllBtn.setStyle("-fx-font-weight: bold;");
+        broadcastAllBtn.setOnAction(e -> broadcastAllSigned());
+        manageButtons.getChildren().addAll(clearBtn, exportAllBtn, spacer2, broadcastAllBtn);
+
+        managePane.getChildren().addAll(manageTable, manageButtons, manageSummaryLabel);
+        VBox.setVgrow(manageTable, Priority.ALWAYS);
+
+        // Refresh signing status when dialog regains focus
+        Platform.runLater(() -> {
+            Window dialogWindow = dialogPane.getScene().getWindow();
+            dialogWindow.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
+                if(isFocused && managePane.isVisible()) {
+                    refreshMigrationStatuses();
+                }
+            });
+        });
+
+        // Main content
+        VBox mainContent = new VBox();
+        mainContent.getChildren().addAll(setupPane, managePane);
+        VBox.setVgrow(setupPane, Priority.ALWAYS);
+        VBox.setVgrow(managePane, Priority.ALWAYS);
+        dialogPane.setContent(mainContent);
+
+        // Hidden CLOSE button type required by JavaFX to allow the X button to work
+        dialogPane.getButtonTypes().add(ButtonType.CLOSE);
+        dialogPane.lookupButton(ButtonType.CLOSE).setVisible(false);
+        dialogPane.lookupButton(ButtonType.CLOSE).setManaged(false);
+        // Remove button bar padding since there are no visible buttons
+        dialogPane.getStylesheets().add("data:text/css," +
+                ".dialog-pane .button-bar { -fx-padding: 0; -fx-min-height: 0; -fx-pref-height: 0; }");
+
+        // Wire up events
+        destWalletCombo.valueProperty().addListener((obs, old, newVal) -> {
+            updateCreateButton(createPsbtsBtn);
+            if(newVal != null) {
+                assignDestinationAddresses();
+            }
+            updateSetupSummary();
+        });
+
+        feeStrategyGroup.selectedToggleProperty().addListener((obs, old, newVal) -> {
+            String strategy = (String) newVal.getUserData();
+            boolean isRandom = "random".equals(strategy);
+            boolean isManual = "manual".equals(strategy);
+            feeRateField.setDisable(isManual);
+            randomRangeBox.setVisible(isRandom);
+            randomRangeBox.setManaged(isRandom);
+            fixedFeeBox.setVisible(!isRandom);
+            fixedFeeBox.setManaged(!isRandom);
+            if("fixed".equals(strategy)) {
+                applyFixedFeeRate();
+            } else if(isRandom) {
+                applyRandomFeeRates();
+            }
+            setupTable.getColumns().get(4).setEditable(isManual);
+        });
+
+        feeRateField.textProperty().addListener((obs, old, newVal) -> {
+            if("fixed".equals(feeStrategyGroup.getSelectedToggle().getUserData())) {
+                applyFixedFeeRate();
+            }
+        });
+
+        randomizeButton.setOnAction(e -> applyRandomFeeRates());
+        createPsbtsBtn.setOnAction(e -> createPsbtsAndShowManagePhase());
+
+        dialogPane.setPrefWidth(1100);
+        dialogPane.setPrefHeight(700);
+        setResizable(true);
+        AppServices.setStageIcon(dialogPane.getScene().getWindow());
+        AppServices.moveToActiveWindowScreen(this);
+        initModality(Modality.NONE);
+
+        populateUtxos();
+
+        // Load saved migration state if available
+        loadMigrationState();
+
+        // Listen for PSBT signing events to auto-close tabs
+        EventManager.get().register(this);
+
+        // Save state and unregister when dialog is closed
+        setOnCloseRequest(e -> {
+            saveMigrationState();
+            EventManager.get().unregister(this);
+        });
+        setResultConverter(btn2 -> {
+            saveMigrationState();
+            EventManager.get().unregister(this);
+            return null;
+        });
+    }
+
+    // === Destination list builder ===
+
+    private List<WalletDestination> buildDestinationList(Wallet source, Map<Wallet, Storage> openWallets) {
+        List<WalletDestination> destinations = new ArrayList<>();
+        Wallet sourceMaster = source.isMasterWallet() ? source : source.getMasterWallet();
+
+        for(Wallet child : sourceMaster.getChildWallets()) {
+            if(!child.equals(source) && child.isValid() && !child.isWhirlpoolChildWallet()
+                    && !child.isBip47() && child.getStandardAccountType() != null) {
+                destinations.add(new WalletDestination(child, sourceMaster.getName() + " - " + child.getDisplayName() + " (same wallet)", true));
+            }
+        }
+        if(!source.isMasterWallet() && sourceMaster.isValid()) {
+            destinations.add(new WalletDestination(sourceMaster, sourceMaster.getName() + " - " + sourceMaster.getDisplayName() + " (same wallet)", true));
+        }
+
+        for(Map.Entry<Wallet, Storage> entry : openWallets.entrySet()) {
+            Wallet w = entry.getKey();
+            if(w.isValid() && !w.equals(source) && !isRelatedWallet(w, source)) {
+                destinations.add(new WalletDestination(w, w.getFullDisplayName(), false));
+            }
+        }
+
+        return destinations;
+    }
+
+    private boolean isRelatedWallet(Wallet w1, Wallet w2) {
+        Wallet master1 = w1.isMasterWallet() ? w1 : w1.getMasterWallet();
+        Wallet master2 = w2.isMasterWallet() ? w2 : w2.getMasterWallet();
+        return master1.equals(master2);
+    }
+
+    // === Setup table ===
+
+    @SuppressWarnings("unchecked")
+    private TableView<UtxoRow> createSetupTable() {
+        TableView<UtxoRow> table = new TableView<>();
+        table.setEditable(true);
+        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+
+        TableColumn<UtxoRow, Boolean> selectCol = new TableColumn<>("");
+        selectCol.setCellValueFactory(cd -> cd.getValue().selectedProperty());
+        selectCol.setCellFactory(CheckBoxTableCell.forTableColumn(selectCol));
+        selectCol.setMinWidth(35);
+        selectCol.setMaxWidth(35);
+        selectCol.setStyle(ALIGN_CENTER);
+
+        TableColumn<UtxoRow, String> utxoCol = new TableColumn<>("UTXO");
+        utxoCol.setCellValueFactory(cd -> cd.getValue().utxoIdProperty());
+
+        TableColumn<UtxoRow, String> destCol = new TableColumn<>("Dest. Address");
+        destCol.setCellValueFactory(cd -> cd.getValue().destAddressProperty());
+
+        TableColumn<UtxoRow, String> valueCol = new TableColumn<>("Value (sats)");
+        valueCol.setCellValueFactory(cd -> cd.getValue().valueDisplayProperty());
+
+        TableColumn<UtxoRow, String> feeCol = new TableColumn<>("Fee (sat/vB)");
+        feeCol.setCellValueFactory(cd -> cd.getValue().feeRateDisplayProperty());
+        feeCol.setCellFactory(col -> new EditableTextFieldCell<>());
+        feeCol.setOnEditCommit(event -> {
+            try {
+                double newRate = Double.parseDouble(event.getNewValue());
+                if(newRate > 0) {
+                    event.getRowValue().setFeeRate(newRate);
+                    updateSetupSummary();
+                }
+            } catch(NumberFormatException e) {
+                // revert
+            }
+        });
+        feeCol.setEditable(false);
+
+        TableColumn<UtxoRow, String> labelCol = new TableColumn<>("Label");
+        labelCol.setCellValueFactory(cd -> cd.getValue().labelProperty());
+
+        table.getColumns().addAll(selectCol, utxoCol, destCol, valueCol, feeCol, labelCol);
+        return table;
+    }
+
+    // === Manage table ===
+
+    @SuppressWarnings("unchecked")
+    private TableView<MigrationRow> createManageTable() {
+        TableView<MigrationRow> table = new TableView<>();
+        table.setEditable(true);
+        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+
+        TableColumn<MigrationRow, String> utxoCol = new TableColumn<>("UTXO");
+        utxoCol.setCellValueFactory(cd -> new SimpleStringProperty(cd.getValue().utxoId));
+
+        TableColumn<MigrationRow, String> destCol = new TableColumn<>("Dest. Address");
+        destCol.setCellValueFactory(cd -> new SimpleStringProperty(cd.getValue().destAddress));
+
+        TableColumn<MigrationRow, String> valueCol = new TableColumn<>("Value (sats)");
+        valueCol.setCellValueFactory(cd -> new SimpleStringProperty(String.format("%,d", cd.getValue().value)));
+
+        TableColumn<MigrationRow, String> feeCol = new TableColumn<>("Fee (sat/vB)");
+        feeCol.setCellValueFactory(cd -> new SimpleStringProperty(String.format("%.1f", cd.getValue().feeRate)));
+        feeCol.setCellFactory(col -> new EditableTextFieldCell<>() {
+            @Override
+            public void startEdit() {
+                MigrationRow row = getTableRow() != null ? getTableRow().getItem() : null;
+                if(row == null || row.getStatus() != MigrationStatus.UNSIGNED) {
+                    return;
+                }
+                super.startEdit();
+            }
+        });
+        feeCol.setOnEditCommit(event -> {
+            MigrationRow row = event.getRowValue();
+            try {
+                double newRate = Double.parseDouble(event.getNewValue().trim());
+                if(newRate > 0) {
+                    row.feeRate = newRate;
+                    saveMigrationState();
+                }
+            } catch(NumberFormatException ignored) {
+            }
+            manageTable.refresh();
+        });
+        feeCol.setEditable(true);
+
+        TableColumn<MigrationRow, String> labelCol = new TableColumn<>("Label");
+        labelCol.setCellValueFactory(cd -> new SimpleStringProperty(cd.getValue().label));
+
+        TableColumn<MigrationRow, MigrationStatus> statusCol = new TableColumn<>("Status");
+        statusCol.setCellValueFactory(cd -> cd.getValue().statusProperty());
+        statusCol.setCellFactory(col -> new StatusCell());
+        statusCol.setStyle(ALIGN_CENTER);
+
+        TableColumn<MigrationRow, Void> actionCol = new TableColumn<>("Action");
+        actionCol.setCellFactory(col -> new ActionCell());
+        actionCol.setStyle(ALIGN_CENTER);
+        actionCol.setMinWidth(ACTION_BTN_WIDTH + 20);
+
+        table.getColumns().addAll(utxoCol, destCol, valueCol, feeCol, labelCol, statusCol, actionCol);
+
+        // Double-click on row to view transaction details
+        table.setRowFactory(tv -> {
+            TableRow<MigrationRow> tableRow = new TableRow<>();
+            tableRow.setOnMouseClicked(event -> {
+                if(event.getClickCount() == 2 && !tableRow.isEmpty()) {
+                    MigrationRow row = tableRow.getItem();
+                    if(row.getStatus() != MigrationStatus.UNSIGNED) {
+                        showTransactionDetails(row);
+                    }
+                }
+            });
+
+            ContextMenu contextMenu = new ContextMenu();
+            MenuItem viewItem = new MenuItem("View transaction");
+            viewItem.setOnAction(e -> {
+                MigrationRow row = tableRow.getItem();
+                if(row != null) {
+                    showTransactionDetails(row);
+                }
+            });
+            MenuItem redoItem = new MenuItem("Reset to unsigned");
+            redoItem.setOnAction(e -> {
+                MigrationRow row = tableRow.getItem();
+                if(row != null) {
+                    row.setStatus(MigrationStatus.UNSIGNED);
+                    manageTable.refresh();
+                    saveMigrationState();
+                }
+            });
+
+            tableRow.itemProperty().addListener((obs, oldItem, newItem) -> {
+                contextMenu.getItems().clear();
+                if(newItem == null) {
+                    tableRow.setContextMenu(null);
+                    return;
+                }
+                MigrationStatus status = newItem.getStatus();
+                if(status == MigrationStatus.UNSIGNED) {
+                    tableRow.setContextMenu(null);
+                } else if(status == MigrationStatus.SIGNED) {
+                    contextMenu.getItems().addAll(viewItem, redoItem);
+                    tableRow.setContextMenu(contextMenu);
+                } else {
+                    contextMenu.getItems().add(viewItem);
+                    tableRow.setContextMenu(contextMenu);
+                }
+            });
+
+            // Also update context menu when status changes
+            tableRow.setOnMousePressed(e -> {
+                if(e.isSecondaryButtonDown() && !tableRow.isEmpty()) {
+                    MigrationRow row = tableRow.getItem();
+                    contextMenu.getItems().clear();
+                    if(row != null && row.getStatus() != MigrationStatus.UNSIGNED) {
+                        contextMenu.getItems().add(viewItem);
+                        if(row.getStatus() == MigrationStatus.SIGNED) {
+                            contextMenu.getItems().add(redoItem);
+                        }
+                        tableRow.setContextMenu(contextMenu);
+                    } else {
+                        tableRow.setContextMenu(null);
+                    }
+                }
+            });
+
+            return tableRow;
+        });
+
+        return table;
+    }
+
+    // === Phase switching ===
+
+    private void showSetupPhase() {
+        managePane.setVisible(false);
+        managePane.setManaged(false);
+        setupPane.setVisible(true);
+        setupPane.setManaged(true);
+    }
+
+    private void showManagePhase() {
+        setupPane.setVisible(false);
+        setupPane.setManaged(false);
+        managePane.setVisible(true);
+        managePane.setManaged(true);
+    }
+
+    private void clearMigration() {
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+                "Clear all PSBTs and go back to setup? This cannot be undone.", ButtonType.YES, ButtonType.NO);
+        confirm.initOwner(getDialogPane().getScene().getWindow());
+        Optional<ButtonType> result = confirm.showAndWait();
+        if(result.isPresent() && result.get() == ButtonType.YES) {
+            migrationRows.clear();
+            manageTable.getItems().clear();
+            saveMigrationState();
+            showSetupPhase();
+        }
+    }
+
+    // === Populate UTXOs ===
+
+    private void populateUtxos() {
+        Map<BlockTransactionHashIndex, WalletNode> spendableUtxos = sourceWallet.getSpendableUtxos();
+        List<UtxoRow> rows = new ArrayList<>();
+        for(Map.Entry<BlockTransactionHashIndex, WalletNode> entry : spendableUtxos.entrySet()) {
+            rows.add(new UtxoRow(entry.getKey(), entry.getValue(), 1.0));
+        }
+        setupTable.setItems(FXCollections.observableArrayList(rows));
+    }
+
+    private void assignDestinationAddresses() {
+        WalletDestination wd = destWalletCombo.getValue();
+        if(wd == null) {
+            return;
+        }
+        Wallet destWallet = wd.wallet();
+
+        WalletNode currentNode = null;
+        for(UtxoRow row : setupTable.getItems()) {
+            WalletNode freshNode = destWallet.getFreshNode(KeyPurpose.RECEIVE, currentNode);
+            row.setDestAddress(freshNode.getAddress().toString());
+            row.setDestWalletNode(freshNode);
+            currentNode = freshNode;
+        }
+        setupTable.refresh();
+    }
+
+    // === Fee logic ===
+
+    private void applyFixedFeeRate() {
+        try {
+            double rate = Double.parseDouble(feeRateField.getText());
+            if(rate > 0) {
+                for(UtxoRow row : setupTable.getItems()) {
+                    row.setFeeRate(rate);
+                }
+                updateSetupSummary();
+                setupTable.refresh();
+            }
+        } catch(NumberFormatException e) {
+            // ignore
+        }
+    }
+
+    private void applyRandomFeeRates() {
+        try {
+            double min = Double.parseDouble(minFeeField.getText());
+            double max = Double.parseDouble(maxFeeField.getText());
+            if(min > 0 && max >= min) {
+                Random random = new Random();
+                for(UtxoRow row : setupTable.getItems()) {
+                    double rate = min + (max - min) * random.nextDouble();
+                    rate = Math.round(rate * 10.0) / 10.0;
+                    row.setFeeRate(rate);
+                }
+                updateSetupSummary();
+                setupTable.refresh();
+            }
+        } catch(NumberFormatException e) {
+            // ignore
+        }
+    }
+
+    // === Button state ===
+
+    private void updateCreateButton(Button createButton) {
+        boolean hasDestination = destWalletCombo.getValue() != null;
+        boolean hasSelection = setupTable.getItems().stream().anyMatch(UtxoRow::isSelected);
+        createButton.setDisable(!hasDestination || !hasSelection);
+    }
+
+    private void updateSetupSummary() {
+        List<UtxoRow> selected = setupTable.getItems().stream().filter(UtxoRow::isSelected).toList();
+        if(selected.isEmpty()) {
+            setupSummaryLabel.setText("");
+            return;
+        }
+        long totalValue = selected.stream().mapToLong(r -> r.getUtxo().getValue()).sum();
+        long totalFees = selected.stream().mapToLong(r -> (long) Math.ceil(110 * r.getFeeRate())).sum();
+        setupSummaryLabel.setText(String.format("%d transactions | Total: %,d sats | Est. fees: ~%,d sats",
+                selected.size(), totalValue, totalFees));
+    }
+
+    // === Create PSBTs and switch to manage phase ===
+
+    private void createPsbtsAndShowManagePhase() {
+        WalletDestination wd = destWalletCombo.getValue();
+        if(wd == null) {
+            return;
+        }
+
+        List<UtxoRow> selected = setupTable.getItems().stream().filter(UtxoRow::isSelected).toList();
+        if(selected.isEmpty()) {
+            return;
+        }
+
+        migrationRows.clear();
+        int errors = 0;
+        for(UtxoRow row : selected) {
+            try {
+                PSBT psbt = createSingleUtxoPsbt(row);
+                long fee = (long) Math.ceil(estimateTxVsize(row) * row.getFeeRate());
+                MigrationRow mr = new MigrationRow(
+                        row.getUtxoId(), row.getUtxo().getValue(),
+                        row.getUtxo().getLabel() != null ? row.getUtxo().getLabel() : "",
+                        row.getDestAddress(), row.getFeeRate(), fee, psbt
+                );
+                migrationRows.add(mr);
+            } catch(Exception e) {
+                errors++;
+                log.error("Failed to create PSBT for " + row.getUtxoId(), e);
+            }
+        }
+
+        if(errors > 0) {
+            AppServices.showErrorDialog("PSBT Creation", errors + " PSBT(s) failed to create. " + migrationRows.size() + " succeeded.");
+        }
+
+        if(migrationRows.isEmpty()) {
+            return;
+        }
+
+        manageTable.setItems(FXCollections.observableArrayList(migrationRows));
+        updateManageSummary();
+        showManagePhase();
+        saveMigrationState();
+    }
+
+    private double estimateTxVsize(UtxoRow row) {
+        BlockTransaction prevBlockTx = sourceWallet.getWalletTransaction(row.getUtxo().getHash());
+        TransactionOutput prevTxOut = prevBlockTx.getTransaction().getOutputs().get((int) row.getUtxo().getIndex());
+
+        Transaction sizeTx = new Transaction();
+        sizeTx.setVersion(2);
+        Wallet.addDummySpendingInput(sizeTx, row.getSourceNode(), prevTxOut);
+        sizeTx.addOutput(row.getUtxo().getValue(), row.getDestWalletNode().getAddress());
+        return sizeTx.getVirtualSize();
+    }
+
+    private PSBT createSingleUtxoPsbt(UtxoRow row) {
+        BlockTransactionHashIndex utxo = row.getUtxo();
+        WalletNode sourceNode = row.getSourceNode();
+        Address destAddress = row.getDestWalletNode().getAddress();
+        double feeRate = row.getFeeRate();
+
+        BlockTransaction prevBlockTx = sourceWallet.getWalletTransaction(utxo.getHash());
+        TransactionOutput prevTxOut = prevBlockTx.getTransaction().getOutputs().get((int) utxo.getIndex());
+
+        // Size estimation
+        Transaction sizeTx = new Transaction();
+        sizeTx.setVersion(2);
+        Wallet.addDummySpendingInput(sizeTx, sourceNode, prevTxOut);
+        sizeTx.addOutput(utxo.getValue(), destAddress);
+        long fee = (long) Math.ceil(sizeTx.getVirtualSize() * feeRate);
+        long outputValue = utxo.getValue() - fee;
+
+        if(outputValue <= 0) {
+            throw new IllegalArgumentException("Fee (" + fee + " sats) exceeds UTXO value (" + utxo.getValue() + " sats)");
+        }
+
+        TransactionOutput dustCheck = new TransactionOutput(sizeTx, outputValue, destAddress.getOutputScript());
+        long dustThreshold = sourceWallet.getDustThreshold(dustCheck, feeRate);
+        if(outputValue < dustThreshold) {
+            throw new IllegalArgumentException("Output " + outputValue + " sats below dust threshold " + dustThreshold + " sats");
+        }
+
+        // Build final tx
+        Transaction finalTx = new Transaction();
+        finalTx.setVersion(2);
+        TransactionInput finalInput = Wallet.addDummySpendingInput(finalTx, sourceNode, prevTxOut);
+        finalInput.setSequenceNumber(TransactionInput.SEQUENCE_RBF_ENABLED);
+        TransactionOutput txOutput = finalTx.addOutput(outputValue, destAddress);
+
+        Map<BlockTransactionHashIndex, WalletNode> selectedUtxos = new LinkedHashMap<>();
+        selectedUtxos.put(utxo, sourceNode);
+
+        Payment payment = new Payment(destAddress, utxo.getLabel(), outputValue, false);
+        List<WalletTransaction.Output> outputs = List.of(new WalletTransaction.PaymentOutput(txOutput, payment));
+
+        Map<Sha256Hash, BlockTransaction> inputTransactions = new LinkedHashMap<>();
+        inputTransactions.put(utxo.getHash(), prevBlockTx);
+
+        WalletTransaction walletTransaction = new WalletTransaction(
+                sourceWallet, finalTx,
+                List.of(new PresetUtxoSelector(selectedUtxos.keySet())),
+                List.of(selectedUtxos),
+                List.of(payment), outputs,
+                Collections.emptyMap(), fee, inputTransactions
+        );
+
+        return walletTransaction.createPSBT();
+    }
+
+    // === Manage phase actions ===
+
+    private void refreshMigrationStatuses() {
+        boolean changed = false;
+        for(MigrationRow row : migrationRows) {
+            if(row.getStatus() == MigrationStatus.UNSIGNED && row.psbt.isSigned()) {
+                row.setStatus(MigrationStatus.SIGNED);
+                changed = true;
+            }
+        }
+        manageTable.refresh();
+        updateManageSummary();
+        if(changed) {
+            saveMigrationState();
+        }
+    }
+
+    private void updateManageSummary() {
+        long total = migrationRows.size();
+        long unsigned = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.UNSIGNED).count();
+        long signed = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.SIGNED).count();
+        long broadcast = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.BROADCAST).count();
+        long failed = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.FAILED).count();
+        manageSummaryLabel.setText(String.format("%d total | %d unsigned | %d signed | %d broadcast%s",
+                total, unsigned, signed, broadcast, failed > 0 ? " | " + failed + " failed" : ""));
+    }
+
+    private void openPsbtForSigning(MigrationRow row) {
+        // Opens the PSBT in a Sparrow transaction tab where the user can verify, sign (USB/QR/software), and return
+        EventManager.get().post(new ViewPSBTEvent(ownerWindow, "Migration: " + row.utxoId, null, row.psbt));
+        // Minimize dialog so user can focus on signing; auto-restores after PSBTFinalizedEvent
+        Window dialogWindow = getDialogPane().getScene().getWindow();
+        if(dialogWindow instanceof Stage stage) {
+            stage.setIconified(true);
+        }
+    }
+
+    private void showTransactionDetails(MigrationRow row) {
+        // Open as a read-only Transaction view (no PSBT = no broadcast button)
+        try {
+            Transaction tx = row.psbt.extractTransaction();
+            EventManager.get().post(new ViewTransactionEvent(ownerWindow, tx));
+        } catch(Exception e) {
+            log.error("Failed to extract transaction", e);
+            EventManager.get().post(new ViewTransactionEvent(ownerWindow, row.psbt.getTransaction()));
+        }
+        // Minimize dialog so user can focus on the transaction view
+        Window dialogWindow = getDialogPane().getScene().getWindow();
+        if(dialogWindow instanceof Stage stage) {
+            stage.setIconified(true);
+        }
+    }
+
+    @Subscribe
+    public void psbtFinalized(PSBTFinalizedEvent event) {
+        // Check if this finalized PSBT belongs to one of our migration rows
+        Sha256Hash eventTxId = event.getPsbt().getTransaction().getTxId();
+        for(MigrationRow row : migrationRows) {
+            if(row.psbt.getTransaction().getTxId().equals(eventTxId)) {
+                Platform.runLater(() -> {
+                    row.setStatus(MigrationStatus.SIGNED);
+                    manageTable.refresh();
+                    updateManageSummary();
+                    saveMigrationState();
+
+                    // Close the PSBT tab in the main window
+                    closeMigrationTab(eventTxId);
+
+                    // Restore and bring dialog to front
+                    Window dialogWindow = getDialogPane().getScene().getWindow();
+                    if(dialogWindow instanceof Stage stage) {
+                        stage.setIconified(false);
+                        stage.toFront();
+                    }
+                });
+                break;
+            }
+        }
+    }
+
+    private void closeMigrationTab(Sha256Hash txId) {
+        if(ownerWindow == null || ownerWindow.getScene() == null) {
+            return;
+        }
+        // Find the main TabPane by fx:id and close the matching transaction tab
+        javafx.scene.Node node = ownerWindow.getScene().getRoot().lookup("#tabs");
+        if(node instanceof TabPane tabPane) {
+            tabPane.getTabs().removeIf(tab -> {
+                if(tab.getUserData() instanceof TransactionTabData ttd) {
+                    return ttd.getTransaction().getTxId().equals(txId);
+                }
+                return false;
+            });
+        }
+    }
+
+    private void broadcastTransaction(MigrationRow row) {
+        if(!row.psbt.isSigned()) {
+            AppServices.showErrorDialog("Not Signed", "This transaction has not been signed yet. Open it to sign first.");
+            return;
+        }
+
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+                "Broadcast transaction for " + row.utxoId + "?\nThis cannot be undone.", ButtonType.YES, ButtonType.NO);
+        confirm.initOwner(getDialogPane().getScene().getWindow());
+        Optional<ButtonType> result = confirm.showAndWait();
+        if(result.isEmpty() || result.get() != ButtonType.YES) {
+            return;
+        }
+
+        try {
+            Transaction finalTx = row.psbt.extractTransaction();
+            ElectrumServer.BroadcastTransactionService broadcastService = new ElectrumServer.BroadcastTransactionService(finalTx, row.fee);
+            broadcastService.setOnSucceeded(event -> {
+                row.setStatus(MigrationStatus.BROADCAST);
+                Platform.runLater(() -> {
+                    manageTable.refresh();
+                    updateManageSummary();
+                    saveMigrationState();
+                    AppServices.showErrorDialog("Broadcast Successful", "Transaction " + row.utxoId + " has been broadcast.");
+                });
+            });
+            broadcastService.setOnFailed(event -> {
+                row.setStatus(MigrationStatus.FAILED);
+                Platform.runLater(() -> {
+                    manageTable.refresh();
+                    updateManageSummary();
+                    saveMigrationState();
+                    AppServices.showErrorDialog("Broadcast Failed", event.getSource().getException().getMessage());
+                });
+            });
+            broadcastService.start();
+        } catch(Exception e) {
+            row.setStatus(MigrationStatus.FAILED);
+            manageTable.refresh();
+            updateManageSummary();
+            AppServices.showErrorDialog("Broadcast Failed", e.getMessage());
+        }
+    }
+
+    private void exportAllPsbts() {
+        List<MigrationRow> toExport = migrationRows.stream()
+                .filter(r -> r.getStatus() == MigrationStatus.UNSIGNED || r.getStatus() == MigrationStatus.SIGNED)
+                .toList();
+        if(toExport.isEmpty()) {
+            AppServices.showErrorDialog("Nothing to export", "No PSBTs to export.");
+            return;
+        }
+
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Export All PSBTs");
+        fileChooser.setInitialFileName("migration_psbts.json");
+        fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("JSON file", "*.json"));
+        File file = fileChooser.showSaveDialog(getDialogPane().getScene().getWindow());
+        if(file != null) {
+            JsonArray psbtsArray = new JsonArray();
+            for(int i = 0; i < migrationRows.size(); i++) {
+                MigrationRow row = migrationRows.get(i);
+                if(row.getStatus() == MigrationStatus.UNSIGNED || row.getStatus() == MigrationStatus.SIGNED) {
+                    JsonObject obj = new JsonObject();
+                    obj.addProperty("utxoId", row.utxoId);
+                    obj.addProperty("status", row.getStatus().name());
+                    obj.addProperty("psbt", Base64.getEncoder().encodeToString(row.psbt.serialize()));
+                    psbtsArray.add(obj);
+                }
+            }
+            try(Writer writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
+                new GsonBuilder().setPrettyPrinting().create().toJson(psbtsArray, writer);
+            } catch(IOException e) {
+                log.error("Failed to export PSBTs", e);
+                AppServices.showErrorDialog("Export Failed", e.getMessage());
+                return;
+            }
+            log.info("Exported {} PSBT(s) to {}", psbtsArray.size(), file.getName());
+        }
+    }
+
+    private void importSignedPsbts() {
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Import PSBTs");
+        fileChooser.getExtensionFilters().addAll(
+                new FileChooser.ExtensionFilter("All supported", "*.json", "*.zip", "*.psbt"),
+                new FileChooser.ExtensionFilter("JSON file", "*.json"),
+                new FileChooser.ExtensionFilter("ZIP archive", "*.zip"),
+                new FileChooser.ExtensionFilter("PSBT files", "*.psbt")
+        );
+        List<File> files = fileChooser.showOpenMultipleDialog(getDialogPane().getScene().getWindow());
+        if(files != null && !files.isEmpty()) {
+            List<byte[]> psbtDataList = readPsbtFiles(files);
+
+            if(migrationRows.isEmpty()) {
+                // Import from Setup phase: load PSBTs as new migration rows
+                int loaded = 0;
+                for(byte[] data : psbtDataList) {
+                    try {
+                        PSBT psbt = new PSBT(data);
+                        Transaction tx = psbt.getTransaction();
+                        String txId = tx.getTxId().toString();
+                        String utxoId = tx.getInputs().getFirst().getOutpoint().getHash().toString().substring(0, 8)
+                                + "...:" + tx.getInputs().getFirst().getOutpoint().getIndex();
+                        long value = 0;
+                        long fee = 0;
+                        String destAddress = "";
+                        if(!tx.getOutputs().isEmpty()) {
+                            TransactionOutput out = tx.getOutputs().getFirst();
+                            value = out.getValue();
+                            destAddress = out.getScript().getToAddress().toString();
+                        }
+                        // Estimate original UTXO value and fee from tx
+                        if(psbt.getPsbtInputs() != null && !psbt.getPsbtInputs().isEmpty()) {
+                            var psbtInput = psbt.getPsbtInputs().getFirst();
+                            if(psbtInput.getWitnessUtxo() != null) {
+                                long inputValue = psbtInput.getWitnessUtxo().getValue();
+                                fee = inputValue - value;
+                                value = inputValue;
+                            } else if(psbtInput.getNonWitnessUtxo() != null) {
+                                long inputIdx = tx.getInputs().getFirst().getOutpoint().getIndex();
+                                long inputValue = psbtInput.getNonWitnessUtxo().getOutputs().get((int) inputIdx).getValue();
+                                fee = inputValue - tx.getOutputs().getFirst().getValue();
+                                value = inputValue;
+                            }
+                        }
+                        double feeRate = fee > 0 ? (double) fee / tx.getVirtualSize() : 0;
+
+                        MigrationRow mr = new MigrationRow(utxoId, value, "", destAddress, feeRate, fee, psbt);
+                        if(psbt.isSigned()) {
+                            mr.setStatus(MigrationStatus.SIGNED);
+                        }
+                        migrationRows.add(mr);
+                        loaded++;
+                    } catch(Exception e) {
+                        log.error("Failed to parse PSBT for import", e);
+                    }
+                }
+
+                if(loaded > 0) {
+                    manageTable.setItems(FXCollections.observableArrayList(migrationRows));
+                    updateManageSummary();
+                    showManagePhase();
+                    saveMigrationState();
+                    log.info("Imported {} PSBT(s)", loaded);
+                }
+            } else {
+                // Import from Manage phase: combine signed PSBTs with existing rows
+                int combined = 0;
+                for(byte[] data : psbtDataList) {
+                    try {
+                        PSBT signedPsbt = new PSBT(data);
+                        for(MigrationRow row : migrationRows) {
+                            if(row.getStatus() == MigrationStatus.UNSIGNED
+                                    && row.psbt.getTransaction().getTxId().equals(signedPsbt.getTransaction().getTxId())) {
+                                row.psbt.combine(signedPsbt);
+                                if(row.psbt.isSigned()) {
+                                    row.setStatus(MigrationStatus.SIGNED);
+                                    combined++;
+                                }
+                                break;
+                            }
+                        }
+                    } catch(Exception e) {
+                        log.error("Failed to parse PSBT", e);
+                    }
+                }
+
+                manageTable.refresh();
+                updateManageSummary();
+                if(combined > 0) {
+                    saveMigrationState();
+                    log.info("Imported {} signed PSBT(s)", combined);
+                }
+            }
+        }
+    }
+
+    private List<byte[]> readPsbtFiles(List<File> files) {
+        List<byte[]> psbtDataList = new ArrayList<>();
+        for(File file : files) {
+            try {
+                String name = file.getName().toLowerCase();
+                if(name.endsWith(".json")) {
+                    String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+                    JsonArray array = JsonParser.parseString(content).getAsJsonArray();
+                    for(JsonElement el : array) {
+                        String b64 = el.getAsJsonObject().get("psbt").getAsString();
+                        psbtDataList.add(Base64.getDecoder().decode(b64));
+                    }
+                } else if(name.endsWith(".zip")) {
+                    try(ZipInputStream zis = new ZipInputStream(new java.io.FileInputStream(file))) {
+                        ZipEntry entry;
+                        while((entry = zis.getNextEntry()) != null) {
+                            if(!entry.isDirectory() && entry.getName().toLowerCase().endsWith(".psbt")) {
+                                psbtDataList.add(zis.readAllBytes());
+                            }
+                            zis.closeEntry();
+                        }
+                    }
+                } else {
+                    psbtDataList.add(Files.readAllBytes(file.toPath()));
+                }
+            } catch(IOException e) {
+                log.error("Failed to read file " + file.getName(), e);
+            }
+        }
+        return psbtDataList;
+    }
+
+    private void broadcastAllSigned() {
+        List<MigrationRow> signed = migrationRows.stream()
+                .filter(r -> r.getStatus() == MigrationStatus.SIGNED)
+                .toList();
+        if(signed.isEmpty()) {
+            AppServices.showErrorDialog("Nothing to broadcast", "No signed transactions ready to broadcast.");
+            return;
+        }
+
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+                "Broadcast " + signed.size() + " signed transaction(s)?\nThis cannot be undone.", ButtonType.YES, ButtonType.NO);
+        confirm.initOwner(getDialogPane().getScene().getWindow());
+        Optional<ButtonType> result = confirm.showAndWait();
+        if(result.isPresent() && result.get() == ButtonType.YES) {
+            final int[] success = {0};
+            final int[] failed = {0};
+            final int total = signed.size();
+            for(MigrationRow row : signed) {
+                broadcastTransactionSilent(row, () -> {
+                    if(row.getStatus() == MigrationStatus.BROADCAST) {
+                        success[0]++;
+                    } else {
+                        failed[0]++;
+                    }
+                    if(success[0] + failed[0] == total) {
+                        log.info("Broadcast complete: {} of {} succeeded, {} failed", success[0], total, failed[0]);
+                    }
+                });
+            }
+        }
+    }
+
+    private void broadcastTransactionSilent(MigrationRow row, Runnable onDone) {
+        if(!row.psbt.isSigned()) {
+            row.setStatus(MigrationStatus.FAILED);
+            Platform.runLater(() -> {
+                manageTable.refresh();
+                updateManageSummary();
+                saveMigrationState();
+            });
+            if(onDone != null) onDone.run();
+            return;
+        }
+
+        try {
+            Transaction finalTx = row.psbt.extractTransaction();
+            ElectrumServer.BroadcastTransactionService broadcastService = new ElectrumServer.BroadcastTransactionService(finalTx, row.fee);
+            broadcastService.setOnSucceeded(event -> {
+                row.setStatus(MigrationStatus.BROADCAST);
+                Platform.runLater(() -> {
+                    manageTable.refresh();
+                    updateManageSummary();
+                    saveMigrationState();
+                });
+                if(onDone != null) onDone.run();
+            });
+            broadcastService.setOnFailed(event -> {
+                row.setStatus(MigrationStatus.FAILED);
+                Platform.runLater(() -> {
+                    manageTable.refresh();
+                    updateManageSummary();
+                    saveMigrationState();
+                });
+                if(onDone != null) onDone.run();
+            });
+            broadcastService.start();
+        } catch(Exception e) {
+            row.setStatus(MigrationStatus.FAILED);
+            Platform.runLater(() -> {
+                manageTable.refresh();
+                updateManageSummary();
+                saveMigrationState();
+            });
+            if(onDone != null) onDone.run();
+        }
+    }
+
+    // === Persistence ===
+
+    private File getMigrationFile() {
+        File migrationsDir = new File(Storage.getSparrowDir(), "migrations");
+        if(!migrationsDir.exists()) {
+            migrationsDir.mkdirs();
+        }
+        String walletId = sourceWallet.getFullName().replaceAll("[^a-zA-Z0-9_-]", "_");
+        return new File(migrationsDir, walletId + ".json");
+    }
+
+    private void saveMigrationState() {
+        if(migrationRows.isEmpty()) {
+            // Remove file if no active migration
+            File file = getMigrationFile();
+            if(file.exists()) {
+                file.delete();
+            }
+            return;
+        }
+
+        // Don't save if all are broadcast (migration complete)
+        boolean allDone = migrationRows.stream().allMatch(r -> r.getStatus() == MigrationStatus.BROADCAST);
+        if(allDone) {
+            File file = getMigrationFile();
+            if(file.exists()) {
+                file.delete();
+            }
+            return;
+        }
+
+        try {
+            JsonObject root = new JsonObject();
+            root.addProperty("sourceWallet", sourceWallet.getFullName());
+            root.addProperty("savedAt", System.currentTimeMillis());
+
+            JsonArray rows = new JsonArray();
+            for(MigrationRow row : migrationRows) {
+                JsonObject obj = new JsonObject();
+                obj.addProperty("utxoId", row.utxoId);
+                obj.addProperty("value", row.value);
+                obj.addProperty("label", row.label);
+                obj.addProperty("destAddress", row.destAddress);
+                obj.addProperty("feeRate", row.feeRate);
+                obj.addProperty("fee", row.fee);
+                obj.addProperty("status", row.getStatus().name());
+                obj.addProperty("psbt", Base64.getEncoder().encodeToString(row.psbt.serialize()));
+                rows.add(obj);
+            }
+            root.add("migrations", rows);
+
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            Files.writeString(getMigrationFile().toPath(), gson.toJson(root), StandardCharsets.UTF_8);
+            log.info("Saved migration state: " + migrationRows.size() + " rows");
+        } catch(Exception e) {
+            log.error("Failed to save migration state", e);
+        }
+    }
+
+    private void loadMigrationState() {
+        File file = getMigrationFile();
+        if(!file.exists()) {
+            return;
+        }
+
+        try {
+            String json = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+            JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+            JsonArray rows = root.getAsJsonArray("migrations");
+
+            migrationRows.clear();
+            for(JsonElement el : rows) {
+                JsonObject obj = el.getAsJsonObject();
+                String utxoId = obj.get("utxoId").getAsString();
+                long value = obj.get("value").getAsLong();
+                String label = obj.has("label") ? obj.get("label").getAsString() : "";
+                String destAddress = obj.get("destAddress").getAsString();
+                double feeRate = obj.get("feeRate").getAsDouble();
+                long fee = obj.get("fee").getAsLong();
+                String statusStr = obj.get("status").getAsString();
+                byte[] psbtBytes = Base64.getDecoder().decode(obj.get("psbt").getAsString());
+
+                PSBT psbt = new PSBT(psbtBytes);
+                MigrationRow mr = new MigrationRow(utxoId, value, label, destAddress, feeRate, fee, psbt);
+                mr.setStatus(MigrationStatus.valueOf(statusStr));
+                migrationRows.add(mr);
+            }
+
+            if(!migrationRows.isEmpty()) {
+                manageTable.setItems(FXCollections.observableArrayList(migrationRows));
+                updateManageSummary();
+                showManagePhase();
+                log.info("Restored migration state: " + migrationRows.size() + " rows");
+            }
+        } catch(Exception e) {
+            log.error("Failed to load migration state", e);
+        }
+    }
+
+    // === Inner types ===
+
+    public enum MigrationStatus {
+        UNSIGNED("Unsigned"),
+        SIGNED("Signed"),
+        BROADCAST("Broadcast"),
+        FAILED("Failed");
+
+        private final String label;
+
+        MigrationStatus(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+    }
+
+    public record WalletDestination(Wallet wallet, String displayName, boolean sameWallet) {
+    }
+
+    public static class MigrationRow {
+        final String utxoId;
+        final long value;
+        final String label;
+        final String destAddress;
+        double feeRate;
+        final long fee;
+        final PSBT psbt;
+        private final SimpleObjectProperty<MigrationStatus> status = new SimpleObjectProperty<>(MigrationStatus.UNSIGNED);
+
+        public MigrationRow(String utxoId, long value, String label, String destAddress, double feeRate, long fee, PSBT psbt) {
+            this.utxoId = utxoId;
+            this.value = value;
+            this.label = label;
+            this.destAddress = destAddress;
+            this.feeRate = feeRate;
+            this.fee = fee;
+            this.psbt = psbt;
+        }
+
+        public MigrationStatus getStatus() { return status.get(); }
+        public void setStatus(MigrationStatus s) { status.set(s); }
+        public SimpleObjectProperty<MigrationStatus> statusProperty() { return status; }
+    }
+
+    // === Table cells ===
+
+    private class StatusCell extends TableCell<MigrationRow, MigrationStatus> {
+        @Override
+        protected void updateItem(MigrationStatus item, boolean empty) {
+            super.updateItem(item, empty);
+            setText(null);
+            setGraphic(null);
+            setStyle("");
+            if(empty || item == null) {
+                return;
+            }
+            switch(item) {
+                case UNSIGNED -> {
+                    setText("Unsigned");
+                    setStyle(ALIGN_CENTER + " -fx-text-fill: white;");
+                }
+                case SIGNED -> {
+                    setText("Signed");
+                    setStyle(ALIGN_CENTER + " -fx-text-fill: white; -fx-font-weight: bold;");
+                }
+                case BROADCAST -> {
+                    setText("Broadcast");
+                    setStyle(ALIGN_CENTER + " -fx-text-fill: #1e88cf; -fx-font-weight: bold;");
+                }
+                case FAILED -> {
+                    setText("Failed");
+                    setStyle(ALIGN_CENTER + " -fx-text-fill: #cc0000;");
+                }
+            }
+        }
+    }
+
+    private static final double ACTION_BTN_WIDTH = 85;
+
+    private class ActionCell extends TableCell<MigrationRow, Void> {
+        private final HBox buttons = new HBox(5);
+
+        public ActionCell() {
+            buttons.setAlignment(Pos.CENTER);
+        }
+
+        @Override
+        protected void updateItem(Void item, boolean empty) {
+            super.updateItem(item, empty);
+            if(empty || getTableRow() == null || getTableRow().getItem() == null) {
+                setGraphic(null);
+                return;
+            }
+
+            MigrationRow row = getTableRow().getItem();
+            buttons.getChildren().clear();
+
+            switch(row.getStatus()) {
+                case UNSIGNED -> {
+                    Button openBtn = new Button("Sign Tx");
+                    openBtn.setPrefWidth(ACTION_BTN_WIDTH);
+                    openBtn.setOnAction(e -> openPsbtForSigning(row));
+                    buttons.getChildren().add(openBtn);
+                }
+                case SIGNED -> {
+                    Button broadcastBtn = new Button("Broadcast");
+                    broadcastBtn.setPrefWidth(ACTION_BTN_WIDTH);
+                    broadcastBtn.setDefaultButton(true);
+                    broadcastBtn.setOnAction(e -> broadcastTransaction(row));
+                    buttons.getChildren().add(broadcastBtn);
+                }
+                case BROADCAST -> {
+                    Label doneLabel = new Label("Done");
+                    doneLabel.setStyle("-fx-text-fill: #1e88cf; -fx-font-weight: bold;");
+                    doneLabel.setPrefWidth(ACTION_BTN_WIDTH);
+                    doneLabel.setAlignment(Pos.CENTER);
+                    buttons.getChildren().add(doneLabel);
+                }
+                case FAILED -> {
+                    Button retryBtn = new Button("Retry");
+                    retryBtn.setPrefWidth(ACTION_BTN_WIDTH);
+                    retryBtn.setOnAction(e -> {
+                        row.setStatus(MigrationStatus.SIGNED);
+                        manageTable.refresh();
+                    });
+                    buttons.getChildren().add(retryBtn);
+                }
+            }
+
+            setGraphic(buttons);
+        }
+    }
+
+    // === Setup table row ===
+
+    public static class UtxoRow {
+        private final BlockTransactionHashIndex utxo;
+        private final WalletNode sourceNode;
+        private final SimpleBooleanProperty selected = new SimpleBooleanProperty(true);
+        private final SimpleStringProperty destAddress = new SimpleStringProperty("");
+        private final SimpleDoubleProperty feeRate;
+        private WalletNode destWalletNode;
+
+        public UtxoRow(BlockTransactionHashIndex utxo, WalletNode sourceNode, double initialFeeRate) {
+            this.utxo = utxo;
+            this.sourceNode = sourceNode;
+            this.feeRate = new SimpleDoubleProperty(initialFeeRate);
+        }
+
+        public BlockTransactionHashIndex getUtxo() { return utxo; }
+        public WalletNode getSourceNode() { return sourceNode; }
+        public boolean isSelected() { return selected.get(); }
+        public SimpleBooleanProperty selectedProperty() { return selected; }
+
+        public String getUtxoId() {
+            return utxo.getHash().toString().substring(0, 8) + "...:" + utxo.getIndex();
+        }
+
+        public SimpleStringProperty utxoIdProperty() { return new SimpleStringProperty(getUtxoId()); }
+        public SimpleStringProperty valueDisplayProperty() { return new SimpleStringProperty(String.format("%,d", utxo.getValue())); }
+        public SimpleStringProperty labelProperty() { return new SimpleStringProperty(utxo.getLabel() != null ? utxo.getLabel() : ""); }
+
+        public String getDestAddress() { return destAddress.get(); }
+        public void setDestAddress(String address) { destAddress.set(address); }
+        public SimpleStringProperty destAddressProperty() { return destAddress; }
+
+        public WalletNode getDestWalletNode() { return destWalletNode; }
+        public void setDestWalletNode(WalletNode node) { this.destWalletNode = node; }
+
+        public double getFeeRate() { return feeRate.get(); }
+        public void setFeeRate(double rate) { feeRate.set(rate); }
+        public SimpleStringProperty feeRateDisplayProperty() { return new SimpleStringProperty(String.format("%.1f", feeRate.get())); }
+    }
+
+    // Editable cell for fee column
+    private static class EditableTextFieldCell<S> extends TableCell<S, String> {
+        private TextField textField;
+
+        @Override
+        public void startEdit() {
+            super.startEdit();
+            if(textField == null) {
+                textField = new TextField();
+                textField.setStyle(ALIGN_RIGHT);
+                textField.setOnAction(e -> commitEdit(textField.getText()));
+                textField.focusedProperty().addListener((obs, wasFocused, isNow) -> {
+                    if(!isNow) {
+                        commitEdit(textField.getText());
+                    }
+                });
+            }
+            textField.setText(getItem());
+            setGraphic(textField);
+            setText(null);
+            textField.selectAll();
+            textField.requestFocus();
+        }
+
+        @Override
+        public void cancelEdit() {
+            super.cancelEdit();
+            setText(getItem());
+            setGraphic(null);
+        }
+
+        @Override
+        protected void updateItem(String item, boolean empty) {
+            super.updateItem(item, empty);
+            if(empty || item == null) {
+                setText(null);
+                setGraphic(null);
+            } else if(isEditing()) {
+                if(textField != null) {
+                    textField.setText(item);
+                }
+                setText(null);
+                setGraphic(textField);
+            } else {
+                setText(item);
+                setGraphic(null);
+            }
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -9,6 +9,8 @@ import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.EventManager;
 import com.sparrowwallet.sparrow.TabData;
 import com.sparrowwallet.sparrow.TransactionTabData;
+import com.sparrowwallet.sparrow.WalletTabData;
+import com.sparrowwallet.sparrow.event.NewBlockEvent;
 import com.sparrowwallet.sparrow.event.PSBTFinalizedEvent;
 import com.sparrowwallet.sparrow.event.ViewPSBTEvent;
 import com.sparrowwallet.sparrow.event.ViewTransactionEvent;
@@ -167,12 +169,10 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         deselectAllBtn.setOnAction(e -> setupTable.getItems().forEach(r -> r.selectedProperty().set(false)));
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
-        Button importPsbtsBtn = new Button("Import PSBTs");
-        importPsbtsBtn.setOnAction(e -> importSignedPsbts());
         Button createPsbtsBtn = new Button("Create PSBTs");
         createPsbtsBtn.setStyle("-fx-font-weight: bold;");
         createPsbtsBtn.setDisable(true);
-        selectButtons.getChildren().addAll(selectAllBtn, deselectAllBtn, spacer, importPsbtsBtn, createPsbtsBtn);
+        selectButtons.getChildren().addAll(selectAllBtn, deselectAllBtn, spacer, createPsbtsBtn);
 
         setupSummaryLabel = new Label("");
         setupSummaryLabel.setStyle("-fx-font-weight: bold;");
@@ -195,16 +195,12 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         manageButtons.setAlignment(Pos.CENTER_LEFT);
         Button clearBtn = new Button("Clear");
         clearBtn.setOnAction(e -> clearMigration());
-        Button exportAllBtn = new Button("Export All PSBTs");
-        exportAllBtn.setOnAction(e -> exportAllPsbts());
         Region spacer2 = new Region();
         HBox.setHgrow(spacer2, Priority.ALWAYS);
         Button signAllBtn = new Button("Sign All");
+        signAllBtn.setStyle("-fx-font-weight: bold;");
         signAllBtn.setOnAction(e -> signAllUnsigned());
-        Button broadcastAllBtn = new Button("Broadcast All Signed");
-        broadcastAllBtn.setStyle("-fx-font-weight: bold;");
-        broadcastAllBtn.setOnAction(e -> broadcastAllSigned());
-        manageButtons.getChildren().addAll(clearBtn, exportAllBtn, spacer2, signAllBtn, broadcastAllBtn);
+        manageButtons.getChildren().addAll(clearBtn, spacer2, signAllBtn);
 
         managePane.getChildren().addAll(manageTable, manageButtons, manageSummaryLabel);
         VBox.setVgrow(manageTable, Priority.ALWAYS);
@@ -447,12 +443,25 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         statusCol.setCellFactory(col -> new StatusCell());
         statusCol.setStyle(ALIGN_CENTER);
 
-        TableColumn<MigrationRow, Void> actionCol = new TableColumn<>("Action");
+        TableColumn<MigrationRow, String> targetBlockCol = new TableColumn<>("Target Block");
+        targetBlockCol.setCellValueFactory(cd -> {
+            MigrationRow row = cd.getValue();
+            if(row.targetBlock <= 0) {
+                return new SimpleStringProperty("");
+            }
+            if(row.getStatus() == MigrationStatus.BROADCAST) {
+                return new SimpleStringProperty(String.format("%,d", row.targetBlock));
+            }
+            return new SimpleStringProperty(String.format("%,d", row.targetBlock));
+        });
+        targetBlockCol.setStyle(ALIGN_CENTER);
+
+        TableColumn<MigrationRow, Void> actionCol = new TableColumn<>("Status");
         actionCol.setCellFactory(col -> new ActionCell());
         actionCol.setStyle(ALIGN_CENTER);
         actionCol.setMinWidth(ACTION_BTN_WIDTH + 20);
 
-        table.getColumns().addAll(utxoCol, destCol, valueCol, feeCol, labelCol, statusCol, actionCol);
+        table.getColumns().addAll(utxoCol, destCol, valueCol, feeCol, labelCol, statusCol, targetBlockCol, actionCol);
 
         // Double-click on row to view transaction details
         table.setRowFactory(tv -> {
@@ -505,7 +514,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                             contextMenu.getItems().add(redoItem);
                         }
                     }
-                    if(isDestWalletHardware(row)) {
+                    if(isDestWalletHardware(row) && row.getStatus() == MigrationStatus.UNSIGNED) {
                         contextMenu.getItems().add(verifyItem);
                     }
                     if(!contextMenu.getItems().isEmpty()) {
@@ -650,9 +659,18 @@ public class MigrateUtxosDialog extends Dialog<Void> {
 
         migrationRows.clear();
         int errors = 0;
+        Integer currentHeight = AppServices.getCurrentBlockHeight();
+        if(currentHeight == null) {
+            AppServices.showErrorDialog("Not connected", "A server connection is required to set transaction locktimes.");
+            return;
+        }
+        Random random = new Random();
+        long nextTargetBlock = currentHeight + 5;
+
         for(UtxoRow row : selected) {
             try {
-                PSBT psbt = createSingleUtxoPsbt(row);
+                long targetBlock = nextTargetBlock;
+                PSBT psbt = createSingleUtxoPsbt(row, targetBlock);
                 long fee = (long) Math.ceil(estimateTxVsize(row) * row.getFeeRate());
                 MigrationRow mr = new MigrationRow(
                         row.getUtxoId(), row.getUtxo().getValue(),
@@ -661,7 +679,9 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                 );
                 mr.destWallet = wd.wallet();
                 mr.destWalletNode = row.getDestWalletNode();
+                mr.targetBlock = targetBlock;
                 migrationRows.add(mr);
+                nextTargetBlock = targetBlock + 1 + random.nextInt(5);
             } catch(Exception e) {
                 errors++;
                 log.error("Failed to create PSBT for " + row.getUtxoId(), e);
@@ -693,7 +713,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         return sizeTx.getVirtualSize();
     }
 
-    private PSBT createSingleUtxoPsbt(UtxoRow row) {
+    private PSBT createSingleUtxoPsbt(UtxoRow row, long locktime) {
         BlockTransactionHashIndex utxo = row.getUtxo();
         WalletNode sourceNode = row.getSourceNode();
         Address destAddress = row.getDestWalletNode().getAddress();
@@ -723,6 +743,9 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         // Build final tx
         Transaction finalTx = new Transaction();
         finalTx.setVersion(2);
+        if(locktime > 0) {
+            finalTx.setLocktime(locktime);
+        }
         TransactionInput finalInput = Wallet.addDummySpendingInput(finalTx, sourceNode, prevTxOut);
         finalInput.setSequenceNumber(TransactionInput.SEQUENCE_RBF_ENABLED);
         TransactionOutput txOutput = finalTx.addOutput(outputValue, destAddress);
@@ -769,9 +792,12 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         long unsigned = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.UNSIGNED).count();
         long signed = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.SIGNED).count();
         long broadcast = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.BROADCAST).count();
+        long confirmed = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.CONFIRMED).count();
         long failed = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.FAILED).count();
-        manageSummaryLabel.setText(String.format("%d total | %d unsigned | %d signed | %d broadcast%s",
-                total, unsigned, signed, broadcast, failed > 0 ? " | " + failed + " failed" : ""));
+        Integer currentHeight = AppServices.getCurrentBlockHeight();
+        String blockInfo = currentHeight != null ? " | Block: " + String.format("%,d", currentHeight) : "";
+        manageSummaryLabel.setText(String.format("%d total | %d unsigned | %d signed | %d unconfirmed | %d confirmed%s%s",
+                total, unsigned, signed, broadcast, confirmed, failed > 0 ? " | " + failed + " failed" : "", blockInfo));
     }
 
     private void openPsbtForSigning(MigrationRow row) {
@@ -883,6 +909,112 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                     }
                 });
                 break;
+            }
+        }
+    }
+
+    @Subscribe
+    public void newBlock(NewBlockEvent event) {
+        int height = event.getHeight();
+        Platform.runLater(() -> {
+            checkConfirmations();
+            manageTable.refresh();
+        });
+
+        List<MigrationRow> ready = migrationRows.stream()
+                .filter(r -> r.getStatus() == MigrationStatus.SIGNED && r.targetBlock > 0 && height >= r.targetBlock)
+                .toList();
+        if(ready.isEmpty()) {
+            return;
+        }
+
+        // Stagger broadcasts with random delays when multiple are ready (e.g. after reopening Sparrow)
+        Random random = new Random();
+        long delayMs = 0;
+        for(MigrationRow row : ready) {
+            final long thisDelay = delayMs;
+            new Thread(() -> {
+                try {
+                    if(thisDelay > 0) {
+                        Thread.sleep(thisDelay);
+                    }
+                    Platform.runLater(() -> autoBroadcast(row));
+                } catch(InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }).start();
+            delayMs += 60_000L + random.nextInt(240_000); // 1-5 min between each
+        }
+    }
+
+    private void autoBroadcast(MigrationRow row) {
+        if(row.getStatus() != MigrationStatus.SIGNED || !row.psbt.isSigned()) {
+            return;
+        }
+        log.info("Auto-broadcasting migration tx {} at target block {}", row.utxoId, row.targetBlock);
+        broadcastTransactionSilent(row, () -> Platform.runLater(() -> {
+            manageTable.refresh();
+            updateManageSummary();
+            saveMigrationState();
+            checkMigrationComplete();
+        }));
+    }
+
+    private void checkConfirmations() {
+        boolean changed = false;
+        for(MigrationRow row : migrationRows) {
+            if(row.getStatus() == MigrationStatus.BROADCAST) {
+                Sha256Hash txId = row.psbt.getTransaction().getTxId();
+                BlockTransaction blockTx = sourceWallet.getTransactions().get(txId);
+                if(blockTx != null && blockTx.getHeight() > 0) {
+                    row.setStatus(MigrationStatus.CONFIRMED);
+                    changed = true;
+                }
+            }
+        }
+        if(changed) {
+            updateManageSummary();
+            saveMigrationState();
+            checkMigrationComplete();
+        }
+    }
+
+    private void checkMigrationComplete() {
+        boolean allConfirmed = migrationRows.stream().allMatch(r -> r.getStatus() == MigrationStatus.CONFIRMED);
+        if(allConfirmed) {
+            // Find the destination wallet from the first row
+            Wallet destWallet = migrationRows.stream()
+                    .filter(r -> r.destWallet != null)
+                    .map(r -> r.destWallet)
+                    .findFirst().orElse(null);
+
+            Alert info = new Alert(Alert.AlertType.INFORMATION,
+                    "All transactions have been confirmed.\nMigration complete.", ButtonType.OK);
+            info.initOwner(getDialogPane().getScene().getWindow());
+            info.showAndWait();
+
+            // Clear migration and close dialog
+            migrationRows.clear();
+            saveMigrationState();
+            close();
+
+            // Switch to destination wallet tab
+            if(destWallet != null && ownerWindow != null && ownerWindow.getScene() != null) {
+                javafx.scene.Node node = ownerWindow.getScene().getRoot().lookup("#tabs");
+                if(node instanceof TabPane tabPane) {
+                    for(Tab tab : tabPane.getTabs()) {
+                        if(tab.getUserData() instanceof WalletTabData) {
+                            TabPane subTabs = (TabPane) tab.getContent();
+                            for(Tab subTab : subTabs.getTabs()) {
+                                if(subTab.getUserData() instanceof WalletTabData wtd && wtd.getWallet() == destWallet) {
+                                    tabPane.getSelectionModel().select(tab);
+                                    subTabs.getSelectionModel().select(subTab);
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -1252,8 +1384,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             return;
         }
 
-        // Don't save if all are broadcast (migration complete)
-        boolean allDone = migrationRows.stream().allMatch(r -> r.getStatus() == MigrationStatus.BROADCAST);
+        // Don't save if all are confirmed (migration complete)
+        boolean allDone = migrationRows.stream().allMatch(r -> r.getStatus() == MigrationStatus.CONFIRMED);
         if(allDone) {
             File file = getMigrationFile();
             if(file.exists()) {
@@ -1277,6 +1409,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                 obj.addProperty("feeRate", row.feeRate);
                 obj.addProperty("fee", row.fee);
                 obj.addProperty("status", row.getStatus().name());
+                obj.addProperty("targetBlock", row.targetBlock);
                 obj.addProperty("psbt", Base64.getEncoder().encodeToString(row.psbt.serialize()));
                 rows.add(obj);
             }
@@ -1316,6 +1449,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                 PSBT psbt = new PSBT(psbtBytes);
                 MigrationRow mr = new MigrationRow(utxoId, value, label, destAddress, feeRate, fee, psbt);
                 mr.setStatus(MigrationStatus.valueOf(statusStr));
+                mr.targetBlock = obj.has("targetBlock") ? obj.get("targetBlock").getAsLong() : 0;
                 resolveDestWallet(mr);
                 migrationRows.add(mr);
             }
@@ -1337,6 +1471,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         UNSIGNED("Unsigned"),
         SIGNED("Signed"),
         BROADCAST("Broadcast"),
+        CONFIRMED("Confirmed"),
         FAILED("Failed");
 
         private final String label;
@@ -1364,6 +1499,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         final PSBT psbt;
         Wallet destWallet;
         WalletNode destWalletNode;
+        long targetBlock;
         private final SimpleObjectProperty<MigrationStatus> status = new SimpleObjectProperty<>(MigrationStatus.UNSIGNED);
 
         public MigrationRow(String utxoId, long value, String label, String destAddress, double feeRate, long fee, PSBT psbt) {
@@ -1403,12 +1539,16 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                     setStyle(ALIGN_CENTER + " -fx-text-fill: white; -fx-font-weight: bold;");
                 }
                 case BROADCAST -> {
-                    setText("Broadcast");
-                    setStyle(ALIGN_CENTER + " -fx-text-fill: #1e88cf; -fx-font-weight: bold;");
+                    setText("Signed");
+                    setStyle(ALIGN_CENTER + " -fx-text-fill: white; -fx-font-weight: bold;");
+                }
+                case CONFIRMED -> {
+                    setText("Signed");
+                    setStyle(ALIGN_CENTER + " -fx-text-fill: white; -fx-font-weight: bold;");
                 }
                 case FAILED -> {
                     setText("Failed");
-                    setStyle(ALIGN_CENTER + " -fx-text-fill: #cc0000;");
+                    setStyle(ALIGN_CENTER + " -fx-text-fill: white;");
                 }
             }
         }
@@ -1442,18 +1582,25 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                     buttons.getChildren().add(openBtn);
                 }
                 case SIGNED -> {
-                    Button broadcastBtn = new Button("Broadcast");
-                    broadcastBtn.setPrefWidth(ACTION_BTN_WIDTH);
-                    broadcastBtn.setDefaultButton(true);
-                    broadcastBtn.setOnAction(e -> broadcastTransaction(row));
-                    buttons.getChildren().add(broadcastBtn);
+                    Label waitLabel = new Label("Scheduled");
+                    waitLabel.setStyle("-fx-text-fill: #e8a838; -fx-font-weight: bold;");
+                    waitLabel.setPrefWidth(ACTION_BTN_WIDTH);
+                    waitLabel.setAlignment(Pos.CENTER);
+                    buttons.getChildren().add(waitLabel);
                 }
                 case BROADCAST -> {
-                    Label doneLabel = new Label("Done");
-                    doneLabel.setStyle("-fx-text-fill: #1e88cf; -fx-font-weight: bold;");
-                    doneLabel.setPrefWidth(ACTION_BTN_WIDTH);
-                    doneLabel.setAlignment(Pos.CENTER);
-                    buttons.getChildren().add(doneLabel);
+                    Label unconfLabel = new Label("Unconfirmed");
+                    unconfLabel.setStyle("-fx-text-fill: #e8a838; -fx-font-weight: bold;");
+                    unconfLabel.setPrefWidth(ACTION_BTN_WIDTH);
+                    unconfLabel.setAlignment(Pos.CENTER);
+                    buttons.getChildren().add(unconfLabel);
+                }
+                case CONFIRMED -> {
+                    Label confirmedLabel = new Label("Confirmed");
+                    confirmedLabel.setStyle("-fx-text-fill: #1e88cf; -fx-font-weight: bold;");
+                    confirmedLabel.setPrefWidth(ACTION_BTN_WIDTH);
+                    confirmedLabel.setAlignment(Pos.CENTER);
+                    buttons.getChildren().add(confirmedLabel);
                 }
                 case FAILED -> {
                     Button retryBtn = new Button("Retry");

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -1,7 +1,6 @@
 package com.sparrowwallet.sparrow.control;
 
 import com.google.common.eventbus.Subscribe;
-import com.google.gson.*;
 import com.sparrowwallet.drongo.KeyPurpose;
 import com.sparrowwallet.drongo.OutputDescriptor;
 import com.sparrowwallet.drongo.address.Address;
@@ -39,9 +38,6 @@ import tornadofx.control.Field;
 import tornadofx.control.Fieldset;
 import tornadofx.control.Form;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -67,6 +63,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
     private final VBox managePane;
     private final TableView<MigrationRow> manageTable;
     private final Label manageSummaryLabel;
+    private final Button signAllBtn;
+    private final Button sendAllBtn;
 
     // State
     private final List<MigrationRow> migrationRows = new ArrayList<>();
@@ -83,7 +81,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         dialogPane.getStylesheets().add(MigrateUtxosDialog.class.getResource("migrate-utxos.css").toExternalForm());
         AppServices.setStageIcon(dialogPane.getScene().getWindow());
         dialogPane.getStyleClass().add("migrate-utxos");
-        dialogPane.setHeaderText("Migrate UTXOs individually to a destination wallet.\nEach UTXO becomes a separate transaction for privacy.");
+        dialogPane.setHeaderText("Send each UTXO as a separate transaction to a destination wallet.");
         dialogPane.setGraphic(new DialogImage(DialogImage.Type.SPARROW));
 
         // === SETUP PHASE ===
@@ -200,10 +198,15 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         clearBtn.setOnAction(e -> clearMigration());
         Region spacer2 = new Region();
         HBox.setHgrow(spacer2, Priority.ALWAYS);
-        Button signAllBtn = new Button("Sign All");
+        signAllBtn = new Button("Sign All");
         signAllBtn.getStyleClass().add("default-button");
         signAllBtn.setOnAction(e -> signAllUnsigned());
-        manageButtons.getChildren().addAll(clearBtn, spacer2, signAllBtn);
+        sendAllBtn = new Button("Send All");
+        sendAllBtn.getStyleClass().add("default-button");
+        sendAllBtn.setOnAction(e -> sendAllSigned());
+        sendAllBtn.setVisible(false);
+        sendAllBtn.setManaged(false);
+        manageButtons.getChildren().addAll(clearBtn, spacer2, signAllBtn, sendAllBtn);
 
         managePane.getChildren().addAll(manageTable, manageButtons, manageSummaryLabel);
         VBox.setVgrow(manageTable, Priority.ALWAYS);
@@ -274,20 +277,14 @@ public class MigrateUtxosDialog extends Dialog<Void> {
 
         populateUtxos();
 
-        // Load saved migration state if available
-        loadMigrationState();
-
         // Listen for PSBT signing events to auto-close tabs
         EventManager.get().register(this);
 
-        // Save state and unregister when dialog is closed
         setOnCloseRequest(e -> {
             batchSigningActive = false;
-            saveMigrationState();
             EventManager.get().unregister(this);
         });
         setResultConverter(btn2 -> {
-            saveMigrationState();
             EventManager.get().unregister(this);
             return null;
         });
@@ -427,7 +424,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                 double newRate = Double.parseDouble(event.getNewValue().trim());
                 if(newRate > 0) {
                     row.feeRate = newRate;
-                    saveMigrationState();
                 }
             } catch(NumberFormatException ignored) {
             }
@@ -443,9 +439,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             MigrationRow row = cd.getValue();
             if(row.targetBlock <= 0) {
                 return new SimpleStringProperty("");
-            }
-            if(row.getStatus() == MigrationStatus.BROADCAST) {
-                return new SimpleStringProperty(String.format("%,d", row.targetBlock));
             }
             return new SimpleStringProperty(String.format("%,d", row.targetBlock));
         });
@@ -484,7 +477,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                 if(row != null) {
                     row.setStatus(MigrationStatus.UNSIGNED);
                     manageTable.refresh();
-                    saveMigrationState();
+                    updateSignSendButtons();
                 }
             });
             MenuItem verifyItem = new MenuItem("Verify address on device");
@@ -550,7 +543,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         if(result.isPresent() && result.get() == ButtonType.YES) {
             migrationRows.clear();
             manageTable.getItems().clear();
-            saveMigrationState();
             showSetupPhase();
         }
     }
@@ -693,8 +685,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
 
         manageTable.setItems(FXCollections.observableArrayList(migrationRows));
         updateManageSummary();
+        updateSignSendButtons();
         showManagePhase();
-        saveMigrationState();
     }
 
     private double estimateTxVsize(UtxoRow row) {
@@ -768,31 +760,41 @@ public class MigrateUtxosDialog extends Dialog<Void> {
     // === Manage phase actions ===
 
     private void refreshMigrationStatuses() {
-        boolean changed = false;
         for(MigrationRow row : migrationRows) {
             if(row.getStatus() == MigrationStatus.UNSIGNED && row.psbt.isSigned()) {
                 row.setStatus(MigrationStatus.SIGNED);
-                changed = true;
             }
         }
         manageTable.refresh();
         updateManageSummary();
-        if(changed) {
-            saveMigrationState();
-        }
+        updateSignSendButtons();
     }
 
     private void updateManageSummary() {
         long total = migrationRows.size();
         long unsigned = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.UNSIGNED).count();
         long signed = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.SIGNED).count();
-        long broadcast = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.BROADCAST).count();
-        long confirmed = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.CONFIRMED).count();
+        long sent = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.SENT).count();
         long failed = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.FAILED).count();
-        Integer currentHeight = AppServices.getCurrentBlockHeight();
-        String blockInfo = currentHeight != null ? " | Block: " + String.format("%,d", currentHeight) : "";
-        manageSummaryLabel.setText(String.format("%d total | %d unsigned | %d signed | %d unconfirmed | %d confirmed%s%s",
-                total, unsigned, signed, broadcast, confirmed, failed > 0 ? " | " + failed + " failed" : "", blockInfo));
+
+        // Show block span for scheduled txs
+        long minBlock = migrationRows.stream().mapToLong(r -> r.targetBlock).filter(b -> b > 0).min().orElse(0);
+        long maxBlock = migrationRows.stream().mapToLong(r -> r.targetBlock).filter(b -> b > 0).max().orElse(0);
+        String spanInfo = minBlock > 0 ? String.format(" | Blocks %,d → %,d (~%d min span)", minBlock, maxBlock, (maxBlock - minBlock) * 10) : "";
+
+        manageSummaryLabel.setText(String.format("%d total | %d unsigned | %d signed | %d sent%s%s",
+                total, unsigned, signed, sent, failed > 0 ? " | " + failed + " failed" : "", spanInfo));
+    }
+
+    private void updateSignSendButtons() {
+        boolean anyUnsigned = migrationRows.stream().anyMatch(r -> r.getStatus() == MigrationStatus.UNSIGNED);
+        boolean anySigned = migrationRows.stream().anyMatch(r -> r.getStatus() == MigrationStatus.SIGNED);
+        boolean allSentOrFailed = migrationRows.stream().allMatch(r -> r.getStatus() == MigrationStatus.SENT || r.getStatus() == MigrationStatus.FAILED);
+
+        signAllBtn.setVisible(anyUnsigned);
+        signAllBtn.setManaged(anyUnsigned);
+        sendAllBtn.setVisible(anySigned && !anyUnsigned && !allSentOrFailed);
+        sendAllBtn.setManaged(anySigned && !anyUnsigned && !allSentOrFailed);
     }
 
     private void openPsbtForSigning(MigrationRow row) {
@@ -886,7 +888,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                     row.setStatus(MigrationStatus.SIGNED);
                     manageTable.refresh();
                     updateManageSummary();
-                    saveMigrationState();
+                    updateSignSendButtons();
 
                     // Close the PSBT tab in the main window
                     closeMigrationTab(eventTxId);
@@ -909,142 +911,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
     }
 
     @Subscribe
-    public void newBlock(NewBlockEvent event) {
-        int height = event.getHeight();
-        Platform.runLater(() -> {
-            checkConfirmations();
-            manageTable.refresh();
-        });
-        List<MigrationRow> ready = migrationRows.stream()
-                .filter(r -> r.getStatus() == MigrationStatus.SIGNED && r.targetBlock > 0 && height >= r.targetBlock)
-                .toList();
-        if(ready.isEmpty()) {
-            return;
-        }
-
-        // Stagger broadcasts with random delays when multiple are ready (e.g. after reopening Sparrow)
-        Random random = new Random();
-        long delayMs = 0;
-        for(MigrationRow row : ready) {
-            final long thisDelay = delayMs;
-            new Thread(() -> {
-                try {
-                    if(thisDelay > 0) {
-                        Thread.sleep(thisDelay);
-                    }
-                    Platform.runLater(() -> autoBroadcast(row));
-                } catch(InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }).start();
-            delayMs += 60_000L + random.nextInt(240_000); // 1-5 min between each
-        }
-    }
-
-    private void broadcastNextReady() {
-        // Resume flow: one at a time, wait for confirmation before next
-        boolean anyBroadcast = migrationRows.stream().anyMatch(r -> r.getStatus() == MigrationStatus.BROADCAST);
-        if(anyBroadcast) {
-            return;
-        }
-
-        Integer currentHeight = AppServices.getCurrentBlockHeight();
-        if(currentHeight == null) {
-            return;
-        }
-
-        migrationRows.stream()
-                .filter(r -> r.getStatus() == MigrationStatus.SIGNED && r.targetBlock > 0 && currentHeight >= r.targetBlock)
-                .findFirst()
-                .ifPresent(row -> Platform.runLater(() -> autoBroadcast(row)));
-    }
-
-    @Subscribe
     public void walletHistoryChanged(WalletHistoryChangedEvent event) {
-        Platform.runLater(() -> {
-            applyLabelsToDestTxos(event.getWallet());
-            checkConfirmations();
-            manageTable.refresh();
-        });
-    }
-
-    private void autoBroadcast(MigrationRow row) {
-        if(row.getStatus() != MigrationStatus.SIGNED || !row.psbt.isSigned()) {
-            return;
-        }
-        log.info("Auto-broadcasting migration tx {} at target block {}", row.utxoId, row.targetBlock);
-        broadcastTransactionSilent(row, () -> Platform.runLater(() -> {
-            manageTable.refresh();
-            updateManageSummary();
-            saveMigrationState();
-            checkMigrationComplete();
-        }));
-    }
-
-    private void checkConfirmations() {
-        boolean changed = false;
-        for(MigrationRow row : migrationRows) {
-            if(row.getStatus() == MigrationStatus.BROADCAST) {
-                Sha256Hash txId = row.psbt.getTransaction().getTxId();
-                BlockTransaction blockTx = sourceWallet.getTransactions().get(txId);
-                if(blockTx != null && blockTx.getHeight() > 0) {
-                    row.setStatus(MigrationStatus.CONFIRMED);
-                    changed = true;
-                } else if(row.destWallet != null) {
-                    BlockTransaction destBlockTx = row.destWallet.getTransactions().get(txId);
-                    if(destBlockTx != null && destBlockTx.getHeight() > 0) {
-                        row.setStatus(MigrationStatus.CONFIRMED);
-                        changed = true;
-                    }
-                }
-            }
-        }
-        if(changed) {
-            updateManageSummary();
-            saveMigrationState();
-            broadcastNextReady();
-            checkMigrationComplete();
-        }
-    }
-
-    private void checkMigrationComplete() {
-        boolean allConfirmed = migrationRows.stream().allMatch(r -> r.getStatus() == MigrationStatus.CONFIRMED);
-        if(allConfirmed) {
-            // Find the destination wallet from the first row
-            Wallet destWallet = migrationRows.stream()
-                    .filter(r -> r.destWallet != null)
-                    .map(r -> r.destWallet)
-                    .findFirst().orElse(null);
-
-            Alert info = new Alert(Alert.AlertType.INFORMATION,
-                    "All transactions have been confirmed.\nMigration complete.", ButtonType.OK);
-            info.initOwner(getDialogPane().getScene().getWindow());
-            info.showAndWait();
-
-            // Clear migration and close dialog
-            migrationRows.clear();
-            saveMigrationState();
-            close();
-
-            // Switch to destination wallet tab
-            if(destWallet != null && ownerWindow != null && ownerWindow.getScene() != null) {
-                javafx.scene.Node node = ownerWindow.getScene().getRoot().lookup("#tabs");
-                if(node instanceof TabPane tabPane) {
-                    for(Tab tab : tabPane.getTabs()) {
-                        if(tab.getUserData() instanceof WalletTabData) {
-                            TabPane subTabs = (TabPane) tab.getContent();
-                            for(Tab subTab : subTabs.getTabs()) {
-                                if(subTab.getUserData() instanceof WalletTabData wtd && wtd.getWallet() == destWallet) {
-                                    tabPane.getSelectionModel().select(tab);
-                                    subTabs.getSelectionModel().select(subTab);
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        Platform.runLater(() -> applyLabelsToDestTxos(event.getWallet()));
     }
 
     private void closeMigrationTab(Sha256Hash txId) {
@@ -1063,48 +931,117 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         }
     }
 
-    private void broadcastTransactionSilent(MigrationRow row, Runnable onDone) {
-        if(!row.psbt.isSigned()) {
-            row.setStatus(MigrationStatus.FAILED);
-            Platform.runLater(() -> {
-                manageTable.refresh();
-                updateManageSummary();
-                saveMigrationState();
-            });
-            if(onDone != null) onDone.run();
+    // === Send All — broadcasts signed txs to server (Broadcast Pool intercepts) ===
+
+    private void sendAllSigned() {
+        List<MigrationRow> signed = migrationRows.stream()
+                .filter(r -> r.getStatus() == MigrationStatus.SIGNED)
+                .toList();
+
+        if(signed.isEmpty()) {
+            AppServices.showErrorDialog("Nothing to send", "No signed transactions to send.");
             return;
         }
 
-        try {
-            Transaction finalTx = row.psbt.extractTransaction();
-            ElectrumServer.BroadcastTransactionService broadcastService = new ElectrumServer.BroadcastTransactionService(finalTx, row.fee);
-            broadcastService.setOnSucceeded(event -> {
-                row.setStatus(MigrationStatus.BROADCAST);
-                Platform.runLater(() -> {
+        sendAllBtn.setDisable(true);
+        final int[] counters = {0, 0}; // [sent, failed]
+        final int total = signed.size();
+
+        for(MigrationRow row : signed) {
+            try {
+                Transaction finalTx = row.psbt.extractTransaction();
+                ElectrumServer.BroadcastTransactionService broadcastService = new ElectrumServer.BroadcastTransactionService(finalTx, row.fee);
+                broadcastService.setOnSucceeded(event -> Platform.runLater(() -> {
+                    row.setStatus(MigrationStatus.SENT);
+                    counters[0]++;
                     manageTable.refresh();
                     updateManageSummary();
-                    saveMigrationState();
-                });
-                if(onDone != null) onDone.run();
-            });
-            broadcastService.setOnFailed(event -> {
+                    if(counters[0] + counters[1] == total) {
+                        onSendAllComplete(counters[0], counters[1]);
+                    }
+                }));
+                broadcastService.setOnFailed(event -> Platform.runLater(() -> {
+                    row.setStatus(MigrationStatus.FAILED);
+                    log.error("Failed to send migration tx {}", row.utxoId, event.getSource().getException());
+                    counters[1]++;
+                    manageTable.refresh();
+                    updateManageSummary();
+                    if(counters[0] + counters[1] == total) {
+                        onSendAllComplete(counters[0], counters[1]);
+                    }
+                }));
+                broadcastService.start();
+            } catch(Exception e) {
                 row.setStatus(MigrationStatus.FAILED);
-                Platform.runLater(() -> {
-                    manageTable.refresh();
-                    updateManageSummary();
-                    saveMigrationState();
-                });
-                if(onDone != null) onDone.run();
-            });
-            broadcastService.start();
-        } catch(Exception e) {
-            row.setStatus(MigrationStatus.FAILED);
-            Platform.runLater(() -> {
-                manageTable.refresh();
-                updateManageSummary();
-                saveMigrationState();
-            });
-            if(onDone != null) onDone.run();
+                log.error("Failed to send migration tx {}", row.utxoId, e);
+                counters[1]++;
+            }
+        }
+
+        // If all failed synchronously
+        if(counters[1] == total) {
+            onSendAllComplete(0, total);
+        }
+    }
+
+    private void onSendAllComplete(int sent, int failed) {
+        // Apply labels to destination wallet
+        Set<Wallet> destWallets = migrationRows.stream()
+                .map(mr -> mr.destWallet).filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        for(Wallet dw : destWallets) {
+            applyLabelsToDestTxos(dw);
+        }
+
+        updateSignSendButtons();
+        sendAllBtn.setDisable(false);
+
+        long minBlock = migrationRows.stream().mapToLong(r -> r.targetBlock).filter(b -> b > 0).min().orElse(0);
+        long maxBlock = migrationRows.stream().mapToLong(r -> r.targetBlock).filter(b -> b > 0).max().orElse(0);
+        String blockRange = minBlock > 0 ? String.format("\nScheduled for blocks %,d → %,d.", minBlock, maxBlock) : "";
+
+        String message = sent + "/" + (sent + failed) + " transactions sent to server." + blockRange
+                + "\nYour Broadcast Pool will handle the rest."
+                + "\nYou can close Sparrow.";
+
+        if(failed > 0) {
+            message += "\n\n" + failed + " transaction(s) failed. Use Retry to resend.";
+        }
+
+        Alert info = new Alert(Alert.AlertType.INFORMATION, message, ButtonType.OK);
+        info.setHeaderText("Migration Sent");
+        info.initOwner(getDialogPane().getScene().getWindow());
+        info.showAndWait();
+
+        if(failed == 0) {
+            // Switch to destination wallet tab
+            Wallet destWallet = migrationRows.stream()
+                    .filter(r -> r.destWallet != null)
+                    .map(r -> r.destWallet)
+                    .findFirst().orElse(null);
+
+            Window window = getDialogPane().getScene().getWindow();
+            if(window instanceof Stage stage) {
+                stage.close();
+            }
+
+            if(destWallet != null && ownerWindow != null && ownerWindow.getScene() != null) {
+                javafx.scene.Node node = ownerWindow.getScene().getRoot().lookup("#tabs");
+                if(node instanceof TabPane tabPane) {
+                    for(Tab tab : tabPane.getTabs()) {
+                        if(tab.getUserData() instanceof WalletTabData) {
+                            TabPane subTabs = (TabPane) tab.getContent();
+                            for(Tab subTab : subTabs.getTabs()) {
+                                if(subTab.getUserData() instanceof WalletTabData wtd && wtd.getWallet() == destWallet) {
+                                    tabPane.getSelectionModel().select(tab);
+                                    subTabs.getSelectionModel().select(subTab);
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -1205,124 +1142,12 @@ public class MigrateUtxosDialog extends Dialog<Void> {
     }
 
 
-    // === Persistence ===
-
-    private File getMigrationFile() {
-        File migrationsDir = new File(Storage.getSparrowDir(), "migrations");
-        if(!migrationsDir.exists()) {
-            migrationsDir.mkdirs();
-        }
-        String walletId = sourceWallet.getFullName().replaceAll("[^a-zA-Z0-9_-]", "_");
-        return new File(migrationsDir, walletId + ".json");
-    }
-
-    private void saveMigrationState() {
-        if(migrationRows.isEmpty()) {
-            // Remove file if no active migration
-            File file = getMigrationFile();
-            if(file.exists()) {
-                file.delete();
-            }
-            return;
-        }
-
-        // Don't save if all are confirmed (migration complete)
-        boolean allDone = migrationRows.stream().allMatch(r -> r.getStatus() == MigrationStatus.CONFIRMED);
-        if(allDone) {
-            File file = getMigrationFile();
-            if(file.exists()) {
-                file.delete();
-            }
-            return;
-        }
-
-        try {
-            JsonObject root = new JsonObject();
-            root.addProperty("sourceWallet", sourceWallet.getFullName());
-            root.addProperty("savedAt", System.currentTimeMillis());
-
-            JsonArray rows = new JsonArray();
-            for(MigrationRow row : migrationRows) {
-                JsonObject obj = new JsonObject();
-                obj.addProperty("utxoId", row.utxoId);
-                obj.addProperty("value", row.value);
-                obj.addProperty("label", row.label);
-                obj.addProperty("destAddress", row.destAddress);
-                obj.addProperty("feeRate", row.feeRate);
-                obj.addProperty("fee", row.fee);
-                obj.addProperty("status", row.getStatus().name());
-                obj.addProperty("targetBlock", row.targetBlock);
-                obj.addProperty("psbt", Base64.getEncoder().encodeToString(row.psbt.serialize()));
-                rows.add(obj);
-            }
-            root.add("migrations", rows);
-
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
-            Files.writeString(getMigrationFile().toPath(), gson.toJson(root), StandardCharsets.UTF_8);
-            log.info("Saved migration state: " + migrationRows.size() + " rows");
-        } catch(Exception e) {
-            log.error("Failed to save migration state", e);
-        }
-    }
-
-    private void loadMigrationState() {
-        File file = getMigrationFile();
-        if(!file.exists()) {
-            return;
-        }
-
-        try {
-            String json = Files.readString(file.toPath(), StandardCharsets.UTF_8);
-            JsonObject root = JsonParser.parseString(json).getAsJsonObject();
-            JsonArray rows = root.getAsJsonArray("migrations");
-
-            migrationRows.clear();
-            for(JsonElement el : rows) {
-                JsonObject obj = el.getAsJsonObject();
-                String utxoId = obj.get("utxoId").getAsString();
-                long value = obj.get("value").getAsLong();
-                String label = obj.has("label") ? obj.get("label").getAsString() : "";
-                String destAddress = obj.get("destAddress").getAsString();
-                double feeRate = obj.get("feeRate").getAsDouble();
-                long fee = obj.get("fee").getAsLong();
-                String statusStr = obj.get("status").getAsString();
-                byte[] psbtBytes = Base64.getDecoder().decode(obj.get("psbt").getAsString());
-
-                PSBT psbt = new PSBT(psbtBytes);
-                MigrationRow mr = new MigrationRow(utxoId, value, label, destAddress, feeRate, fee, psbt);
-                mr.setStatus(MigrationStatus.valueOf(statusStr));
-                mr.targetBlock = obj.has("targetBlock") ? obj.get("targetBlock").getAsLong() : 0;
-                resolveDestWallet(mr);
-                migrationRows.add(mr);
-            }
-
-            if(!migrationRows.isEmpty()) {
-                // Apply labels to dest wallets for txs that arrived while app was closed
-                Set<Wallet> destWallets = migrationRows.stream()
-                        .map(mr -> mr.destWallet).filter(Objects::nonNull)
-                        .collect(Collectors.toSet());
-                for(Wallet dw : destWallets) {
-                    applyLabelsToDestTxos(dw);
-                }
-                checkConfirmations();
-                broadcastNextReady();
-                manageTable.setItems(FXCollections.observableArrayList(migrationRows));
-                updateManageSummary();
-                showManagePhase();
-                log.info("Restored migration state: " + migrationRows.size() + " rows");
-            }
-        } catch(Exception e) {
-            log.error("Failed to load migration state", e);
-        }
-    }
-
     // === Inner types ===
 
     public enum MigrationStatus {
         UNSIGNED("Unsigned"),
         SIGNED("Signed"),
-        BROADCAST("Broadcast"),
-        CONFIRMED("Confirmed"),
+        SENT("Sent"),
         FAILED("Failed");
 
         private final String label;
@@ -1398,25 +1223,18 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                     buttons.getChildren().add(openBtn);
                 }
                 case SIGNED -> {
-                    Label waitLabel = new Label("Scheduled");
-                    waitLabel.getStyleClass().add("status-scheduled");
-                    waitLabel.setPrefWidth(ACTION_BTN_WIDTH);
-                    waitLabel.setAlignment(Pos.CENTER);
-                    buttons.getChildren().add(waitLabel);
+                    Label readyLabel = new Label("Ready");
+                    readyLabel.getStyleClass().add("status-scheduled");
+                    readyLabel.setPrefWidth(ACTION_BTN_WIDTH);
+                    readyLabel.setAlignment(Pos.CENTER);
+                    buttons.getChildren().add(readyLabel);
                 }
-                case BROADCAST -> {
-                    Label unconfLabel = new Label("Unconfirmed");
-                    unconfLabel.getStyleClass().add("status-unconfirmed");
-                    unconfLabel.setPrefWidth(ACTION_BTN_WIDTH);
-                    unconfLabel.setAlignment(Pos.CENTER);
-                    buttons.getChildren().add(unconfLabel);
-                }
-                case CONFIRMED -> {
-                    Label confirmedLabel = new Label("Confirmed");
-                    confirmedLabel.getStyleClass().add("status-confirmed");
-                    confirmedLabel.setPrefWidth(ACTION_BTN_WIDTH);
-                    confirmedLabel.setAlignment(Pos.CENTER);
-                    buttons.getChildren().add(confirmedLabel);
+                case SENT -> {
+                    Label sentLabel = new Label("Sent");
+                    sentLabel.getStyleClass().add("status-confirmed");
+                    sentLabel.setPrefWidth(ACTION_BTN_WIDTH);
+                    sentLabel.setAlignment(Pos.CENTER);
+                    buttons.getChildren().add(sentLabel);
                 }
                 case FAILED -> {
                     Button retryBtn = new Button("Retry");
@@ -1424,6 +1242,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                     retryBtn.setOnAction(e -> {
                         row.setStatus(MigrationStatus.SIGNED);
                         manageTable.refresh();
+                        updateSignSendButtons();
                     });
                     buttons.getChildren().add(retryBtn);
                 }

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -1,6 +1,9 @@
 package com.sparrowwallet.sparrow.control;
 
+import com.google.common.eventbus.Subscribe;
+import com.google.gson.*;
 import com.sparrowwallet.drongo.KeyPurpose;
+import com.sparrowwallet.drongo.OutputDescriptor;
 import com.sparrowwallet.drongo.address.Address;
 import com.sparrowwallet.drongo.protocol.*;
 import com.sparrowwallet.drongo.psbt.PSBT;
@@ -10,15 +13,7 @@ import com.sparrowwallet.sparrow.EventManager;
 import com.sparrowwallet.sparrow.TabData;
 import com.sparrowwallet.sparrow.TransactionTabData;
 import com.sparrowwallet.sparrow.WalletTabData;
-import com.sparrowwallet.sparrow.event.NewBlockEvent;
-import com.sparrowwallet.sparrow.event.PSBTFinalizedEvent;
-import com.sparrowwallet.sparrow.event.ViewPSBTEvent;
-import com.sparrowwallet.sparrow.event.ViewTransactionEvent;
-import com.sparrowwallet.sparrow.event.WalletDataChangedEvent;
-import com.sparrowwallet.sparrow.event.WalletHistoryChangedEvent;
-import com.google.common.eventbus.Subscribe;
-import com.sparrowwallet.drongo.OutputDescriptor;
-import com.sparrowwallet.drongo.wallet.KeystoreSource;
+import com.sparrowwallet.sparrow.event.*;
 import com.sparrowwallet.sparrow.io.Storage;
 import com.sparrowwallet.sparrow.net.ElectrumServer;
 import javafx.application.Platform;
@@ -27,7 +22,6 @@ import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.CheckBoxTableCell;
@@ -35,15 +29,15 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
-import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 import javafx.util.StringConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.gson.*;
+import tornadofx.control.Field;
+import tornadofx.control.Fieldset;
+import tornadofx.control.Form;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -53,9 +47,6 @@ import java.util.stream.Collectors;
 
 public class MigrateUtxosDialog extends Dialog<Void> {
     private static final Logger log = LoggerFactory.getLogger(MigrateUtxosDialog.class);
-
-    private static final String ALIGN_RIGHT = "-fx-alignment: CENTER-RIGHT;";
-    private static final String ALIGN_CENTER = "-fx-alignment: CENTER;";
 
     private final Wallet sourceWallet;
     private final Window ownerWindow;
@@ -68,8 +59,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
     private final ToggleGroup feeStrategyGroup;
     private final TextField minFeeField;
     private final TextField maxFeeField;
-    private final HBox randomRangeBox;
-    private final HBox fixedFeeBox;
+    private final Field randomFeeField;
+    private final Field fixedFeeField;
     private final Label setupSummaryLabel;
 
     // Manage phase UI
@@ -88,23 +79,27 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         final DialogPane dialogPane = getDialogPane();
         setTitle("Migrate UTXOs");
         dialogPane.getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
-        dialogPane.setStyle("-fx-font-size: 13px;");
-        // Center column headers
-        Platform.runLater(() -> dialogPane.getScene().getRoot().setStyle(
-                dialogPane.getScene().getRoot().getStyle() +
-                "; -fx-alignment: CENTER;"));
-        dialogPane.getStylesheets().add("data:text/css," +
-                ".table-view .column-header .label { -fx-alignment: CENTER; }");
+        dialogPane.getStylesheets().add(AppServices.class.getResource("dialog.css").toExternalForm());
+        dialogPane.getStylesheets().add(MigrateUtxosDialog.class.getResource("migrate-utxos.css").toExternalForm());
+        AppServices.setStageIcon(dialogPane.getScene().getWindow());
+        dialogPane.getStyleClass().add("migrate-utxos");
         dialogPane.setHeaderText("Migrate UTXOs individually to a destination wallet.\nEach UTXO becomes a separate transaction for privacy.");
+        dialogPane.setGraphic(new DialogImage(DialogImage.Type.SPARROW));
 
         // === SETUP PHASE ===
         setupPane = new VBox(10);
-        setupPane.setPadding(new Insets(10));
+        setupPane.getStyleClass().add("setup-pane");
+
+        // Form fields using tornadofx pattern
+        Form form = new Form();
+        Fieldset fieldset = new Fieldset();
+        fieldset.setText("");
+        fieldset.setSpacing(10);
 
         // Destination wallet selector
         List<WalletDestination> destinations = buildDestinationList(sourceWallet, openWallets);
-        HBox destBox = new HBox(10);
-        destBox.setAlignment(Pos.CENTER_LEFT);
+        Field destField = new Field();
+        destField.setText("Destination:");
         destWalletCombo = new ComboBox<>(FXCollections.observableArrayList(destinations));
         destWalletCombo.setConverter(new StringConverter<>() {
             @Override
@@ -122,11 +117,11 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             destWalletCombo.setPromptText("Open a destination wallet first");
             destWalletCombo.setDisable(true);
         }
-        destBox.getChildren().addAll(new Label("Destination:"), destWalletCombo);
+        destField.getInputs().add(destWalletCombo);
 
         // Fee strategy
-        HBox feeBox = new HBox(10);
-        feeBox.setAlignment(Pos.CENTER_LEFT);
+        Field feeStrategyField = new Field();
+        feeStrategyField.setText("Fee strategy:");
         feeStrategyGroup = new ToggleGroup();
         RadioButton fixedRadio = new RadioButton("Fixed");
         fixedRadio.setToggleGroup(feeStrategyGroup);
@@ -138,26 +133,32 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         RadioButton randomRadio = new RadioButton("Random range");
         randomRadio.setToggleGroup(feeStrategyGroup);
         randomRadio.setUserData("random");
-        feeBox.getChildren().addAll(new Label("Fee strategy:"), fixedRadio, manualRadio, randomRadio);
+        HBox strategyRadios = new HBox(10, fixedRadio, manualRadio, randomRadio);
+        feeStrategyField.getInputs().add(strategyRadios);
 
         // Fixed fee rate input
-        fixedFeeBox = new HBox(10);
-        fixedFeeBox.setAlignment(Pos.CENTER_LEFT);
+        fixedFeeField = new Field();
+        fixedFeeField.setText("Fee rate (sat/vB):");
         feeRateField = new TextField("1.0");
         feeRateField.setPrefWidth(80);
-        fixedFeeBox.getChildren().addAll(new Label("Fee rate (sat/vB):"), feeRateField);
+        fixedFeeField.getInputs().add(feeRateField);
 
         // Random range input
-        randomRangeBox = new HBox(10);
-        randomRangeBox.setAlignment(Pos.CENTER_LEFT);
+        randomFeeField = new Field();
+        randomFeeField.setText("Fee range (sat/vB):");
         minFeeField = new TextField("0.5");
         minFeeField.setPrefWidth(60);
         maxFeeField = new TextField("4.0");
         maxFeeField.setPrefWidth(60);
         Button randomizeButton = new Button("Randomize");
-        randomRangeBox.getChildren().addAll(new Label("Min (sat/vB):"), minFeeField, new Label("Max:"), maxFeeField, randomizeButton);
-        randomRangeBox.setVisible(false);
-        randomRangeBox.setManaged(false);
+        HBox rangeInputs = new HBox(10, new Label("Min:"), minFeeField, new Label("Max:"), maxFeeField, randomizeButton);
+        rangeInputs.setAlignment(Pos.CENTER_LEFT);
+        randomFeeField.getInputs().add(rangeInputs);
+        randomFeeField.setVisible(false);
+        randomFeeField.setManaged(false);
+
+        fieldset.getChildren().addAll(destField, feeStrategyField, fixedFeeField, randomFeeField);
+        form.getChildren().add(fieldset);
 
         // Setup table
         setupTable = createSetupTable();
@@ -172,26 +173,26 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
         Button createPsbtsBtn = new Button("Create PSBTs");
-        createPsbtsBtn.setStyle("-fx-font-weight: bold;");
+        createPsbtsBtn.getStyleClass().add("default-button");
         createPsbtsBtn.setDisable(true);
         selectButtons.getChildren().addAll(selectAllBtn, deselectAllBtn, spacer, createPsbtsBtn);
 
         setupSummaryLabel = new Label("");
-        setupSummaryLabel.setStyle("-fx-font-weight: bold;");
+        setupSummaryLabel.getStyleClass().add("summary-label");
 
-        setupPane.getChildren().addAll(destBox, feeBox, fixedFeeBox, randomRangeBox, setupTable, selectButtons, setupSummaryLabel);
+        setupPane.getChildren().addAll(form, setupTable, selectButtons, setupSummaryLabel);
         VBox.setVgrow(setupTable, Priority.ALWAYS);
 
         // === MANAGE PHASE ===
         managePane = new VBox(10);
-        managePane.setPadding(new Insets(10));
+        managePane.getStyleClass().add("manage-pane");
         managePane.setVisible(false);
         managePane.setManaged(false);
 
         manageTable = createManageTable();
 
         manageSummaryLabel = new Label("");
-        manageSummaryLabel.setStyle("-fx-font-weight: bold;");
+        manageSummaryLabel.getStyleClass().add("summary-label");
 
         HBox manageButtons = new HBox(10);
         manageButtons.setAlignment(Pos.CENTER_LEFT);
@@ -200,7 +201,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         Region spacer2 = new Region();
         HBox.setHgrow(spacer2, Priority.ALWAYS);
         Button signAllBtn = new Button("Sign All");
-        signAllBtn.setStyle("-fx-font-weight: bold;");
+        signAllBtn.getStyleClass().add("default-button");
         signAllBtn.setOnAction(e -> signAllUnsigned());
         manageButtons.getChildren().addAll(clearBtn, spacer2, signAllBtn);
 
@@ -228,9 +229,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         dialogPane.getButtonTypes().add(ButtonType.CLOSE);
         dialogPane.lookupButton(ButtonType.CLOSE).setVisible(false);
         dialogPane.lookupButton(ButtonType.CLOSE).setManaged(false);
-        // Remove button bar padding since there are no visible buttons
-        dialogPane.getStylesheets().add("data:text/css," +
-                ".dialog-pane .button-bar { -fx-padding: 0; -fx-min-height: 0; -fx-pref-height: 0; }");
+        // Button bar padding is hidden via migrate-utxos.css
 
         // Wire up events
         destWalletCombo.valueProperty().addListener((obs, old, newVal) -> {
@@ -246,10 +245,10 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             boolean isRandom = "random".equals(strategy);
             boolean isManual = "manual".equals(strategy);
             feeRateField.setDisable(isManual);
-            randomRangeBox.setVisible(isRandom);
-            randomRangeBox.setManaged(isRandom);
-            fixedFeeBox.setVisible(!isRandom);
-            fixedFeeBox.setManaged(!isRandom);
+            randomFeeField.setVisible(isRandom);
+            randomFeeField.setManaged(isRandom);
+            fixedFeeField.setVisible(!isRandom);
+            fixedFeeField.setManaged(!isRandom);
             if("fixed".equals(strategy)) {
                 applyFixedFeeRate();
             } else if(isRandom) {
@@ -270,7 +269,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         dialogPane.setPrefWidth(1100);
         dialogPane.setPrefHeight(700);
         setResizable(true);
-        AppServices.setStageIcon(dialogPane.getScene().getWindow());
         AppServices.moveToActiveWindowScreen(this);
         initModality(Modality.NONE);
 
@@ -341,7 +339,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         selectCol.setCellFactory(CheckBoxTableCell.forTableColumn(selectCol));
         selectCol.setMinWidth(35);
         selectCol.setMaxWidth(35);
-        selectCol.setStyle(ALIGN_CENTER);
+        selectCol.setStyle("-fx-alignment: CENTER;");
 
         TableColumn<UtxoRow, String> utxoCol = new TableColumn<>("UTXO");
         utxoCol.setCellValueFactory(cd -> cd.getValue().utxoIdProperty());
@@ -451,11 +449,11 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             }
             return new SimpleStringProperty(String.format("%,d", row.targetBlock));
         });
-        targetBlockCol.setStyle(ALIGN_CENTER);
+        targetBlockCol.setStyle("-fx-alignment: CENTER;");
 
         TableColumn<MigrationRow, Void> actionCol = new TableColumn<>("Status");
         actionCol.setCellFactory(col -> new ActionCell());
-        actionCol.setStyle(ALIGN_CENTER);
+        actionCol.setStyle("-fx-alignment: CENTER;");
         actionCol.setMinWidth(ACTION_BTN_WIDTH + 20);
 
         table.getColumns().addAll(utxoCol, destCol, valueCol, feeCol, labelCol, targetBlockCol, actionCol);
@@ -1065,231 +1063,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         }
     }
 
-    private void broadcastTransaction(MigrationRow row) {
-        if(!row.psbt.isSigned()) {
-            AppServices.showErrorDialog("Not Signed", "This transaction has not been signed yet. Open it to sign first.");
-            return;
-        }
-
-        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
-                "Broadcast transaction for " + row.utxoId + "?\nThis cannot be undone.", ButtonType.YES, ButtonType.NO);
-        confirm.initOwner(getDialogPane().getScene().getWindow());
-        Optional<ButtonType> result = confirm.showAndWait();
-        if(result.isEmpty() || result.get() != ButtonType.YES) {
-            return;
-        }
-
-        try {
-            Transaction finalTx = row.psbt.extractTransaction();
-            ElectrumServer.BroadcastTransactionService broadcastService = new ElectrumServer.BroadcastTransactionService(finalTx, row.fee);
-            broadcastService.setOnSucceeded(event -> {
-                row.setStatus(MigrationStatus.BROADCAST);
-                Platform.runLater(() -> {
-                    manageTable.refresh();
-                    updateManageSummary();
-                    saveMigrationState();
-                    AppServices.showErrorDialog("Broadcast Successful", "Transaction " + row.utxoId + " has been broadcast.");
-                });
-            });
-            broadcastService.setOnFailed(event -> {
-                row.setStatus(MigrationStatus.FAILED);
-                Platform.runLater(() -> {
-                    manageTable.refresh();
-                    updateManageSummary();
-                    saveMigrationState();
-                    AppServices.showErrorDialog("Broadcast Failed", event.getSource().getException().getMessage());
-                });
-            });
-            broadcastService.start();
-        } catch(Exception e) {
-            row.setStatus(MigrationStatus.FAILED);
-            manageTable.refresh();
-            updateManageSummary();
-            AppServices.showErrorDialog("Broadcast Failed", e.getMessage());
-        }
-    }
-
-    private void exportAllPsbts() {
-        List<MigrationRow> toExport = migrationRows.stream()
-                .filter(r -> r.getStatus() == MigrationStatus.UNSIGNED || r.getStatus() == MigrationStatus.SIGNED)
-                .toList();
-        if(toExport.isEmpty()) {
-            AppServices.showErrorDialog("Nothing to export", "No PSBTs to export.");
-            return;
-        }
-
-        FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("Export All PSBTs");
-        fileChooser.setInitialFileName("migration_psbts.json");
-        fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("JSON file", "*.json"));
-        File file = fileChooser.showSaveDialog(getDialogPane().getScene().getWindow());
-        if(file != null) {
-            JsonArray psbtsArray = new JsonArray();
-            for(int i = 0; i < migrationRows.size(); i++) {
-                MigrationRow row = migrationRows.get(i);
-                if(row.getStatus() == MigrationStatus.UNSIGNED || row.getStatus() == MigrationStatus.SIGNED) {
-                    JsonObject obj = new JsonObject();
-                    obj.addProperty("utxoId", row.utxoId);
-                    obj.addProperty("status", row.getStatus().name());
-                    obj.addProperty("psbt", Base64.getEncoder().encodeToString(row.psbt.serialize()));
-                    psbtsArray.add(obj);
-                }
-            }
-            try(Writer writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
-                new GsonBuilder().setPrettyPrinting().create().toJson(psbtsArray, writer);
-            } catch(IOException e) {
-                log.error("Failed to export PSBTs", e);
-                AppServices.showErrorDialog("Export Failed", e.getMessage());
-                return;
-            }
-            log.info("Exported {} PSBT(s) to {}", psbtsArray.size(), file.getName());
-        }
-    }
-
-    private void importSignedPsbts() {
-        FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("Import PSBTs");
-        fileChooser.getExtensionFilters().addAll(
-                new FileChooser.ExtensionFilter("JSON file", "*.json")
-        );
-        List<File> files = fileChooser.showOpenMultipleDialog(getDialogPane().getScene().getWindow());
-        if(files != null && !files.isEmpty()) {
-            List<byte[]> psbtDataList = readPsbtFiles(files);
-
-            if(migrationRows.isEmpty()) {
-                // Import from Setup phase: load PSBTs as new migration rows
-                int loaded = 0;
-                for(byte[] data : psbtDataList) {
-                    try {
-                        PSBT psbt = new PSBT(data);
-                        Transaction tx = psbt.getTransaction();
-                        String txId = tx.getTxId().toString();
-                        String utxoId = tx.getInputs().getFirst().getOutpoint().getHash().toString().substring(0, 8)
-                                + "...:" + tx.getInputs().getFirst().getOutpoint().getIndex();
-                        long value = 0;
-                        long fee = 0;
-                        String destAddress = "";
-                        if(!tx.getOutputs().isEmpty()) {
-                            TransactionOutput out = tx.getOutputs().getFirst();
-                            value = out.getValue();
-                            destAddress = out.getScript().getToAddress().toString();
-                        }
-                        // Estimate original UTXO value and fee from tx
-                        if(psbt.getPsbtInputs() != null && !psbt.getPsbtInputs().isEmpty()) {
-                            var psbtInput = psbt.getPsbtInputs().getFirst();
-                            if(psbtInput.getWitnessUtxo() != null) {
-                                long inputValue = psbtInput.getWitnessUtxo().getValue();
-                                fee = inputValue - value;
-                                value = inputValue;
-                            } else if(psbtInput.getNonWitnessUtxo() != null) {
-                                long inputIdx = tx.getInputs().getFirst().getOutpoint().getIndex();
-                                long inputValue = psbtInput.getNonWitnessUtxo().getOutputs().get((int) inputIdx).getValue();
-                                fee = inputValue - tx.getOutputs().getFirst().getValue();
-                                value = inputValue;
-                            }
-                        }
-                        double feeRate = fee > 0 ? (double) fee / tx.getVirtualSize() : 0;
-
-                        MigrationRow mr = new MigrationRow(utxoId, value, "", destAddress, feeRate, fee, psbt);
-                        if(psbt.isSigned()) {
-                            mr.setStatus(MigrationStatus.SIGNED);
-                        }
-                        resolveDestWallet(mr);
-                        migrationRows.add(mr);
-                        loaded++;
-                    } catch(Exception e) {
-                        log.error("Failed to parse PSBT for import", e);
-                    }
-                }
-
-                if(loaded > 0) {
-                    manageTable.setItems(FXCollections.observableArrayList(migrationRows));
-                    updateManageSummary();
-                    showManagePhase();
-                    saveMigrationState();
-                    log.info("Imported {} PSBT(s)", loaded);
-                }
-            } else {
-                // Import from Manage phase: combine signed PSBTs with existing rows
-                int combined = 0;
-                for(byte[] data : psbtDataList) {
-                    try {
-                        PSBT signedPsbt = new PSBT(data);
-                        for(MigrationRow row : migrationRows) {
-                            if(row.getStatus() == MigrationStatus.UNSIGNED
-                                    && row.psbt.getTransaction().getTxId().equals(signedPsbt.getTransaction().getTxId())) {
-                                row.psbt.combine(signedPsbt);
-                                if(row.psbt.isSigned()) {
-                                    row.setStatus(MigrationStatus.SIGNED);
-                                    combined++;
-                                }
-                                break;
-                            }
-                        }
-                    } catch(Exception e) {
-                        log.error("Failed to parse PSBT", e);
-                    }
-                }
-
-                manageTable.refresh();
-                updateManageSummary();
-                if(combined > 0) {
-                    saveMigrationState();
-                    log.info("Imported {} signed PSBT(s)", combined);
-                }
-            }
-        }
-    }
-
-    private List<byte[]> readPsbtFiles(List<File> files) {
-        List<byte[]> psbtDataList = new ArrayList<>();
-        for(File file : files) {
-            try {
-                String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
-                JsonArray array = JsonParser.parseString(content).getAsJsonArray();
-                for(JsonElement el : array) {
-                    String b64 = el.getAsJsonObject().get("psbt").getAsString();
-                    psbtDataList.add(Base64.getDecoder().decode(b64));
-                }
-            } catch(IOException e) {
-                log.error("Failed to read file " + file.getName(), e);
-            }
-        }
-        return psbtDataList;
-    }
-
-    private void broadcastAllSigned() {
-        List<MigrationRow> signed = migrationRows.stream()
-                .filter(r -> r.getStatus() == MigrationStatus.SIGNED)
-                .toList();
-        if(signed.isEmpty()) {
-            AppServices.showErrorDialog("Nothing to broadcast", "No signed transactions ready to broadcast.");
-            return;
-        }
-
-        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
-                "Broadcast " + signed.size() + " signed transaction(s)?\nThis cannot be undone.", ButtonType.YES, ButtonType.NO);
-        confirm.initOwner(getDialogPane().getScene().getWindow());
-        Optional<ButtonType> result = confirm.showAndWait();
-        if(result.isPresent() && result.get() == ButtonType.YES) {
-            final int[] success = {0};
-            final int[] failed = {0};
-            final int total = signed.size();
-            for(MigrationRow row : signed) {
-                broadcastTransactionSilent(row, () -> {
-                    if(row.getStatus() == MigrationStatus.BROADCAST) {
-                        success[0]++;
-                    } else {
-                        failed[0]++;
-                    }
-                    if(success[0] + failed[0] == total) {
-                        log.info("Broadcast complete: {} of {} succeeded, {} failed", success[0], total, failed[0]);
-                    }
-                });
-            }
-        }
-    }
-
     private void broadcastTransactionSilent(MigrationRow row, Runnable onDone) {
         if(!row.psbt.isSigned()) {
             row.setStatus(MigrationStatus.FAILED);
@@ -1597,41 +1370,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
 
     // === Table cells ===
 
-    private class StatusCell extends TableCell<MigrationRow, MigrationStatus> {
-        @Override
-        protected void updateItem(MigrationStatus item, boolean empty) {
-            super.updateItem(item, empty);
-            setText(null);
-            setGraphic(null);
-            setStyle("");
-            if(empty || item == null) {
-                return;
-            }
-            switch(item) {
-                case UNSIGNED -> {
-                    setText("Unsigned");
-                    setStyle(ALIGN_CENTER + " -fx-text-fill: white;");
-                }
-                case SIGNED -> {
-                    setText("Signed");
-                    setStyle(ALIGN_CENTER + " -fx-text-fill: white; -fx-font-weight: bold;");
-                }
-                case BROADCAST -> {
-                    setText("Signed");
-                    setStyle(ALIGN_CENTER + " -fx-text-fill: white; -fx-font-weight: bold;");
-                }
-                case CONFIRMED -> {
-                    setText("Signed");
-                    setStyle(ALIGN_CENTER + " -fx-text-fill: white; -fx-font-weight: bold;");
-                }
-                case FAILED -> {
-                    setText("Failed");
-                    setStyle(ALIGN_CENTER + " -fx-text-fill: white;");
-                }
-            }
-        }
-    }
-
     private static final double ACTION_BTN_WIDTH = 85;
 
     private class ActionCell extends TableCell<MigrationRow, Void> {
@@ -1661,21 +1399,21 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                 }
                 case SIGNED -> {
                     Label waitLabel = new Label("Scheduled");
-                    waitLabel.setStyle("-fx-text-fill: #e8a838; -fx-font-weight: bold;");
+                    waitLabel.getStyleClass().add("status-scheduled");
                     waitLabel.setPrefWidth(ACTION_BTN_WIDTH);
                     waitLabel.setAlignment(Pos.CENTER);
                     buttons.getChildren().add(waitLabel);
                 }
                 case BROADCAST -> {
                     Label unconfLabel = new Label("Unconfirmed");
-                    unconfLabel.setStyle("-fx-text-fill: #e8a838; -fx-font-weight: bold;");
+                    unconfLabel.getStyleClass().add("status-unconfirmed");
                     unconfLabel.setPrefWidth(ACTION_BTN_WIDTH);
                     unconfLabel.setAlignment(Pos.CENTER);
                     buttons.getChildren().add(unconfLabel);
                 }
                 case CONFIRMED -> {
                     Label confirmedLabel = new Label("Confirmed");
-                    confirmedLabel.setStyle("-fx-text-fill: #1e88cf; -fx-font-weight: bold;");
+                    confirmedLabel.getStyleClass().add("status-confirmed");
                     confirmedLabel.setPrefWidth(ACTION_BTN_WIDTH);
                     confirmedLabel.setAlignment(Pos.CENTER);
                     buttons.getChildren().add(confirmedLabel);
@@ -1745,7 +1483,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             super.startEdit();
             if(textField == null) {
                 textField = new TextField();
-                textField.setStyle(ALIGN_RIGHT);
+                textField.getStyleClass().add("fee-text-field");
                 textField.setOnAction(e -> commitEdit(textField.getText()));
                 textField.focusedProperty().addListener((obs, wasFocused, isNow) -> {
                     if(!isNow) {

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -14,6 +14,8 @@ import com.sparrowwallet.sparrow.event.NewBlockEvent;
 import com.sparrowwallet.sparrow.event.PSBTFinalizedEvent;
 import com.sparrowwallet.sparrow.event.ViewPSBTEvent;
 import com.sparrowwallet.sparrow.event.ViewTransactionEvent;
+import com.sparrowwallet.sparrow.event.WalletDataChangedEvent;
+import com.sparrowwallet.sparrow.event.WalletHistoryChangedEvent;
 import com.google.common.eventbus.Subscribe;
 import com.sparrowwallet.drongo.OutputDescriptor;
 import com.sparrowwallet.drongo.wallet.KeystoreSource;
@@ -691,6 +693,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             return;
         }
 
+        applyLabelsToDestWallets();
         manageTable.setItems(FXCollections.observableArrayList(migrationRows));
         updateManageSummary();
         showManagePhase();
@@ -942,6 +945,14 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         }
     }
 
+    @Subscribe
+    public void walletHistoryChanged(WalletHistoryChangedEvent event) {
+        Platform.runLater(() -> {
+            checkConfirmations();
+            manageTable.refresh();
+        });
+    }
+
     private void autoBroadcast(MigrationRow row) {
         if(row.getStatus() != MigrationStatus.SIGNED || !row.psbt.isSigned()) {
             return;
@@ -964,6 +975,12 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                 if(blockTx != null && blockTx.getHeight() > 0) {
                     row.setStatus(MigrationStatus.CONFIRMED);
                     changed = true;
+                } else if(row.destWallet != null) {
+                    BlockTransaction destBlockTx = row.destWallet.getTransactions().get(txId);
+                    if(destBlockTx != null && destBlockTx.getHeight() > 0) {
+                        row.setStatus(MigrationStatus.CONFIRMED);
+                        changed = true;
+                    }
                 }
             }
         }
@@ -1358,6 +1375,43 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         dlg.showAndWait();
     }
 
+    // === Label propagation to destination wallet ===
+
+    private void applyLabelsToDestWallets() {
+        Set<Wallet> modifiedWallets = new HashSet<>();
+        for(MigrationRow mr : migrationRows) {
+            if(mr.destWalletNode == null || mr.label == null || mr.label.isEmpty()) {
+                continue;
+            }
+            String baseLabel = stripLabelSuffix(mr.label);
+            if(baseLabel.isEmpty()) {
+                continue;
+            }
+            if(mr.destWalletNode.getLabel() == null || mr.destWalletNode.getLabel().isEmpty()) {
+                mr.destWalletNode.setLabel(baseLabel);
+                if(mr.destWallet != null) {
+                    modifiedWallets.add(mr.destWallet);
+                }
+                log.debug("Applied label '{}' to dest node {}", baseLabel, mr.destWalletNode.getDerivationPath());
+            }
+        }
+        for(Wallet w : modifiedWallets) {
+            EventManager.get().post(new WalletDataChangedEvent(w));
+        }
+    }
+
+    private static String stripLabelSuffix(String label) {
+        if(label == null) {
+            return "";
+        }
+        for(String suffix : List.of(" (received)", " (change)", " (sent)")) {
+            if(label.endsWith(suffix)) {
+                return label.substring(0, label.length() - suffix.length());
+            }
+        }
+        return label;
+    }
+
     // === Persistence ===
 
     private File getMigrationFile() {
@@ -1450,6 +1504,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             }
 
             if(!migrationRows.isEmpty()) {
+                applyLabelsToDestWallets();
+                checkConfirmations();
                 manageTable.setItems(FXCollections.observableArrayList(migrationRows));
                 updateManageSummary();
                 showManagePhase();

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -1215,7 +1215,6 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         }
         return row.destWallet.getKeystores().stream().anyMatch(ks ->
                 ks.getSource().equals(KeystoreSource.HW_USB)
-                || ks.getSource().equals(KeystoreSource.HW_AIRGAPPED)
                 || ks.getSource().equals(KeystoreSource.SW_WATCH));
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -46,8 +46,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 public class MigrateUtxosDialog extends Dialog<Void> {
     private static final Logger log = LoggerFactory.getLogger(MigrateUtxosDialog.class);
@@ -77,6 +75,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
 
     // State
     private final List<MigrationRow> migrationRows = new ArrayList<>();
+    private boolean batchSigningActive = false;
 
     public MigrateUtxosDialog(Wallet sourceWallet, Map<Wallet, Storage> openWallets, Window owner) {
         this.sourceWallet = sourceWallet;
@@ -200,10 +199,12 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         exportAllBtn.setOnAction(e -> exportAllPsbts());
         Region spacer2 = new Region();
         HBox.setHgrow(spacer2, Priority.ALWAYS);
+        Button signAllBtn = new Button("Sign All");
+        signAllBtn.setOnAction(e -> signAllUnsigned());
         Button broadcastAllBtn = new Button("Broadcast All Signed");
         broadcastAllBtn.setStyle("-fx-font-weight: bold;");
         broadcastAllBtn.setOnAction(e -> broadcastAllSigned());
-        manageButtons.getChildren().addAll(clearBtn, exportAllBtn, spacer2, broadcastAllBtn);
+        manageButtons.getChildren().addAll(clearBtn, exportAllBtn, spacer2, signAllBtn, broadcastAllBtn);
 
         managePane.getChildren().addAll(manageTable, manageButtons, manageSummaryLabel);
         VBox.setVgrow(manageTable, Priority.ALWAYS);
@@ -285,6 +286,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
 
         // Save state and unregister when dialog is closed
         setOnCloseRequest(e -> {
+            batchSigningActive = false;
             saveMigrationState();
             EventManager.get().unregister(this);
         });
@@ -334,6 +336,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         TableView<UtxoRow> table = new TableView<>();
         table.setEditable(true);
         table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        table.setFixedCellSize(30);
 
         TableColumn<UtxoRow, Boolean> selectCol = new TableColumn<>("");
         selectCol.setCellValueFactory(cd -> cd.getValue().selectedProperty());
@@ -381,6 +384,8 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         TableView<MigrationRow> table = new TableView<>();
         table.setEditable(true);
         table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+
+        table.setFixedCellSize(30);
 
         TableColumn<MigrationRow, String> utxoCol = new TableColumn<>("UTXO");
         utxoCol.setCellValueFactory(cd -> new SimpleStringProperty(cd.getValue().utxoId));
@@ -779,6 +784,61 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         }
     }
 
+    private void signAllUnsigned() {
+        long unsignedCount = migrationRows.stream().filter(r -> r.getStatus() == MigrationStatus.UNSIGNED).count();
+        if(unsignedCount == 0) {
+            AppServices.showErrorDialog("Nothing to sign", "No unsigned transactions.");
+            return;
+        }
+        batchSigningActive = true;
+        openNextUnsignedForBatch();
+    }
+
+    private void openNextUnsignedForBatch() {
+        Optional<MigrationRow> nextUnsigned = migrationRows.stream()
+                .filter(r -> r.getStatus() == MigrationStatus.UNSIGNED)
+                .findFirst();
+        if(nextUnsigned.isPresent()) {
+            openPsbtForSigning(nextUnsigned.get());
+            Platform.runLater(() -> attachBatchTabCloseListener(nextUnsigned.get()));
+        } else {
+            batchSigningActive = false;
+            Window dialogWindow = getDialogPane().getScene().getWindow();
+            if(dialogWindow instanceof Stage stage) {
+                stage.setIconified(false);
+                stage.toFront();
+            }
+        }
+    }
+
+    private void attachBatchTabCloseListener(MigrationRow row) {
+        if(ownerWindow == null || ownerWindow.getScene() == null) {
+            return;
+        }
+        javafx.scene.Node node = ownerWindow.getScene().getRoot().lookup("#tabs");
+        if(node instanceof TabPane tabPane) {
+            Sha256Hash txId = row.psbt.getTransaction().getTxId();
+            for(Tab tab : tabPane.getTabs()) {
+                if(tab.getUserData() instanceof TransactionTabData ttd
+                        && ttd.getTransaction().getTxId().equals(txId)) {
+                    tab.setOnClosed(e -> {
+                        if(row.getStatus() == MigrationStatus.UNSIGNED) {
+                            batchSigningActive = false;
+                            Platform.runLater(() -> {
+                                Window dialogWindow = getDialogPane().getScene().getWindow();
+                                if(dialogWindow instanceof Stage stage) {
+                                    stage.setIconified(false);
+                                    stage.toFront();
+                                }
+                            });
+                        }
+                    });
+                    break;
+                }
+            }
+        }
+    }
+
     private void showTransactionDetails(MigrationRow row) {
         // Open as a read-only Transaction view (no PSBT = no broadcast button)
         try {
@@ -810,11 +870,16 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                     // Close the PSBT tab in the main window
                     closeMigrationTab(eventTxId);
 
-                    // Restore and bring dialog to front
-                    Window dialogWindow = getDialogPane().getScene().getWindow();
-                    if(dialogWindow instanceof Stage stage) {
-                        stage.setIconified(false);
-                        stage.toFront();
+                    if(batchSigningActive) {
+                        // Chain to next unsigned PSBT
+                        openNextUnsignedForBatch();
+                    } else {
+                        // Single sign — restore dialog
+                        Window dialogWindow = getDialogPane().getScene().getWindow();
+                        if(dialogWindow instanceof Stage stage) {
+                            stage.setIconified(false);
+                            stage.toFront();
+                        }
                     }
                 });
                 break;
@@ -923,10 +988,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Import PSBTs");
         fileChooser.getExtensionFilters().addAll(
-                new FileChooser.ExtensionFilter("All supported", "*.json", "*.zip", "*.psbt"),
-                new FileChooser.ExtensionFilter("JSON file", "*.json"),
-                new FileChooser.ExtensionFilter("ZIP archive", "*.zip"),
-                new FileChooser.ExtensionFilter("PSBT files", "*.psbt")
+                new FileChooser.ExtensionFilter("JSON file", "*.json")
         );
         List<File> files = fileChooser.showOpenMultipleDialog(getDialogPane().getScene().getWindow());
         if(files != null && !files.isEmpty()) {
@@ -970,6 +1032,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                         if(psbt.isSigned()) {
                             mr.setStatus(MigrationStatus.SIGNED);
                         }
+                        resolveDestWallet(mr);
                         migrationRows.add(mr);
                         loaded++;
                     } catch(Exception e) {
@@ -1020,26 +1083,11 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         List<byte[]> psbtDataList = new ArrayList<>();
         for(File file : files) {
             try {
-                String name = file.getName().toLowerCase();
-                if(name.endsWith(".json")) {
-                    String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
-                    JsonArray array = JsonParser.parseString(content).getAsJsonArray();
-                    for(JsonElement el : array) {
-                        String b64 = el.getAsJsonObject().get("psbt").getAsString();
-                        psbtDataList.add(Base64.getDecoder().decode(b64));
-                    }
-                } else if(name.endsWith(".zip")) {
-                    try(ZipInputStream zis = new ZipInputStream(new java.io.FileInputStream(file))) {
-                        ZipEntry entry;
-                        while((entry = zis.getNextEntry()) != null) {
-                            if(!entry.isDirectory() && entry.getName().toLowerCase().endsWith(".psbt")) {
-                                psbtDataList.add(zis.readAllBytes());
-                            }
-                            zis.closeEntry();
-                        }
-                    }
-                } else {
-                    psbtDataList.add(Files.readAllBytes(file.toPath()));
+                String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+                JsonArray array = JsonParser.parseString(content).getAsJsonArray();
+                for(JsonElement el : array) {
+                    String b64 = el.getAsJsonObject().get("psbt").getAsString();
+                    psbtDataList.add(Base64.getDecoder().decode(b64));
                 }
             } catch(IOException e) {
                 log.error("Failed to read file " + file.getName(), e);
@@ -1125,6 +1173,40 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         }
     }
 
+    // === Destination wallet resolution ===
+
+    private void resolveDestWallet(MigrationRow mr) {
+        try {
+            Address addr = Address.fromString(mr.destAddress);
+            for(Wallet w : AppServices.get().getOpenWallets().keySet()) {
+                Map<Address, WalletNode> addresses = w.getWalletAddresses();
+                WalletNode node = addresses.get(addr);
+                if(node != null) {
+                    mr.destWallet = w;
+                    mr.destWalletNode = node;
+                    log.debug("Resolved dest wallet for {} -> {}", mr.destAddress, w.getFullName());
+                    return;
+                }
+                // Also check child wallets directly
+                for(Wallet child : w.getChildWallets()) {
+                    if(child.isValid()) {
+                        Map<Address, WalletNode> childAddresses = child.getWalletAddresses();
+                        WalletNode childNode = childAddresses.get(addr);
+                        if(childNode != null) {
+                            mr.destWallet = child;
+                            mr.destWalletNode = childNode;
+                            log.debug("Resolved dest wallet (child) for {} -> {}", mr.destAddress, child.getFullName());
+                            return;
+                        }
+                    }
+                }
+            }
+            log.debug("Could not resolve dest wallet for address {}", mr.destAddress);
+        } catch(Exception e) {
+            log.error("Error resolving dest wallet for address {}", mr.destAddress, e);
+        }
+    }
+
     // === Hardware wallet address verification ===
 
     private boolean isDestWalletHardware(MigrationRow row) {
@@ -1132,7 +1214,9 @@ public class MigrateUtxosDialog extends Dialog<Void> {
             return false;
         }
         return row.destWallet.getKeystores().stream().anyMatch(ks ->
-                ks.getSource().equals(KeystoreSource.HW_USB) || ks.getSource().equals(KeystoreSource.SW_WATCH));
+                ks.getSource().equals(KeystoreSource.HW_USB)
+                || ks.getSource().equals(KeystoreSource.HW_AIRGAPPED)
+                || ks.getSource().equals(KeystoreSource.SW_WATCH));
     }
 
     private void verifyDestAddressOnDevice(MigrationRow row) {
@@ -1233,6 +1317,7 @@ public class MigrateUtxosDialog extends Dialog<Void> {
                 PSBT psbt = new PSBT(psbtBytes);
                 MigrationRow mr = new MigrationRow(utxoId, value, label, destAddress, feeRate, fee, psbt);
                 mr.setStatus(MigrationStatus.valueOf(statusStr));
+                resolveDestWallet(mr);
                 migrationRows.add(mr);
             }
 

--- a/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MigrateUtxosDialog.java
@@ -1014,6 +1014,9 @@ public class MigrateUtxosDialog extends Dialog<Void> {
         info.showAndWait();
 
         if(failed == 0) {
+            // Register a persistent label propagator that survives dialog close
+            registerLabelPropagator();
+
             // Switch to destination wallet tab
             Wallet destWallet = migrationRows.stream()
                     .filter(r -> r.destWallet != null)
@@ -1104,6 +1107,80 @@ public class MigrateUtxosDialog extends Dialog<Void> {
     }
 
     // === Label propagation to destination wallet ===
+
+    private void registerLabelPropagator() {
+        // Build a map of txid -> label for all sent txs with labels
+        Map<Sha256Hash, String> txLabels = new LinkedHashMap<>();
+        Map<Sha256Hash, Wallet> txDestWallets = new LinkedHashMap<>();
+        Map<Sha256Hash, WalletNode> txDestNodes = new LinkedHashMap<>();
+
+        for(MigrationRow mr : migrationRows) {
+            if(mr.getStatus() == MigrationStatus.SENT && mr.label != null && !mr.label.isEmpty()) {
+                Sha256Hash txId = mr.psbt.getTransaction().getTxId();
+                txLabels.put(txId, mr.label);
+                txDestWallets.put(txId, mr.destWallet);
+                txDestNodes.put(txId, mr.destWalletNode);
+            }
+        }
+
+        if(txLabels.isEmpty()) {
+            return;
+        }
+
+        // Anonymous listener that applies labels when dest wallet sees the txs
+        Object propagator = new Object() {
+            @Subscribe
+            public void walletHistoryChanged(WalletHistoryChangedEvent event) {
+                Platform.runLater(() -> {
+                    Wallet w = event.getWallet();
+                    boolean applied = false;
+                    Iterator<Map.Entry<Sha256Hash, String>> it = txLabels.entrySet().iterator();
+                    while(it.hasNext()) {
+                        Map.Entry<Sha256Hash, String> entry = it.next();
+                        Sha256Hash txId = entry.getKey();
+                        String label = entry.getValue();
+                        Wallet destWallet = txDestWallets.get(txId);
+                        if(destWallet == null || destWallet != w) {
+                            continue;
+                        }
+
+                        BlockTransaction blockTx = destWallet.getTransactions().get(txId);
+                        if(blockTx != null && (blockTx.getLabel() == null || blockTx.getLabel().isEmpty())) {
+                            blockTx.setLabel(label);
+                            applied = true;
+                        }
+
+                        WalletNode destNode = txDestNodes.get(txId);
+                        if(destNode != null) {
+                            for(BlockTransactionHashIndex txo : destNode.getTransactionOutputs()) {
+                                if(txo.getHash().equals(txId) && (txo.getLabel() == null || txo.getLabel().isEmpty())) {
+                                    txo.setLabel(label);
+                                    applied = true;
+                                }
+                            }
+                        }
+
+                        if(blockTx != null) {
+                            it.remove();
+                        }
+                    }
+
+                    if(applied) {
+                        EventManager.get().post(new WalletDataChangedEvent(w));
+                    }
+
+                    // Unregister when all labels applied
+                    if(txLabels.isEmpty()) {
+                        EventManager.get().unregister(this);
+                        log.info("Label propagation complete, listener unregistered");
+                    }
+                });
+            }
+        };
+
+        EventManager.get().register(propagator);
+        log.info("Registered label propagator for {} transactions", txLabels.size());
+    }
 
     private void applyLabelsToDestTxos(Wallet changedWallet) {
         boolean changed = false;

--- a/src/main/resources/com/sparrowwallet/sparrow/app.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/app.fxml
@@ -145,6 +145,7 @@
                 <Menu fx:id="toolsMenu" mnemonicParsing="false" text="Tools">
                     <MenuItem mnemonicParsing="false" text="Sign/Verify Message" accelerator="Shortcut+M" onAction="#signVerifyMessage"/>
                     <MenuItem fx:id="sendToMany" mnemonicParsing="false" text="Send To Many" onAction="#sendToMany"/>
+                    <MenuItem fx:id="migrateUtxos" mnemonicParsing="false" text="Migrate UTXOs" onAction="#migrateUtxos"/>
                     <MenuItem fx:id="sweepPrivateKey" mnemonicParsing="false" text="Sweep Private Key" onAction="#sweepPrivateKey"/>
                     <SeparatorMenuItem />
                     <MenuItem fx:id="showPayNym" mnemonicParsing="false" text="Show PayNym" onAction="#showPayNym"/>

--- a/src/main/resources/com/sparrowwallet/sparrow/control/migrate-utxos.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/control/migrate-utxos.css
@@ -39,12 +39,6 @@
 }
 
 .migrate-utxos .status-scheduled {
-    -fx-text-fill: derive(gold, -10%);
-    -fx-font-weight: bold;
-}
-
-.migrate-utxos .status-unconfirmed {
-    -fx-text-fill: derive(gold, -10%);
     -fx-font-weight: bold;
 }
 

--- a/src/main/resources/com/sparrowwallet/sparrow/control/migrate-utxos.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/control/migrate-utxos.css
@@ -1,0 +1,54 @@
+.migrate-utxos .table-view .column-header .label {
+    -fx-alignment: CENTER;
+}
+
+.migrate-utxos .default-button {
+    -fx-font-weight: bold;
+}
+
+.migrate-utxos .summary-label {
+    -fx-font-weight: bold;
+}
+
+.migrate-utxos .setup-pane,
+.migrate-utxos .manage-pane {
+    -fx-padding: 10;
+}
+
+.migrate-utxos .fee-text-field {
+    -fx-alignment: CENTER-RIGHT;
+}
+
+.migrate-utxos .button-bar {
+    -fx-padding: 0;
+    -fx-min-height: 0;
+    -fx-pref-height: 0;
+}
+
+.migrate-utxos .status-unsigned {
+    -fx-alignment: CENTER;
+}
+
+.migrate-utxos .status-signed {
+    -fx-alignment: CENTER;
+    -fx-font-weight: bold;
+}
+
+.migrate-utxos .status-failed {
+    -fx-alignment: CENTER;
+}
+
+.migrate-utxos .status-scheduled {
+    -fx-text-fill: derive(gold, -10%);
+    -fx-font-weight: bold;
+}
+
+.migrate-utxos .status-unconfirmed {
+    -fx-text-fill: derive(gold, -10%);
+    -fx-font-weight: bold;
+}
+
+.migrate-utxos .status-confirmed {
+    -fx-text-fill: -fx-default-button;
+    -fx-font-weight: bold;
+}


### PR DESCRIPTION
## Add "Migrate UTXOs" feature (Tools menu)

Implements #1981 — Migrate UTXOs individually between wallets, creating one transaction per UTXO to preserve privacy.

### Problem

When a user needs to move funds between wallets — for example migrating from a wallet without a passphrase to one with a passphrase, or moving funds to a multisig wallet — sending all UTXOs in a single transaction links them together on-chain, destroying privacy. There is currently no built-in way to migrate UTXOs individually.

### Solution

A new dialog under **Tools → Migrate UTXOs** that creates separate PSBTs for each selected UTXO, each sending to a unique address in the destination wallet. The entire flow is managed in a two-phase modeless dialog.

### Flow

#### Phase 1 — Setup

1. **Select destination wallet** — Shows other open wallets and other accounts within the same wallet (e.g., accounts with a different script type). Excludes Whirlpool child wallets, BIP47 payment code wallets, and the source wallet itself.
2. **Choose fee strategy:**
   - **Fixed** — Same fee rate (sat/vB) for all transactions
   - **Manual per-tx** — Double-click the Fee column to set a custom fee rate per UTXO
   - **Random range** — Randomize fee rates within a min/max range (with a re-randomize button)
3. **Select UTXOs** — Table with checkboxes showing UTXO, destination address, value, fee rate, and label. Includes **Select All** / **Deselect All** buttons.
4. **Import PSBTs** — Load previously exported PSBTs in JSON format to resume a migration. Jumps directly to Phase 2.
5. **Create PSBTs** — Generates one PSBT per selected UTXO and advances to Phase 2.

> **[Screenshot: Setup phase]** — Dialog with several UTXOs listed, destination wallet selected, and fee strategy options visible.

#### Phase 2 — Sign & Broadcast

Table showing all migration transactions with columns: UTXO, Dest. Address, Value, Fee, Label, Status, Action.

**The Fee column is editable** — Double-click to change the fee rate on any unsigned transaction.

**Status flow:** Unsigned → Signed → Broadcast (or Failed)

**Per-row actions (Action column):**
- **Unsigned** → "Sign Tx" button — Opens the PSBT in Sparrow's transaction tab for signing. The dialog minimizes automatically and restores after signing.
- **Signed** → "Broadcast" button — Broadcasts with an individual confirmation prompt.
- **Broadcast** → "Done" label in blue.
- **Failed** → "Retry" button.

**Right-click context menu:**
- On **Signed** rows: "View transaction" and "Reset to unsigned"
- On **Broadcast** or **Failed** rows: "View transaction"
- On any row (when destination is a hardware wallet): **"Verify address on device"** — opens Sparrow's native device dialog to display the address on a USB-connected hardware wallet

**Double-click on a destination address** shows a **QR code** for scanning with airgapped devices (Passport, Keystone, Jade, etc.)

**Double-click** on any other column in a signed/broadcast/failed row opens transaction details (read-only view).

> **[Screenshot: Manage phase with mixed statuses]** — Table with rows in Unsigned, Signed, and Broadcast states showing status colors and action buttons.

> **[Screenshot: Right-click context menu showing "Verify address on device"]**

> **[Screenshot: QR code displayed after double-clicking a destination address]**

**Toolbar buttons:**
- **Clear** — Returns to Phase 1 (with confirmation)
- **Export All** — Exports all unsigned/signed PSBTs to a single JSON file (Base64-encoded PSBTs with metadata)
- **Broadcast All Signed** — Broadcasts all signed transactions with a single confirmation prompt, no intermediate dialogs. Results are reflected directly in the Status column.

### Persistence

Migration state is automatically saved to `~/.sparrow[/testnet4]/migrations/<walletName>.json`. If you close the dialog or Sparrow and reopen, the migration resumes where it was left off. Completed migrations (all broadcast) are auto-cleaned on next open.

### Privacy considerations

- Each UTXO is a separate transaction to a unique destination address — no on-chain link between them
- Random fee rate option prevents fee fingerprinting
- Manual per-tx fee allows full control
- The user can choose to broadcast transactions at different times to avoid linking them through timing analysis

> **[Screenshot: Fee strategy options]** — The three radio buttons with random range fields visible.

### Files changed

- **`MigrateUtxosDialog.java`** (new) — Full dialog implementation
- **`app.fxml`** — Menu item under Tools
- **`AppController.java`** — Handler method with single-instance enforcement