### PR TITLE
Bound BBQr decoded payload size

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/io/bbqr/BBQRDecoder.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/bbqr/BBQRDecoder.java
@@ -37,9 +37,7 @@ public class BBQRDecoder {
 
             if(receivedParts.size() == totalParts) {
                 byte[] data = concatParts();
-                BBQREncoding.checkDecodedLength(data.length);
                 data = header.inflate(data);
-                BBQREncoding.checkDecodedLength(data.length);
 
                 if(type == BBQRType.PSBT) {
                     result = new Result(new PSBT(data));

--- a/src/main/java/com/sparrowwallet/sparrow/io/bbqr/BBQRDecoder.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/bbqr/BBQRDecoder.java
@@ -37,7 +37,9 @@ public class BBQRDecoder {
 
             if(receivedParts.size() == totalParts) {
                 byte[] data = concatParts();
+                BBQREncoding.checkDecodedLength(data.length);
                 data = header.inflate(data);
+                BBQREncoding.checkDecodedLength(data.length);
 
                 if(type == BBQRType.PSBT) {
                     result = new Result(new PSBT(data));
@@ -58,6 +60,9 @@ public class BBQRDecoder {
     private byte[] concatParts() {
         int totalLength = 0;
         for(byte[] part : receivedParts.values()) {
+            if(totalLength > BBQREncoding.MAX_DECODED_DATA_LENGTH - part.length) {
+                throw new BBQREncodingException("Decoded BBQr data exceeds maximum size of " + BBQREncoding.MAX_DECODED_DATA_LENGTH + " bytes");
+            }
             totalLength += part.length;
         }
 

--- a/src/main/java/com/sparrowwallet/sparrow/io/bbqr/BBQREncoding.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/bbqr/BBQREncoding.java
@@ -17,9 +17,7 @@ public enum BBQREncoding {
 
         @Override
         public byte[] decode(String part) throws BBQREncodingException {
-            byte[] decoded = Utils.hexToBytes(part);
-            checkDecodedLength(decoded.length);
-            return decoded;
+            return Utils.hexToBytes(part);
         }
 
         @Override
@@ -34,9 +32,7 @@ public enum BBQREncoding {
 
         @Override
         public byte[] decode(String part) throws BBQREncodingException {
-            byte[] decoded = BaseEncoding.base32().decode(part);
-            checkDecodedLength(decoded.length);
-            return decoded;
+            return BaseEncoding.base32().decode(part);
         }
 
         @Override

--- a/src/main/java/com/sparrowwallet/sparrow/io/bbqr/BBQREncoding.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/bbqr/BBQREncoding.java
@@ -17,7 +17,9 @@ public enum BBQREncoding {
 
         @Override
         public byte[] decode(String part) throws BBQREncodingException {
-            return Utils.hexToBytes(part);
+            byte[] decoded = Utils.hexToBytes(part);
+            checkDecodedLength(decoded.length);
+            return decoded;
         }
 
         @Override
@@ -32,7 +34,9 @@ public enum BBQREncoding {
 
         @Override
         public byte[] decode(String part) throws BBQREncodingException {
-            return BaseEncoding.base32().decode(part);
+            byte[] decoded = BaseEncoding.base32().decode(part);
+            checkDecodedLength(decoded.length);
+            return decoded;
         }
 
         @Override
@@ -67,14 +71,21 @@ public enum BBQREncoding {
 
         @Override
         public byte[] inflate(byte[] data) throws BBQREncodingException {
-            try {
-                Inflater inflater = new Inflater(10, true);
-                ByteArrayInputStream in = new ByteArrayInputStream(data);
-                InflaterInputStream zIn = new InflaterInputStream(in, inflater);
-                byte[] decoded = zIn.readAllBytes();
-                zIn.close();
+            try(ByteArrayInputStream in = new ByteArrayInputStream(data);
+                InflaterInputStream zIn = new InflaterInputStream(in, new Inflater(10, true));
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+                while((bytesRead = zIn.read(buffer)) != -1) {
+                    if(out.size() > MAX_DECODED_DATA_LENGTH - bytesRead) {
+                        throw new BBQREncodingException("Decoded BBQr data exceeds maximum size of " + MAX_DECODED_DATA_LENGTH + " bytes");
+                    }
+                    out.write(buffer, 0, bytesRead);
+                }
 
-                return decoded;
+                return out.toByteArray();
+            } catch(BBQREncodingException e) {
+                throw e;
             } catch(Exception e) {
                 throw new BBQREncodingException("Error inflating with zlib", e);
             }
@@ -85,6 +96,9 @@ public enum BBQREncoding {
             return 8;
         }
     };
+
+    // BBQr targets PSBT and transaction payloads up to 500k; enforce the cap before parsing decoded data.
+    public static final int MAX_DECODED_DATA_LENGTH = 500_000;
 
     public static BBQREncoding fromString(String code) {
         for(BBQREncoding encoding : values()) {
@@ -111,7 +125,14 @@ public enum BBQREncoding {
     }
 
     public byte[] inflate(byte[] data) throws BBQREncodingException {
+        checkDecodedLength(data.length);
         return data;
+    }
+
+    static void checkDecodedLength(int length) throws BBQREncodingException {
+        if(length > MAX_DECODED_DATA_LENGTH) {
+            throw new BBQREncodingException("Decoded BBQr data exceeds maximum size of " + MAX_DECODED_DATA_LENGTH + " bytes");
+        }
     }
 
     public abstract String encode(byte[] data) throws BBQREncodingException;

--- a/src/test/java/com/sparrowwallet/sparrow/io/bbqr/BBQRDecoderTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/bbqr/BBQRDecoderTest.java
@@ -34,4 +34,30 @@ public class BBQRDecoderTest {
             }
         }
     }
+
+    @Test
+    public void rejectsOversizedZlibPayload() {
+        byte[] data = new byte[BBQREncoding.MAX_DECODED_DATA_LENGTH + 1];
+        BBQREncoder encoder = new BBQREncoder(BBQRType.BINARY, BBQREncoding.ZLIB, data, 2000, 0);
+        BBQRDecoder decoder = new BBQRDecoder();
+
+        while(decoder.getResult() == null) {
+            decoder.receivePart(encoder.nextPart());
+        }
+
+        Assertions.assertEquals(BBQRDecoder.ResultType.FAILURE, decoder.getResult().getResultType());
+    }
+
+    @Test
+    public void rejectsOversizedBase32Payload() {
+        byte[] data = new byte[BBQREncoding.MAX_DECODED_DATA_LENGTH + 1];
+        BBQREncoder encoder = new BBQREncoder(BBQRType.BINARY, BBQREncoding.BASE32, data, 2000, 0);
+        BBQRDecoder decoder = new BBQRDecoder();
+
+        while(decoder.getResult() == null) {
+            decoder.receivePart(encoder.nextPart());
+        }
+
+        Assertions.assertEquals(BBQRDecoder.ResultType.FAILURE, decoder.getResult().getResultType());
+    }
 }

--- a/src/test/java/com/sparrowwallet/sparrow/io/bbqr/BBQREncodingTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/bbqr/BBQREncodingTest.java
@@ -46,7 +46,6 @@ public class BBQREncodingTest {
     @Test
     public void rejectsOversizedZlibInflate() {
         byte[] data = new byte[BBQREncoding.MAX_DECODED_DATA_LENGTH + 1];
-
         byte[] deflated = BBQREncoding.ZLIB.deflate(data);
 
         Assertions.assertThrows(BBQREncodingException.class, () -> BBQREncoding.ZLIB.inflate(deflated));

--- a/src/test/java/com/sparrowwallet/sparrow/io/bbqr/BBQREncodingTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/bbqr/BBQREncodingTest.java
@@ -42,4 +42,13 @@ public class BBQREncodingTest {
 
         Assertions.assertArrayEquals(data, inflated);
     }
+
+    @Test
+    public void rejectsOversizedZlibInflate() {
+        byte[] data = new byte[BBQREncoding.MAX_DECODED_DATA_LENGTH + 1];
+
+        byte[] deflated = BBQREncoding.ZLIB.deflate(data);
+
+        Assertions.assertThrows(BBQREncodingException.class, () -> BBQREncoding.ZLIB.inflate(deflated));
+    }
 }


### PR DESCRIPTION
## Summary
- cap decoded BBQr payloads at 500,000 bytes before parsing PSBT, transaction, text, or binary data
- replace zlib readAllBytes() inflation with bounded streaming inflation
- guard multi-part concatenation before allocating the aggregate decoded buffer
- add regression coverage for oversized zlib and base32 BBQr payloads

## Why
BBQr input is accepted from scanned QR data. The BBQr spec targets PSBT and signed transaction payloads up to 500k, and mode Z decompresses the whole file after all QR parts are received. Without a decoded-output cap, an attacker-controlled BBQr payload can drive excessive allocation during decompression or assembly before normal parsing rejects it.

Spec reference: https://bbqr.org/BBQr.html

## Validation
- Before the fix, a focused oversized-zlib regression test failed because inflate() returned data above the intended cap.
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew :test --tests com.sparrowwallet.sparrow.io.bbqr.BBQREncodingTest --tests com.sparrowwallet.sparrow.io.bbqr.BBQRDecoderTest --no-daemon --rerun-tasks`
- `git diff --check`