### PR TITLE
Add Iroh P2P transport for private Electrum server connectivity

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/io/Config.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Config.java
@@ -84,6 +84,7 @@ public class Config {
     private boolean legacyServer;
     private Server electrumServer;
     private List<Server> recentElectrumServers;
+    private List<Server> recentIrohServers;
     private File electrumServerCert;
     private boolean useProxy;
     private String proxyServer;
@@ -663,12 +664,17 @@ public class Config {
     public List<Server> getRecentElectrumServers() {
         return recentElectrumServers == null ? new ArrayList<>() : recentElectrumServers;
     }
+    public List<Server> getRecentIrohServers() {
+        return recentIrohServers == null ? new ArrayList<>() : recentIrohServers;
+    }
 
     public boolean addRecentServer() {
         if(serverType == ServerType.BITCOIN_CORE && coreServer != null) {
             return addRecentCoreServer(coreServer);
         } else if(serverType == ServerType.ELECTRUM_SERVER && electrumServer != null) {
             return addRecentElectrumServer(electrumServer);
+        } else if(serverType == ServerType.IROH_SERVER && electrumServer != null) {
+            return addRecentIrohServer(electrumServer);
         }
 
         return false;
@@ -688,6 +694,18 @@ public class Config {
             return true;
         }
 
+        return false;
+    }
+
+    public boolean addRecentIrohServer(Server irohServer) {
+        if(recentIrohServers == null) {
+            recentIrohServers = new ArrayList<>();
+        }
+        if(!recentIrohServers.contains(irohServer)) {
+            recentIrohServers.add(irohServer);
+            flush();
+            return true;
+        }
         return false;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
@@ -127,6 +127,8 @@ public class ElectrumServer {
                     electrumServer = Config.get().getElectrumServer();
                     electrumServerCert = Config.get().getElectrumServerCert();
                     proxyServer = Config.get().getProxyServer();
+                } else if(Config.get().getServerType() == ServerType.IROH_SERVER) {
+                    electrumServer = Config.get().getElectrumServer();
                 }
 
                 if(electrumServer == null) {
@@ -149,7 +151,8 @@ public class ElectrumServer {
                 previousServer = electrumServer;
 
                 HostAndPort hostAndPort = electrumServer.getHostAndPort();
-                boolean localNetworkAddress = !Protocol.isOnionAddress(hostAndPort) && !PublicElectrumServer.isPublicServer(hostAndPort)
+                boolean localNetworkAddress = Config.get().getServerType() != ServerType.IROH_SERVER
+                        && !Protocol.isOnionAddress(hostAndPort) && !PublicElectrumServer.isPublicServer(hostAndPort)
                         && IpAddressMatcher.isLocalNetworkAddress(hostAndPort.getHost());
 
                 if(!localNetworkAddress && Config.get().isUseProxy() && proxyServer != null && !proxyServer.isBlank()) {

--- a/src/main/java/com/sparrowwallet/sparrow/net/IrohTransport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/IrohTransport.java
@@ -1,0 +1,97 @@
+package com.sparrowwallet.sparrow.net;
+
+import com.google.common.net.HostAndPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class IrohTransport extends TcpTransport {
+    private static final Logger log = LoggerFactory.getLogger(IrohTransport.class);
+    private static final String BRIDGE_BINARY = "iroh-electrum-bridge";
+    private Process bridgeProcess;
+    private ServerSocket serverSocket;
+
+    public IrohTransport(HostAndPort server) {
+        super(server);
+    }
+
+    @Override
+    protected void createSocket() throws IOException {
+        String nodeId = server.getHost();
+        File bridge = findBridge();
+        if(bridge == null) throw new IOException("iroh-electrum-bridge binary not found");
+        serverSocket = new ServerSocket(0);
+        int localPort = serverSocket.getLocalPort();
+        ProcessBuilder pb = new ProcessBuilder(bridge.getAbsolutePath(), nodeId);
+        pb.redirectErrorStream(false);
+        bridgeProcess = pb.start();
+        Thread acceptThread = new Thread(() -> {
+            try {
+                Socket clientSocket = serverSocket.accept();
+                Thread toSocket = new Thread(() -> {
+                    try { pipe(bridgeProcess.getInputStream(), clientSocket.getOutputStream()); }
+                    catch(IOException e) { log.debug("Bridge stdout pipe closed"); }
+                }, "iroh-to-socket");
+                toSocket.setDaemon(true);
+                toSocket.start();
+                Thread fromSocket = new Thread(() -> {
+                    try { pipe(clientSocket.getInputStream(), bridgeProcess.getOutputStream()); }
+                    catch(IOException e) { log.debug("Bridge stdin pipe closed"); }
+                }, "socket-to-iroh");
+                fromSocket.setDaemon(true);
+                fromSocket.start();
+            } catch(IOException e) { log.error("Bridge accept error", e); }
+        }, "iroh-bridge-accept");
+        acceptThread.setDaemon(true);
+        acceptThread.start();
+        // Wait for bridge to signal ready on stderr
+        Thread readyWaiter = new Thread(() -> {
+            try {
+                java.io.BufferedReader err = new java.io.BufferedReader(
+                    new java.io.InputStreamReader(bridgeProcess.getErrorStream()));
+                String line;
+                while((line = err.readLine()) != null) {
+                    log.debug("Bridge: " + line);
+                    if(line.equals("READY")) break;
+                }
+            } catch(java.io.IOException e) {
+                log.warn("Bridge stderr error", e);
+            }
+        }, "iroh-bridge-ready");
+        readyWaiter.setDaemon(true);
+        readyWaiter.start();
+        try { readyWaiter.join(60000); } catch(InterruptedException e) { Thread.currentThread().interrupt(); }
+
+        socket = new Socket();
+        socket.connect(new InetSocketAddress("127.0.0.1", localPort));
+    }
+
+    private void pipe(InputStream in, OutputStream out) throws IOException {
+        byte[] buf = new byte[4096];
+        int n;
+        while((n = in.read(buf)) != -1) { out.write(buf, 0, n); out.flush(); }
+    }
+
+    private File findBridge() {
+        File jar = new File(IrohTransport.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+        File next = new File(jar.getParentFile(), BRIDGE_BINARY);
+        if(next.exists() && next.canExecute()) return next;
+        String path = System.getenv("PATH");
+        if(path != null) {
+            for(String dir : path.split(File.pathSeparator)) {
+                File f = new File(dir, BRIDGE_BINARY);
+                if(f.exists() && f.canExecute()) return f;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        if(bridgeProcess != null) bridgeProcess.destroy();
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/net/Protocol.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/Protocol.java
@@ -38,7 +38,28 @@ public enum Protocol {
             return getTransport(server, proxy);
         }
     },
-    SSL(50002) {
+    IROH(0) {
+        @Override
+        public CloseableTransport getTransport(HostAndPort server) {
+            return new IrohTransport(server);
+        }
+
+        @Override
+        public CloseableTransport getTransport(HostAndPort server, File serverCert) {
+            return new IrohTransport(server);
+        }
+
+        @Override
+        public CloseableTransport getTransport(HostAndPort server, HostAndPort proxy) {
+            return new IrohTransport(server);
+        }
+
+        @Override
+        public CloseableTransport getTransport(HostAndPort server, File serverCert, HostAndPort proxy) {
+            return new IrohTransport(server);
+        }
+    },
+        SSL(50002) {
         @Override
         public CloseableTransport getTransport(HostAndPort server) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
             if(isOnionAddress(server)) {
@@ -178,6 +199,9 @@ public enum Protocol {
     }
 
     public static Protocol getProtocol(String url) {
+        if(url.startsWith("iroh://") || url.endsWith(":i")) {
+            return IROH;
+        }
         if(url.startsWith("tcp://") || url.endsWith(":t")) {
             return TCP;
         }

--- a/src/main/java/com/sparrowwallet/sparrow/net/ServerType.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/ServerType.java
@@ -1,7 +1,7 @@
 package com.sparrowwallet.sparrow.net;
 
 public enum ServerType {
-    BITCOIN_CORE("Bitcoin Core"), ELECTRUM_SERVER("Private Electrum"), PUBLIC_ELECTRUM_SERVER("Public Electrum");
+    BITCOIN_CORE("Bitcoin Core"), ELECTRUM_SERVER("Private Electrum"), PUBLIC_ELECTRUM_SERVER("Public Electrum"), IROH_SERVER("Iroh P2P");
 
     private final String name;
 

--- a/src/main/java/com/sparrowwallet/sparrow/settings/ServerSettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/settings/ServerSettingsController.java
@@ -160,6 +160,8 @@ public class ServerSettingsController extends SettingsDetailController {
     @FXML
     private ComboBoxTextField irohNodeId;
     @FXML
+    private ComboBox<Server> recentIrohServers;
+    @FXML
     private Button testConnection;
 
     @FXML
@@ -506,12 +508,27 @@ public class ServerSettingsController extends SettingsDetailController {
         }
 
         // Iroh server initialization
+        recentIrohServers.setCellFactory(value -> new ServerCell());
+        recentIrohServers.setItems(getObservableIrohServerList(Config.get().getRecentIrohServers()));
+        recentIrohServers.prefWidthProperty().bind(irohNodeId.widthProperty());
+        recentIrohServers.valueProperty().addListener((observable, oldValue, newValue) -> {
+            if(newValue != null && newValue != MANAGE_ALIASES_SERVER) {
+                irohNodeId.setText(newValue.getHostAndPort().getHost());
+                Platform.runLater(() -> recentIrohServers.getSelectionModel().clearSelection());
+            }
+        });
         if(config.getServerType() == ServerType.IROH_SERVER && config.getElectrumServer() != null) {
             irohNodeId.setText(config.getElectrumServer().getHostAndPort().getHost());
         }
         irohNodeId.textProperty().addListener((observable, oldValue, newValue) -> {
             if(newValue != null && !newValue.isBlank()) {
-                config.setElectrumServer(new Server("iroh://" + newValue.trim()));
+                try {
+                    config.setElectrumServer(new Server("iroh://" + newValue.trim()));
+                } catch(Exception e) {
+                    log.warn("Invalid Iroh Node ID: " + e.getMessage());
+                }
+            } else {
+                config.setElectrumServer(null);
             }
         });
 
@@ -587,6 +604,8 @@ public class ServerSettingsController extends SettingsDetailController {
                     recentCoreServers.setItems(getObservableServerList(Config.get().getRecentCoreServers()));
                 } else if(Config.get().getServerType() == ServerType.ELECTRUM_SERVER) {
                     recentElectrumServers.setItems(getObservableServerList(Config.get().getRecentElectrumServers()));
+                } else if(Config.get().getServerType() == ServerType.IROH_SERVER) {
+                    recentIrohServers.setItems(getObservableIrohServerList(Config.get().getRecentIrohServers()));
                 }
             }
         });
@@ -866,6 +885,7 @@ public class ServerSettingsController extends SettingsDetailController {
     }
 
     private void setElectrumServerInConfig(Config config) {
+        if(Config.get().getServerType() == ServerType.IROH_SERVER) return;
         Server existingServer = config.getRecentElectrumServers().stream().filter(server -> electrumHost.getText().equals(server.getAlias())).findFirst().orElse(null);
         if(existingServer != null) {
             config.setElectrumServer(existingServer);
@@ -990,6 +1010,10 @@ public class ServerSettingsController extends SettingsDetailController {
         serverObservableList.add(MANAGE_ALIASES_SERVER);
         serverObservableList.add(SCAN_QR_SERVER);
         return serverObservableList;
+    }
+
+    private ObservableList<Server> getObservableIrohServerList(List<Server> servers) {
+        return FXCollections.observableList(new ArrayList<>(servers));
     }
 
     @Subscribe

--- a/src/main/java/com/sparrowwallet/sparrow/settings/ServerSettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/settings/ServerSettingsController.java
@@ -156,6 +156,10 @@ public class ServerSettingsController extends SettingsDetailController {
     private TextField proxyPort;
 
     @FXML
+    private Form irohForm;
+    @FXML
+    private ComboBoxTextField irohNodeId;
+    @FXML
     private Button testConnection;
 
     @FXML
@@ -189,16 +193,16 @@ public class ServerSettingsController extends SettingsDetailController {
         publicElectrumForm.managedProperty().bind(publicElectrumForm.visibleProperty());
         coreForm.managedProperty().bind(coreForm.visibleProperty());
         electrumForm.managedProperty().bind(electrumForm.visibleProperty());
+        irohForm.managedProperty().bind(irohForm.visibleProperty());
         serverTypeToggleGroup.selectedToggleProperty().addListener((observable, oldValue, newValue) -> {
             if(serverTypeToggleGroup.getSelectedToggle() != null) {
                 ServerType existingType = config.getServerType();
                 ServerType serverType = (ServerType)newValue.getUserData();
                 publicElectrumForm.setVisible(serverType == ServerType.PUBLIC_ELECTRUM_SERVER);
                 coreForm.setVisible(serverType == ServerType.BITCOIN_CORE);
-                electrumForm.setVisible(serverType == ServerType.ELECTRUM_SERVER || serverType == ServerType.IROH_SERVER);
-                if(existingType != ServerType.IROH_SERVER || serverType != ServerType.ELECTRUM_SERVER) {
-                    config.setServerType(serverType);
-                }
+                electrumForm.setVisible(serverType == ServerType.ELECTRUM_SERVER);
+                irohForm.setVisible(serverType == ServerType.IROH_SERVER);
+                config.setServerType(serverType);
                 testConnection.setGraphic(getGlyph(FontAwesome5.Glyph.QUESTION_CIRCLE, ""));
                 testResults.clear();
                 if(existingType != serverType && !(existingType == ServerType.IROH_SERVER && serverType == ServerType.ELECTRUM_SERVER)) {
@@ -216,8 +220,7 @@ public class ServerSettingsController extends SettingsDetailController {
             serverTypeSegmentedButton.getButtons().remove(publicElectrumToggle);
             serverTypeToggleGroup.getToggles().remove(publicElectrumToggle);
         }
-        ServerType displayType = serverType == ServerType.IROH_SERVER ? ServerType.ELECTRUM_SERVER : serverType;
-        serverTypeToggleGroup.selectToggle(serverTypeToggleGroup.getToggles().stream().filter(toggle -> toggle.getUserData() == displayType).findFirst().orElse(null));
+        serverTypeToggleGroup.selectToggle(serverTypeToggleGroup.getToggles().stream().filter(toggle -> toggle.getUserData() == serverType).findFirst().orElse(null));
 
         List<PolicyType> policyTypes = AppServices.get().getOpenWallets().keySet().stream().map(Wallet::getPolicyType).filter(Objects::nonNull).collect(Collectors.toList());
         publicElectrumServer.setButtonCell(new PublicElectrumServerButtonCell());
@@ -501,6 +504,16 @@ public class ServerSettingsController extends SettingsDetailController {
                 electrumPort.setText(Integer.toString(hostAndPort.getPort()));
             }
         }
+
+        // Iroh server initialization
+        if(config.getServerType() == ServerType.IROH_SERVER && config.getElectrumServer() != null) {
+            irohNodeId.setText(config.getElectrumServer().getHostAndPort().getHost());
+        }
+        irohNodeId.textProperty().addListener((observable, oldValue, newValue) -> {
+            if(newValue != null && !newValue.isBlank()) {
+                config.setElectrumServer(new Server("iroh://" + newValue.trim()));
+            }
+        });
 
         File certificateFile = config.getElectrumServerCert();
         if(certificateFile != null) {

--- a/src/main/java/com/sparrowwallet/sparrow/settings/ServerSettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/settings/ServerSettingsController.java
@@ -195,11 +195,13 @@ public class ServerSettingsController extends SettingsDetailController {
                 ServerType serverType = (ServerType)newValue.getUserData();
                 publicElectrumForm.setVisible(serverType == ServerType.PUBLIC_ELECTRUM_SERVER);
                 coreForm.setVisible(serverType == ServerType.BITCOIN_CORE);
-                electrumForm.setVisible(serverType == ServerType.ELECTRUM_SERVER);
-                config.setServerType(serverType);
+                electrumForm.setVisible(serverType == ServerType.ELECTRUM_SERVER || serverType == ServerType.IROH_SERVER);
+                if(existingType != ServerType.IROH_SERVER || serverType != ServerType.ELECTRUM_SERVER) {
+                    config.setServerType(serverType);
+                }
                 testConnection.setGraphic(getGlyph(FontAwesome5.Glyph.QUESTION_CIRCLE, ""));
                 testResults.clear();
-                if(existingType != serverType) {
+                if(existingType != serverType && !(existingType == ServerType.IROH_SERVER && serverType == ServerType.ELECTRUM_SERVER)) {
                     EventManager.get().post(new ServerTypeChangedEvent(serverType));
                 }
             } else if(oldValue != null) {
@@ -214,7 +216,8 @@ public class ServerSettingsController extends SettingsDetailController {
             serverTypeSegmentedButton.getButtons().remove(publicElectrumToggle);
             serverTypeToggleGroup.getToggles().remove(publicElectrumToggle);
         }
-        serverTypeToggleGroup.selectToggle(serverTypeToggleGroup.getToggles().stream().filter(toggle -> toggle.getUserData() == serverType).findFirst().orElse(null));
+        ServerType displayType = serverType == ServerType.IROH_SERVER ? ServerType.ELECTRUM_SERVER : serverType;
+        serverTypeToggleGroup.selectToggle(serverTypeToggleGroup.getToggles().stream().filter(toggle -> toggle.getUserData() == displayType).findFirst().orElse(null));
 
         List<PolicyType> policyTypes = AppServices.get().getOpenWallets().keySet().stream().map(Wallet::getPolicyType).filter(Objects::nonNull).collect(Collectors.toList());
         publicElectrumServer.setButtonCell(new PublicElectrumServerButtonCell());
@@ -885,6 +888,7 @@ public class ServerSettingsController extends SettingsDetailController {
     }
 
     private Protocol getProtocol() {
+        if(Config.get().getServerType() == ServerType.IROH_SERVER) return Protocol.IROH;
         return (electrumUseSsl.isSelected() ? Protocol.SSL : Protocol.TCP);
     }
 

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
@@ -62,6 +62,14 @@
                                 <ServerType fx:constant="ELECTRUM_SERVER"/>
                             </userData>
                         </ToggleButton>
+                        <ToggleButton fx:id="irohToggle" text="Iroh P2P" toggleGroup="$serverTypeToggleGroup">
+                            <graphic>
+                                <Glyph fontFamily="Font Awesome 5 Free Solid" fontSize="12" icon="TOGGLE_ON" styleClass="iroh-server" />
+                            </graphic>
+                            <userData>
+                                <ServerType fx:constant="IROH_SERVER"/>
+                            </userData>
+                        </ToggleButton>
                     </buttons>
                 </SegmentedButton>
             </Field>
@@ -173,6 +181,14 @@
             <Field text="Proxy URL:">
                 <TextField fx:id="proxyHost" promptText="e.g. 127.0.0.1" />
                 <TextField fx:id="proxyPort" maxWidth="120" promptText="e.g. 9050/9150" />
+            </Field>
+        </Fieldset>
+    </Form>
+
+    <Form fx:id="irohForm" GridPane.columnIndex="0" GridPane.rowIndex="1">
+        <Fieldset text="Iroh P2P Server">
+            <Field text="Node ID:">
+                <ComboBoxTextField fx:id="irohNodeId" promptText="e.g. 6ba25662..." comboProperty="$recentElectrumServers" />
             </Field>
         </Fieldset>
     </Form>

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
@@ -188,7 +188,10 @@
     <Form fx:id="irohForm" GridPane.columnIndex="0" GridPane.rowIndex="1">
         <Fieldset text="Iroh P2P Server">
             <Field text="Node ID:">
-                <ComboBoxTextField fx:id="irohNodeId" promptText="e.g. 6ba25662..." comboProperty="$recentElectrumServers" />
+                <StackPane>
+                    <ComboBox fx:id="recentIrohServers" />
+                    <ComboBoxTextField fx:id="irohNodeId" promptText="e.g. 6ba25662583545b9e3c4d47de6364d509..." comboProperty="$recentIrohServers" />
+                </StackPane>
             </Field>
         </Fieldset>
     </Form>


### PR DESCRIPTION
## Summary

Adds support for connecting to a private Electrum server (electrs/Fulcrum) 
via Iroh QUIC P2P transport, without requiring TCP port forwarding, Tor, or VPN.

The user only needs to enter the server's Iroh Node ID (64-char hex string).
Sparrow spawns `iroh-electrum-bridge` as a subprocess and connects through it.

## Motivation

Users running their own Bitcoin node at home (Start9, Umbrel, RaspiBlitz etc.)
currently need to either:
- Open ports on their router (security risk)
- Run Tor (slow, complex)
- Set up a VPN (complex)

With Iroh P2P, the connection works automatically from anywhere, with no 
configuration beyond installing the bridge binary.

## Changes

- `ServerType.IROH_SERVER` — new server type
- `Protocol.IROH` — new protocol (`iroh://` prefix, `:i` suffix)
- `IrohTransport` — extends `TcpTransport`, spawns bridge subprocess
- `Config` — `recentIrohServers` list
- `server.fxml` — new "Iroh..." toggle button and "Iroh P2P Server" form
- `ServerSettingsController` — full Iroh UI handling

## Requirements

The `iroh-electrum-bridge` binary must be on PATH or next to the Sparrow jar.
Source: https://github.com/rueckwaerts/iroh-electrum-bridge

The server must run electrs with Iroh support:
https://github.com/rueckwaerts/electrs (branch: iroh-test)

## Testing

Tested: Sparrow → Iroh relay → electrs on Start9, from outside home network.
Connected to electrs/0.11.1 on protocol version 1.4 ✓