### PR TITLE
Validate LNURL-auth URL schemes

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/LnurlAuth.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/LnurlAuth.java
@@ -41,9 +41,17 @@ public class LnurlAuth {
     public LnurlAuth(URI uri) throws MalformedURLException, URISyntaxException {
         String lnurl = uri.getSchemeSpecificPart();
         Bech32.Bech32Data bech32 = Bech32.decode(lnurl, 2000);
+        if(!"lnurl".equals(bech32.hrp)) {
+            throw new IllegalArgumentException("LNURL-auth bech32 prefix must be lnurl.");
+        }
+
         byte[] urlBytes = Bech32.convertBits(bech32.data, 0, bech32.data.length, 5, 8, false);
         String strUrl = new String(urlBytes, StandardCharsets.UTF_8);
-        this.url = new URI(strUrl).toURL();
+        URI decodedUri = new URI(strUrl);
+        if(!isSecureLnurl(decodedUri)) {
+            throw new IllegalArgumentException("LNURL-auth URL must be https or http onion.");
+        }
+        this.url = decodedUri.toURL();
 
         Map<String, String> parameterMap = new LinkedHashMap<>();
         String query = url.getQuery();
@@ -83,6 +91,16 @@ public class LnurlAuth {
 
     public String getDomain() {
         return url.getHost();
+    }
+
+    private static boolean isSecureLnurl(URI uri) {
+        String scheme = uri.getScheme();
+        String host = uri.getHost();
+        if(scheme == null || host == null) {
+            return false;
+        }
+
+        return "https".equalsIgnoreCase(scheme) || ("http".equalsIgnoreCase(scheme) && Protocol.isOnionHost(host));
     }
 
     public String getLoginMessage() {

--- a/src/test/java/com/sparrowwallet/sparrow/net/LnurlAuthTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/LnurlAuthTest.java
@@ -1,0 +1,57 @@
+package com.sparrowwallet.sparrow.net;
+
+import com.sparrowwallet.drongo.protocol.Bech32;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LnurlAuthTest {
+    private static final String K1 = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+    @Test
+    public void acceptsHttpsCallbacks() throws Exception {
+        LnurlAuth lnurlAuth = new LnurlAuth(lightningUri("https://example.com/lnurl-auth?tag=login&k1=" + K1));
+
+        assertEquals("example.com", lnurlAuth.getDomain());
+        assertEquals("login to example.com", lnurlAuth.getLoginMessage());
+    }
+
+    @Test
+    public void acceptsHttpOnionCallbacks() throws Exception {
+        LnurlAuth lnurlAuth = new LnurlAuth(lightningUri("http://abcdefghijklmnopqrstuvwxyzabcdefghijklmnop.onion/lnurl-auth?tag=login&k1=" + K1));
+
+        assertEquals("abcdefghijklmnopqrstuvwxyzabcdefghijklmnop.onion", lnurlAuth.getDomain());
+    }
+
+    @Test
+    public void rejectsHttpClearnetCallbacks() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new LnurlAuth(lightningUri("http://example.com/lnurl-auth?tag=login&k1=" + K1)));
+    }
+
+    @Test
+    public void rejectsNonHttpCallbacks() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new LnurlAuth(lightningUri("ftp://example.com/lnurl-auth?tag=login&k1=" + K1)));
+    }
+
+    @Test
+    public void rejectsNonLnurlBech32Prefix() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new LnurlAuth(lightningUri("lnurlx", "https://example.com/lnurl-auth?tag=login&k1=" + K1)));
+    }
+
+    private static URI lightningUri(String url) throws Exception {
+        return lightningUri("lnurl", url);
+    }
+
+    private static URI lightningUri(String prefix, String url) throws Exception {
+        byte[] urlBytes = url.getBytes(StandardCharsets.UTF_8);
+        byte[] lnurlData = Bech32.convertBits(urlBytes, 0, urlBytes.length, 8, 5, true);
+        return new URI("lightning:" + Bech32.encode(prefix, Bech32.Encoding.BECH32, lnurlData));
+    }
+}


### PR DESCRIPTION
## Summary
- reject LNURL-auth values that are not encoded with the `lnurl` Bech32 prefix
- enforce the LNURL transport boundary before any signing flow starts: HTTPS URLs are accepted, and HTTP is accepted only for onion hosts
- add focused regression coverage for HTTPS, HTTP onion, HTTP clearnet, non-HTTP, and non-LNURL Bech32 inputs

## Why
LUD-01 defines LNURL as a Bech32-encoded HTTPS or onion URL, and LUD-04 has wallets sign `k1` and send the signature/key back to the decoded LNURL endpoint. The existing parser accepted other schemes such as clearnet HTTP or FTP once `tag=login` and a valid `k1` were present. Rejecting these during parsing keeps unsafe callbacks out of the authentication/signing path.

References:
- https://github.com/lnurl/luds/blob/luds/01.md
- https://github.com/lnurl/luds/blob/luds/04.md

## Validation
- Before the fix, `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew :test --tests com.sparrowwallet.sparrow.net.LnurlAuthTest --no-daemon --rerun-tasks` failed on `rejectsHttpClearnetCallbacks` and `rejectsNonHttpCallbacks`
- After the fix, the same command passes
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew :compileJava :compileTestJava --no-daemon`