### PR TITLE
Validate Payjoin URL schemes

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -842,8 +842,36 @@ public class AppServices {
         return payjoinURIs.get(address);
     }
 
+    public static URI getSecurePayjoinUrl(BitcoinURI bitcoinURI) {
+        if(bitcoinURI != null) {
+            Object payjoinUrlObj = bitcoinURI.getParameterByName(BitcoinURI.FIELD_PAYJOIN_URL);
+            if(payjoinUrlObj instanceof String payjoinUrl) {
+                try {
+                    URI uri = new URI(payjoinUrl);
+                    if(isSecurePayjoinUrl(uri)) {
+                        return uri;
+                    }
+                    log.error("Insecure payjoin URL provided, must be https or http .onion: " + payjoinUrl);
+                } catch(URISyntaxException e) {
+                    log.error("Invalid payjoin URL provided", e);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean isSecurePayjoinUrl(URI uri) {
+        if(uri == null || uri.getScheme() == null || uri.getHost() == null) {
+            return false;
+        }
+
+        String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+        return "https".equals(scheme) || ("http".equals(scheme) && Protocol.isOnionHost(uri.getHost()));
+    }
+
     public static void addPayjoinURI(BitcoinURI bitcoinURI) {
-        if(bitcoinURI.getPayjoinUrl() == null || bitcoinURI.getAddress() == null) {
+        if(getSecurePayjoinUrl(bitcoinURI) == null || bitcoinURI.getAddress() == null) {
             throw new IllegalArgumentException("Not a valid payjoin URI");
         }
         payjoinURIs.put(bitcoinURI.getAddress(), bitcoinURI);

--- a/src/main/java/com/sparrowwallet/sparrow/payjoin/Payjoin.java
+++ b/src/main/java/com/sparrowwallet/sparrow/payjoin/Payjoin.java
@@ -57,10 +57,10 @@ public class Payjoin {
             allowOutputSubstitution = false;
         }
 
-        URI uri = payjoinURI.getPayjoinUrl();
+        URI uri = AppServices.getSecurePayjoinUrl(payjoinURI);
         if(uri == null) {
-            log.error("No payjoin URL provided");
-            throw new PayjoinReceiverException("No payjoin URL provided");
+            log.error("No valid payjoin URL provided");
+            throw new PayjoinReceiverException("No valid payjoin URL provided");
         }
 
         long additionalFeeContribution = getAdditionalFeeContribution();

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/PaymentController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/PaymentController.java
@@ -821,7 +821,7 @@ public class PaymentController extends WalletFormController implements Initializ
             setRecipientValueSats(bitcoinURI.getAmount());
             setFiatAmount(AppServices.getFiatCurrencyExchangeRate(), bitcoinURI.getAmount());
         }
-        if(bitcoinURI.getAddress() != null && bitcoinURI.getPayjoinUrl() != null) {
+        if(bitcoinURI.getAddress() != null && AppServices.getSecurePayjoinUrl(bitcoinURI) != null) {
             AppServices.addPayjoinURI(bitcoinURI);
         }
         sendController.updateTransaction();

--- a/src/test/java/com/sparrowwallet/sparrow/AppServicesTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/AppServicesTest.java
@@ -1,0 +1,50 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.uri.BitcoinURI;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class AppServicesTest {
+    private static final String ADDRESS = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+    @Test
+    public void acceptsHttpsPayjoinUri() throws Exception {
+        BitcoinURI bitcoinURI = payjoinUri("https://example.com/payjoin");
+
+        Assertions.assertDoesNotThrow(() -> AppServices.addPayjoinURI(bitcoinURI));
+        Assertions.assertEquals(bitcoinURI, AppServices.getPayjoinURI(bitcoinURI.getAddress()));
+
+        AppServices.clearPayjoinURI(bitcoinURI.getAddress());
+    }
+
+    @Test
+    public void acceptsHttpOnionPayjoinUri() throws Exception {
+        BitcoinURI bitcoinURI = payjoinUri("http://abcdefghijklmnopqrstuvwxyzabcdefghijklmnop.onion/payjoin");
+
+        Assertions.assertDoesNotThrow(() -> AppServices.addPayjoinURI(bitcoinURI));
+        Assertions.assertEquals(bitcoinURI, AppServices.getPayjoinURI(bitcoinURI.getAddress()));
+
+        AppServices.clearPayjoinURI(bitcoinURI.getAddress());
+    }
+
+    @Test
+    public void rejectsNonHttpOnionPayjoinUri() throws Exception {
+        BitcoinURI bitcoinURI = payjoinUri("file://abcdefghijklmnopqrstuvwxyzabcdefghijklmnop.onion/payjoin");
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AppServices.addPayjoinURI(bitcoinURI));
+    }
+
+    @Test
+    public void rejectsMalformedPayjoinUri() throws Exception {
+        BitcoinURI bitcoinURI = payjoinUri("payjoin");
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AppServices.addPayjoinURI(bitcoinURI));
+    }
+
+    private static BitcoinURI payjoinUri(String payjoinUrl) throws Exception {
+        return new BitcoinURI("bitcoin:" + ADDRESS + "?pj=" + URLEncoder.encode(payjoinUrl, StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary
- Parse the raw BIP21 pj parameter and accept only HTTPS endpoints, or HTTP endpoints for .onion hosts.
- Reuse the same validation when caching scanned Payjoin URIs and when sending the Payjoin PSBT request.
- Add focused regression coverage for valid HTTPS, valid HTTP .onion, non-HTTP .onion rejection, and malformed pj rejection.

## Why
BIP78 defines pj as an http(s) endpoint and requires senders to avoid unauthenticated or unencrypted connections unless the endpoint is protected by an authenticated mechanism such as a hidden service. Sparrow's previous validation came from BitcoinURI#getPayjoinUrl(), which allowed any scheme when the host ended in .onion and could throw on malformed or non-hierarchical pj values.

Reference: https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki

## Validation
- Before the fix, JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew :test --tests com.sparrowwallet.sparrow.AppServicesTest --no-daemon --rerun-tasks failed on the non-HTTP .onion and malformed pj cases.
- After the fix, the same targeted test command passes.
- git diff --check passes.