### PR TITLE
Validate auth47 callback protocols

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/Auth47.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/Auth47.java
@@ -70,6 +70,9 @@ public class Auth47 {
             this.callback = new URI(HTTPS_PROTOCOL + srbnUrl.getHost()).toURL();
         } else {
             this.callback = new URI(strCallback).toURL();
+            if(!isHttpCallback(this.callback)) {
+                throw new IllegalArgumentException("Invalid callback parameter (not http/s or srbn): " + strCallback);
+            }
         }
 
         this.expiry = parameterMap.get("e");
@@ -77,7 +80,7 @@ public class Auth47 {
         if(resource == null) {
             if(srbn) {
                 this.resource = "srbn";
-            } else if(strCallback.startsWith("http")) {
+            } else if(isHttpCallback(this.callback)) {
                 this.resource = strCallback;
             } else {
                 throw new IllegalArgumentException("Invalid callback parameter (not http/s or srbn): " + strCallback);
@@ -186,6 +189,11 @@ public class Auth47 {
 
     public URL getCallback() {
         return callback;
+    }
+
+    private static boolean isHttpCallback(URL callback) {
+        String protocol = callback.getProtocol();
+        return "http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol);
     }
 
     private static class Response {

--- a/src/test/java/com/sparrowwallet/sparrow/net/Auth47Test.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/Auth47Test.java
@@ -1,0 +1,24 @@
+package com.sparrowwallet.sparrow.net;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Auth47Test {
+    @Test
+    public void acceptsHttpCallbacksWithResource() throws Exception {
+        Auth47 auth47 = new Auth47(new URI("auth47://nonce?c=https://example.com/auth&r=example"));
+
+        assertEquals("https", auth47.getCallback().getProtocol());
+        assertEquals("example.com", auth47.getCallback().getHost());
+    }
+
+    @Test
+    public void rejectsNonHttpCallbacksWithResource() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new Auth47(new URI("auth47://nonce?c=file:///tmp/auth47&r=example")));
+    }
+}


### PR DESCRIPTION
## Summary
- reject non-HTTP/S auth47 callbacks when parsing the URI
- keep Soroban callbacks unchanged and use protocol-aware checks for normal callbacks
- add a regression test for callbacks that include a resource parameter

## Why
Auth47 responses are sent through `HttpURLConnection`, but a non-HTTP callback could be accepted when the URI supplied an `r` parameter. Validating the callback protocol during parsing keeps invalid callbacks from reaching the send path.

## Validation
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew :test --tests com.sparrowwallet.sparrow.net.Auth47Test --no-daemon --rerun-tasks`