### PR TITLE
Verify scanned or loaded transactions match the originating PSBT

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -614,6 +614,10 @@ public class AppController implements Initializable {
     }
 
     public void openTransactionFromFile(ActionEvent event) {
+        openTransactionFromFile(event, null);
+    }
+
+    private void openTransactionFromFile(ActionEvent event, PSBT contextPsbt) {
         Stage window = new Stage();
 
         FileChooser fileChooser = new FileChooser();
@@ -628,19 +632,25 @@ public class AppController implements Initializable {
         List<File> files = fileChooser.showOpenMultipleDialog(window);
         if(files != null) {
             for(File file : files) {
-                openTransactionFile(file);
+                openTransactionFile(file, contextPsbt);
             }
         }
     }
 
     private void openTransactionFile(File file) {
-        for(Tab tab : tabs.getTabs()) {
-            TabData tabData = (TabData)tab.getUserData();
-            if(tabData instanceof TransactionTabData) {
-                TransactionTabData transactionTabData = (TransactionTabData)tabData;
-                if(file.equals(transactionTabData.getFile())) {
-                    tabs.getSelectionModel().select(tab);
-                    return;
+        openTransactionFile(file, null);
+    }
+
+    private void openTransactionFile(File file, PSBT contextPsbt) {
+        if(contextPsbt == null) {
+            for(Tab tab : tabs.getTabs()) {
+                TabData tabData = (TabData)tab.getUserData();
+                if(tabData instanceof TransactionTabData) {
+                    TransactionTabData transactionTabData = (TransactionTabData)tabData;
+                    if(file.equals(transactionTabData.getFile())) {
+                        tabs.getSelectionModel().select(tab);
+                        return;
+                    }
                 }
             }
         }
@@ -651,9 +661,9 @@ public class AppController implements Initializable {
                 String name = file.getName();
 
                 if(Utils.isHex(bytes) || Utils.isBase64(bytes)) {
-                    addTransactionTab(name, file, new String(bytes, StandardCharsets.UTF_8).trim());
+                    addTransactionTab(name, file, new String(bytes, StandardCharsets.UTF_8).trim(), contextPsbt);
                 } else {
-                    addTransactionTab(name, file, bytes);
+                    addTransactionTab(name, file, bytes, contextPsbt);
                 }
             } catch(IOException e) {
                 showErrorDialog("Error opening file", e.getMessage());
@@ -1932,24 +1942,40 @@ public class AppController implements Initializable {
     }
 
     private void addTransactionTab(String name, File file, String string) throws ParseException, PSBTParseException, TransactionParseException {
+        addTransactionTab(name, file, string, null);
+    }
+
+    private void addTransactionTab(String name, File file, String string, PSBT contextPsbt) throws ParseException, PSBTParseException, TransactionParseException {
         if(Utils.isBase64(string) && !Utils.isHex(string)) {
-            addTransactionTab(name, file, Base64.getDecoder().decode(string));
+            addTransactionTab(name, file, Base64.getDecoder().decode(string), contextPsbt);
         } else if(Utils.isHex(string)) {
-            addTransactionTab(name, file, Utils.hexToBytes(string));
+            addTransactionTab(name, file, Utils.hexToBytes(string), contextPsbt);
         } else {
             throw new ParseException("Input is not base64 or hex", 0);
         }
     }
 
     private void addTransactionTab(String name, File file, byte[] bytes) throws PSBTParseException, ParseException, TransactionParseException {
+        addTransactionTab(name, file, bytes, null);
+    }
+
+    private void addTransactionTab(String name, File file, byte[] bytes, PSBT contextPsbt) throws PSBTParseException, ParseException, TransactionParseException {
         if(PSBT.isPSBT(bytes)) {
             //Don't verify signatures here - provided PSBT may omit UTXO data that can be found when combining with an existing PSBT
             PSBT psbt = new PSBT(bytes, false);
-            addTransactionTab(name, file, psbt);
+            if(contextPsbt == null || contextPsbt.matches(psbt)) {
+                addTransactionTab(name, file, psbt);
+            } else {
+                AppServices.showErrorDialog("Mismatched Transaction", "The loaded transaction does not match the transaction in this tab.\n\nCheck that the correct transaction was signed and exported from the signing device.");
+            }
         } else if(Transaction.isTransaction(bytes)) {
             try {
                 Transaction transaction = new Transaction(bytes);
-                addTransactionTab(name, file, transaction);
+                if(contextPsbt == null || AppServices.psbtMatchesTransaction(contextPsbt, transaction)) {
+                    addTransactionTab(name, file, transaction);
+                } else {
+                    AppServices.showErrorDialog("Mismatched Transaction", "The loaded transaction does not match the transaction in this tab.\n\nCheck that the correct transaction was signed and exported from the signing device.");
+                }
             } catch(Exception e) {
                 throw new TransactionParseException(e.getMessage());
             }
@@ -3290,9 +3316,9 @@ public class AppController implements Initializable {
     public void requestTransactionOpen(RequestTransactionOpenEvent event) {
         if(tabs.getScene().getWindow().equals(event.getWindow())) {
             if(event.getFile() != null) {
-                openTransactionFile(event.getFile());
+                openTransactionFile(event.getFile(), event.getContextPsbt());
             } else {
-                openTransactionFromFile(null);
+                openTransactionFromFile(null, event.getContextPsbt());
             }
         }
     }

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -18,8 +18,11 @@ import com.sparrowwallet.sparrow.control.WalletPasswordDialog;
 import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
 import com.sparrowwallet.sparrow.net.Auth47;
 import com.sparrowwallet.drongo.protocol.BlockHeader;
+import com.sparrowwallet.drongo.protocol.Script;
 import com.sparrowwallet.drongo.protocol.ScriptType;
 import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionInput;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
 import com.sparrowwallet.drongo.psbt.PSBT;
 import com.sparrowwallet.drongo.uri.BitcoinURI;
 import com.sparrowwallet.sparrow.control.TrayManager;
@@ -719,6 +722,22 @@ public class AppServices {
     public Window getWindowForPSBT(PSBT psbt) {
         Optional<Window> optWindow = walletWindows.entrySet().stream().filter(entry -> entry.getValue().stream().anyMatch(walletTabData -> walletTabData.getWallet().canSign(psbt))).map(Map.Entry::getKey).findFirst();
         return optWindow.orElse(null);
+    }
+
+    public static boolean psbtMatchesTransaction(PSBT psbt, Transaction transaction) {
+        //Compare against a copy with empty scriptSigs, since a signed non-segwit transaction will have a different txid to the PSBT transaction
+        Transaction unsigned = new Transaction();
+        unsigned.setVersion(transaction.getVersion());
+        unsigned.setLocktime(transaction.getLocktime());
+        for(TransactionInput txInput : transaction.getInputs()) {
+            TransactionInput unsignedInput = unsigned.addInput(txInput.getOutpoint().getHash(), txInput.getOutpoint().getIndex(), new Script(new byte[0]));
+            unsignedInput.setSequenceNumber(txInput.getSequenceNumber());
+        }
+        for(TransactionOutput txOutput : transaction.getOutputs()) {
+            unsigned.addOutput(txOutput.getValue(), txOutput.getScript());
+        }
+
+        return psbt.getTransaction().getTxId().equals(unsigned.getTxId()) || psbt.possibleUnverifiableSilentPaymentsTransaction(transaction);
     }
 
     public double getWalletWindowMaxX() {

--- a/src/main/java/com/sparrowwallet/sparrow/event/RequestTransactionOpenEvent.java
+++ b/src/main/java/com/sparrowwallet/sparrow/event/RequestTransactionOpenEvent.java
@@ -1,5 +1,6 @@
 package com.sparrowwallet.sparrow.event;
 
+import com.sparrowwallet.drongo.psbt.PSBT;
 import javafx.stage.Window;
 
 import java.io.File;
@@ -10,15 +11,20 @@ import java.io.File;
 public class RequestTransactionOpenEvent {
     private final Window window;
     private final File file;
+    private final PSBT contextPsbt;
 
     public RequestTransactionOpenEvent(Window window) {
-        this.window = window;
-        this.file = null;
+        this(window, null, null);
     }
 
     public RequestTransactionOpenEvent(Window window, File file) {
+        this(window, file, null);
+    }
+
+    public RequestTransactionOpenEvent(Window window, File file, PSBT contextPsbt) {
         this.window = window;
         this.file = file;
+        this.contextPsbt = contextPsbt;
     }
 
     public Window getWindow() {
@@ -27,5 +33,9 @@ public class RequestTransactionOpenEvent {
 
     public File getFile() {
         return file;
+    }
+
+    public PSBT getContextPsbt() {
+        return contextPsbt;
     }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -1037,9 +1037,17 @@ public class HeadersController extends TransactionFormController implements Init
         if(optionalResult.isPresent()) {
             QRScanDialog.Result result = optionalResult.get();
             if(result.transaction != null) {
-                EventManager.get().post(new ViewTransactionEvent(toggleButton.getScene().getWindow(), result.transaction));
+                if(AppServices.psbtMatchesTransaction(headersForm.getPsbt(), result.transaction)) {
+                    EventManager.get().post(new ViewTransactionEvent(toggleButton.getScene().getWindow(), result.transaction));
+                } else {
+                    AppServices.showErrorDialog("Mismatched Transaction", "The scanned transaction does not match the transaction in this tab.\n\nCheck that the correct transaction was signed and exported from the signing device.");
+                }
             } else if(result.psbt != null) {
-                EventManager.get().post(new ViewPSBTEvent(toggleButton.getScene().getWindow(), null, null, result.psbt));
+                if(headersForm.getPsbt().matches(result.psbt)) {
+                    EventManager.get().post(new ViewPSBTEvent(toggleButton.getScene().getWindow(), null, null, result.psbt));
+                } else {
+                    AppServices.showErrorDialog("Mismatched Transaction", "The scanned transaction does not match the transaction in this tab.\n\nCheck that the correct transaction was signed and exported from the signing device.");
+                }
             } else if(result.seed != null) {
                 signFromSeed(result.seed);
             } else if(result.exception != null) {
@@ -1110,7 +1118,7 @@ public class HeadersController extends TransactionFormController implements Init
         ToggleButton toggleButton = (ToggleButton)event.getSource();
         toggleButton.setSelected(false);
 
-        EventManager.get().post(new RequestTransactionOpenEvent(toggleButton.getScene().getWindow()));
+        EventManager.get().post(new RequestTransactionOpenEvent(toggleButton.getScene().getWindow(), null, headersForm.getPsbt()));
     }
 
     public void signPSBT(ActionEvent event) {

--- a/src/test/java/com/sparrowwallet/sparrow/AppServicesTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/AppServicesTest.java
@@ -1,0 +1,47 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionInput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.Utils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AppServicesTest {
+    private Transaction buildTransaction(byte[] scriptSig, long outputValue) {
+        Transaction tx = new Transaction();
+        tx.setVersion(2);
+        tx.setLocktime(850000);
+        TransactionInput input = tx.addInput(Sha256Hash.wrap(Utils.hexToBytes("aa00000000000000000000000000000000000000000000000000000000000011")), 1, new Script(scriptSig));
+        input.setSequenceNumber(0xfffffffdL);
+        tx.addOutput(outputValue, new Script(Utils.hexToBytes("76a914000000000000000000000000000000000000000088ac")));
+        return tx;
+    }
+
+    @Test
+    public void signedLegacyTransactionMatchesSourcePsbt() {
+        PSBT psbt = new PSBT(buildTransaction(new byte[0], 12345L));
+        Transaction signedTx = buildTransaction(Utils.hexToBytes("483045022100aa11"), 12345L);
+
+        Assertions.assertNotEquals(psbt.getTransaction().getTxId(), signedTx.getTxId(), "Legacy signed txid should differ from unsigned txid");
+        Assertions.assertTrue(AppServices.psbtMatchesTransaction(psbt, signedTx));
+    }
+
+    @Test
+    public void tamperedTransactionDoesNotMatchSourcePsbt() {
+        PSBT psbt = new PSBT(buildTransaction(new byte[0], 12345L));
+        Transaction tamperedTx = buildTransaction(Utils.hexToBytes("483045022100aa11"), 99999L);
+
+        Assertions.assertFalse(AppServices.psbtMatchesTransaction(psbt, tamperedTx));
+    }
+
+    @Test
+    public void unsignedTransactionMatchesSourcePsbt() {
+        PSBT psbt = new PSBT(buildTransaction(new byte[0], 12345L));
+        Transaction sameTx = buildTransaction(new byte[0], 12345L);
+
+        Assertions.assertTrue(AppServices.psbtMatchesTransaction(psbt, sameTx));
+    }
+}


### PR DESCRIPTION
When a transaction tab's Scan QR or Load Transaction buttons (or the scan button on the Show QR dialog) are used to import a signed transaction, verify it matches the transaction in the tab instead of opening a new tab on mismatch, where the discrepancy could go unnoticed before broadcasting.