### PR TITLE
expand account subtabs vertically when extra space is available

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -35,6 +35,7 @@ import de.jangassen.MenuToolkit;
 import javafx.animation.*;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
+import javafx.beans.binding.DoubleBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ChangeListener;
@@ -85,6 +86,9 @@ public class AppController implements Initializable {
     public static final int TAB_LABEL_MAX_WIDTH = 300;
     public static final double TAB_LABEL_GRAPHIC_OPACITY_INACTIVE = 0.8;
     public static final double TAB_LABEL_GRAPHIC_OPACITY_ACTIVE = 0.95;
+    private static final double SUBTAB_MIN_SIZE = 90.0;
+    private static final double SUBTAB_MAX_SIZE = 180.0;
+    private static final double SUBTAB_HEIGHT_MARGIN = 20.0;
     public static final String LOADING_TRANSACTIONS_MESSAGE = "Loading wallet, select Transactions tab to view...";
     public static final String CONNECTION_FAILED_PREFIX = "Connection failed: ";
     public static final String TRYING_ANOTHER_SERVER_MESSAGE = "trying another server...";
@@ -1851,6 +1855,12 @@ public class AppController implements Initializable {
                 subTabLabel.setTooltip(new Tooltip(label));
             }
             subTab.setGraphic(subTabLabel);
+
+            DoubleBinding subTabSize = Bindings.createDoubleBinding(() ->
+                    computeSubTabSize(subTabs.getHeight(), subTabs.getTabs().size()),
+                    subTabs.heightProperty(), subTabs.getTabs());
+            subTab.styleProperty().bind(subTabSize.asString(Locale.ROOT, "-fx-pref-width: %.0fpx;"));
+            subTabLabel.prefWidthProperty().bind(subTabSize);
             FXMLLoader walletLoader = new FXMLLoader(getClass().getResource("wallet/wallet.fxml"));
             subTab.setContent(walletLoader.load());
             WalletController controller = walletLoader.getController();
@@ -2478,7 +2488,15 @@ public class AppController implements Initializable {
     }
 
     private boolean isSubTabLabelTruncated(Label subTabLabel, String label) {
-        return TextUtils.computeTextWidth(subTabLabel.getFont(), label, 0.0D) > (90-6);
+        return TextUtils.computeTextWidth(subTabLabel.getFont(), label, 0.0D) > (SUBTAB_MIN_SIZE - 6);
+    }
+
+    static double computeSubTabSize(double tabPaneHeight, int tabCount) {
+        int count = Math.max(1, tabCount);
+        if(tabPaneHeight <= 0) {
+            return SUBTAB_MIN_SIZE;
+        }
+        return Math.max(SUBTAB_MIN_SIZE, Math.min(SUBTAB_MAX_SIZE, (tabPaneHeight - SUBTAB_HEIGHT_MARGIN) / count));
     }
 
     private void configureSwitchServer() {

--- a/src/test/java/com/sparrowwallet/sparrow/AppControllerTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/AppControllerTest.java
@@ -1,0 +1,36 @@
+package com.sparrowwallet.sparrow;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AppControllerTest {
+    @Test
+    public void subTabSizeFallsBackToMinWhenHeightUnknown() {
+        Assertions.assertEquals(90.0, AppController.computeSubTabSize(0, 1), 0.001);
+        Assertions.assertEquals(90.0, AppController.computeSubTabSize(-1, 5), 0.001);
+    }
+
+    @Test
+    public void subTabSizeFallsBackToMinWhenManyTabs() {
+        // 8 tabs in a 600px pane: (600-20)/8 = 72.5, below min of 90 → clamped to 90
+        Assertions.assertEquals(90.0, AppController.computeSubTabSize(600, 8), 0.001);
+    }
+
+    @Test
+    public void subTabSizeExpandsWhenFewTabs() {
+        // 2 tabs in a 600px pane: (600-20)/2 = 290, above max of 180 → clamped to 180
+        Assertions.assertEquals(180.0, AppController.computeSubTabSize(600, 2), 0.001);
+    }
+
+    @Test
+    public void subTabSizeScalesProportionallyInRange() {
+        // 4 tabs in a 600px pane: (600-20)/4 = 145, within [90,180] → 145
+        Assertions.assertEquals(145.0, AppController.computeSubTabSize(600, 4), 0.001);
+    }
+
+    @Test
+    public void subTabSizeHandlesZeroTabCount() {
+        // Defensive: 0 tabs treated as 1
+        Assertions.assertEquals(180.0, AppController.computeSubTabSize(600, 0), 0.001);
+    }
+}


### PR DESCRIPTION
Fixes #1578.

Binds each subtab's pref-width to `(paneHeight - 20) / tabCount`, clamped to `[90, 180]`. Wallets with 2-4 named accounts now get enough horizontal room for full labels; the 90px floor preserves the existing layout when many tabs are present. Math is in `AppController.computeSubTabSize`, tested at the boundaries (0/min/max/in-range/zero).

Visually verified via an in-process `Node.snapshot()` harness against a `TabPane` configured exactly like the wallet sidebar.