### PR TITLE
explain that multisig signing is unsupported in sign message dialog

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -1485,6 +1485,9 @@ public class AppController implements Initializable {
         if(messageSignDialog == null) {
             //Can verify only
             messageSignDialog = new MessageSignDialog();
+            if(selectedWalletForm != null && selectedWalletForm.getWallet().getPolicyType() == PolicyType.MULTI_HD) {
+                messageSignDialog.setNoticeText("Multisig wallets cannot sign messages — only single-signature wallets are supported. Signatures from other sources can still be verified here.");
+            }
         }
 
         messageSignDialog.initOwner(rootStack.getScene().getWindow());

--- a/src/main/java/com/sparrowwallet/sparrow/control/MessageSignDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MessageSignDialog.java
@@ -62,6 +62,7 @@ public class MessageSignDialog extends Dialog<ButtonBar.ButtonData> {
     private final ToggleButton formatElectrum;
     private final ToggleButton formatBip322;
     private final Wallet wallet;
+    private final VBox contentBox;
     private WalletNode walletNode;
     private boolean canSign;
     private boolean closed;
@@ -123,8 +124,8 @@ public class MessageSignDialog extends Dialog<ButtonBar.ButtonData> {
         dialogPane.setHeaderText(title == null ? (wallet == null ? "Verify Message" : "Sign/Verify Message") : title);
         dialogPane.setGraphic(new WalletModelImage(WalletModel.SEED));
 
-        VBox vBox = new VBox();
-        vBox.setSpacing(20);
+        contentBox = new VBox();
+        contentBox.setSpacing(10);
 
         Form form = new Form();
         Fieldset fieldset = new Fieldset();
@@ -185,7 +186,8 @@ public class MessageSignDialog extends Dialog<ButtonBar.ButtonData> {
 
         fieldset.getChildren().addAll(addressField, messageField, signatureField, formatField);
         form.getChildren().add(fieldset);
-        dialogPane.setContent(form);
+        contentBox.getChildren().add(form);
+        dialogPane.setContent(contentBox);
 
         if(msg != null) {
             message.setText(msg);
@@ -240,7 +242,7 @@ public class MessageSignDialog extends Dialog<ButtonBar.ButtonData> {
             ValidationSupport validationSupport = new ValidationSupport();
             Platform.runLater(() -> {
                 validationSupport.setValidationDecorator(new StyleClassValidationDecoration());
-                validationSupport.registerValidator(address, (Control c, String newValue) -> ValidationResult.fromErrorIf(c, "Invalid address", !isValidAddress()));
+                validationSupport.registerValidator(address, (Control c, String newValue) -> ValidationResult.fromErrorIf(c, getAddressValidationMessage(), !isValidAddress()));
             });
 
             address.textProperty().addListener((observable, oldValue, newValue) -> {
@@ -335,6 +337,37 @@ public class MessageSignDialog extends Dialog<ButtonBar.ButtonData> {
             return address.getScriptType().isAllowed(PolicyType.SINGLE_HD) || address.getScriptType() == ScriptType.P2SH;
         } catch (InvalidAddressException e) {
             return false;
+        }
+    }
+
+    private String getAddressValidationMessage() {
+        return getAddressValidationMessage(address.getText());
+    }
+
+    static String getAddressValidationMessage(String addressText) {
+        try {
+            ScriptType scriptType = Address.fromString(addressText).getScriptType();
+            if(!scriptType.isAllowed(PolicyType.SINGLE_HD) && scriptType != ScriptType.P2SH) {
+                return "Multisig addresses are not supported for signing";
+            }
+        } catch(InvalidAddressException e) {
+            //Fall through
+        }
+        return "Invalid address";
+    }
+
+    /**
+     * Adds a notice paragraph at the top of the dialog content. Pass null to clear.
+     */
+    public void setNoticeText(String text) {
+        contentBox.getChildren().removeIf(node -> "messageSignDialogNotice".equals(node.getId()));
+        if(text != null && !text.isEmpty()) {
+            Label notice = new Label(text);
+            notice.setId("messageSignDialogNotice");
+            notice.setWrapText(true);
+            notice.setMaxWidth(Double.MAX_VALUE);
+            notice.setStyle("-fx-font-style: italic; -fx-padding: 0 0 4 0;");
+            contentBox.getChildren().addFirst(notice);
         }
     }
 

--- a/src/test/java/com/sparrowwallet/sparrow/control/MessageSignDialogTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/MessageSignDialogTest.java
@@ -1,0 +1,26 @@
+package com.sparrowwallet.sparrow.control;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MessageSignDialogTest {
+    @Test
+    public void multisigAddressGivesSpecificValidationMessage() {
+        // P2WSH (native witness multisig) address — script type is not allowed for single-sig
+        String p2wshMainnet = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
+        Assertions.assertEquals("Multisig addresses are not supported for signing",
+                MessageSignDialog.getAddressValidationMessage(p2wshMainnet));
+    }
+
+    @Test
+    public void unparseableAddressGivesGenericMessage() {
+        Assertions.assertEquals("Invalid address",
+                MessageSignDialog.getAddressValidationMessage("not-a-bitcoin-address"));
+    }
+
+    @Test
+    public void emptyAddressGivesGenericMessage() {
+        Assertions.assertEquals("Invalid address",
+                MessageSignDialog.getAddressValidationMessage(""));
+    }
+}


### PR DESCRIPTION
Fixes #1717.

Two cues for the multisig-cannot-sign case:
1. The address-field validator returns "Multisig addresses are not supported for signing" instead of the generic "Invalid address" when an entered address parses but its script type isn't allowed for `SINGLE_HD` (and isn't `P2SH`, which can still be wrapped single-sig).
2. `MessageSignDialog.setNoticeText(String)` adds an inline notice at the top of the dialog. `AppController.signVerifyMessage` populates it when the active wallet is multisig and the dialog falls through to verify-only.

Three unit tests on the static validator helper.