### PR TITLE
Support XDG base directory specification

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -525,7 +525,7 @@ public class AppController implements Initializable {
     }
 
     public void showLogFile(ActionEvent event) throws IOException {
-        File logFile = new File(SparrowDirectories.getSparrowHomeDirs().state(), "sparrow.log");
+        File logFile = new File(SparrowDirectories.getHomeDirs().state(), "sparrow.log");
         if(logFile.exists()) {
             AppServices.get().getApplication().getHostServices().showDocument(logFile.toPath().toUri().toString());
         } else {
@@ -1042,7 +1042,7 @@ public class AppController implements Initializable {
         DirectoryChooser directoryChooser = new DirectoryChooser();
         directoryChooser.setTitle("Choose Sparrow Home Folder");
         directoryChooser.setInitialDirectory(initialDir == null || !initialDir.exists()
-                ? SparrowDirectories.getSparrowHomeDirs().config()
+                ? SparrowDirectories.getHomeDirs().config()
                 : initialDir);
         File newHome = directoryChooser.showDialog(window);
 

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -524,7 +524,7 @@ public class AppController implements Initializable {
     }
 
     public void showLogFile(ActionEvent event) throws IOException {
-        File logFile = new File(Storage.getSparrowHome(), "sparrow.log");
+        File logFile = new File(Storage.getSparrowStateHome(), "sparrow.log");
         if(logFile.exists()) {
             AppServices.get().getApplication().getHostServices().showDocument(logFile.toPath().toUri().toString());
         } else {
@@ -1040,7 +1040,7 @@ public class AppController implements Initializable {
         Stage window = new Stage();
         DirectoryChooser directoryChooser = new DirectoryChooser();
         directoryChooser.setTitle("Choose Sparrow Home Folder");
-        directoryChooser.setInitialDirectory(initialDir == null || !initialDir.exists() ? Storage.getSparrowHome() : initialDir);
+        directoryChooser.setInitialDirectory(initialDir == null || !initialDir.exists() ? Storage.getSparrowConfigHome() : initialDir);
         File newHome = directoryChooser.showDialog(window);
 
         if(newHome != null) {

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -18,6 +18,7 @@ import com.sparrowwallet.sparrow.control.*;
 import com.sparrowwallet.sparrow.event.*;
 import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
 import com.sparrowwallet.sparrow.io.*;
+import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
 import com.sparrowwallet.sparrow.io.bbqr.BBQR;
 import com.sparrowwallet.sparrow.io.bbqr.BBQRType;
 import com.sparrowwallet.sparrow.net.ElectrumServer;
@@ -524,7 +525,7 @@ public class AppController implements Initializable {
     }
 
     public void showLogFile(ActionEvent event) throws IOException {
-        File logFile = new File(Storage.getSparrowStateHome(), "sparrow.log");
+        File logFile = new File(SparrowDirectories.getSparrowHomeDirs().state(), "sparrow.log");
         if(logFile.exists()) {
             AppServices.get().getApplication().getHostServices().showDocument(logFile.toPath().toUri().toString());
         } else {
@@ -1040,7 +1041,9 @@ public class AppController implements Initializable {
         Stage window = new Stage();
         DirectoryChooser directoryChooser = new DirectoryChooser();
         directoryChooser.setTitle("Choose Sparrow Home Folder");
-        directoryChooser.setInitialDirectory(initialDir == null || !initialDir.exists() ? Storage.getSparrowConfigHome() : initialDir);
+        directoryChooser.setInitialDirectory(initialDir == null || !initialDir.exists()
+                ? SparrowDirectories.getSparrowHomeDirs().config()
+                : initialDir);
         File newHome = directoryChooser.showDialog(window);
 
         if(newHome != null) {

--- a/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
@@ -71,17 +71,17 @@ public class SparrowWallet {
             }
         }
 
-        File testnetFlag = new File(Storage.getSparrowHome(), "network-" + Network.TESTNET.getName());
+        File testnetFlag = new File(Storage.getSparrowStateHome(), "network-" + Network.TESTNET.getName());
         if(testnetFlag.exists()) {
             Network.set(Network.TESTNET);
         }
 
-        File testnet4Flag = new File(Storage.getSparrowHome(), "network-" + Network.TESTNET4.getName());
+        File testnet4Flag = new File(Storage.getSparrowStateHome(), "network-" + Network.TESTNET4.getName());
         if(testnet4Flag.exists()) {
             Network.set(Network.TESTNET4);
         }
 
-        File signetFlag = new File(Storage.getSparrowHome(), "network-" + Network.SIGNET.getName());
+        File signetFlag = new File(Storage.getSparrowStateHome(), "network-" + Network.SIGNET.getName());
         if(signetFlag.exists()) {
             Network.set(Network.SIGNET);
         }

--- a/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
@@ -71,17 +71,17 @@ public class SparrowWallet {
             }
         }
 
-        File testnetFlag = new File(SparrowDirectories.getSparrowHomeDirs().state(), "network-" + Network.TESTNET.getName());
+        File testnetFlag = new File(SparrowDirectories.getHomeDirs().state(), "network-" + Network.TESTNET.getName());
         if(testnetFlag.exists()) {
             Network.set(Network.TESTNET);
         }
 
-        File testnet4Flag = new File(SparrowDirectories.getSparrowHomeDirs().state(), "network-" + Network.TESTNET4.getName());
+        File testnet4Flag = new File(SparrowDirectories.getHomeDirs().state(), "network-" + Network.TESTNET4.getName());
         if(testnet4Flag.exists()) {
             Network.set(Network.TESTNET4);
         }
 
-        File signetFlag = new File(SparrowDirectories.getSparrowHomeDirs().state(), "network-" + Network.SIGNET.getName());
+        File signetFlag = new File(SparrowDirectories.getHomeDirs().state(), "network-" + Network.SIGNET.getName());
         if(signetFlag.exists()) {
             Network.set(Network.SIGNET);
         }

--- a/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
@@ -3,7 +3,7 @@ package com.sparrowwallet.sparrow;
 import com.beust.jcommander.JCommander;
 import com.sparrowwallet.drongo.Drongo;
 import com.sparrowwallet.drongo.Network;
-import com.sparrowwallet.sparrow.io.Storage;
+import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
 import com.sparrowwallet.sparrow.instance.InstanceException;
 import com.sparrowwallet.sparrow.instance.InstanceList;
 import com.sparrowwallet.sparrow.terminal.SparrowTerminal;
@@ -71,17 +71,17 @@ public class SparrowWallet {
             }
         }
 
-        File testnetFlag = new File(Storage.getSparrowStateHome(), "network-" + Network.TESTNET.getName());
+        File testnetFlag = new File(SparrowDirectories.getSparrowHomeDirs().state(), "network-" + Network.TESTNET.getName());
         if(testnetFlag.exists()) {
             Network.set(Network.TESTNET);
         }
 
-        File testnet4Flag = new File(Storage.getSparrowStateHome(), "network-" + Network.TESTNET4.getName());
+        File testnet4Flag = new File(SparrowDirectories.getSparrowHomeDirs().state(), "network-" + Network.TESTNET4.getName());
         if(testnet4Flag.exists()) {
             Network.set(Network.TESTNET4);
         }
 
-        File signetFlag = new File(Storage.getSparrowStateHome(), "network-" + Network.SIGNET.getName());
+        File signetFlag = new File(SparrowDirectories.getSparrowHomeDirs().state(), "network-" + Network.SIGNET.getName());
         if(signetFlag.exists()) {
             Network.set(Network.SIGNET);
         }

--- a/src/main/java/com/sparrowwallet/sparrow/instance/Instance.java
+++ b/src/main/java/com/sparrowwallet/sparrow/instance/Instance.java
@@ -164,7 +164,7 @@ public abstract class Instance {
             }
         }
 
-        return Storage.getSparrowDir().toPath().resolve(applicationId + ".lock");
+        return Storage.getSparrowStateDir().toPath().resolve(applicationId + ".lock");
     }
 
     private void createSymlink(Path lockFile) {
@@ -194,7 +194,7 @@ public abstract class Instance {
         }
 
         try {
-            File sparrowHome = Storage.getSparrowHome(true);
+            File sparrowHome = Storage.getSparrowStateHome(true);
             if(!sparrowHome.exists()) {
                 Storage.createOwnerOnlyDirectory(sparrowHome);
                 sparrowHome.deleteOnExit(); //Will only delete on exit if empty

--- a/src/main/java/com/sparrowwallet/sparrow/instance/Instance.java
+++ b/src/main/java/com/sparrowwallet/sparrow/instance/Instance.java
@@ -1,6 +1,8 @@
 package com.sparrowwallet.sparrow.instance;
 
 import com.sparrowwallet.sparrow.io.Storage;
+import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,7 +166,7 @@ public abstract class Instance {
             }
         }
 
-        return Storage.getSparrowStateDir().toPath().resolve(applicationId + ".lock");
+        return SparrowDirectories.getSparrowHomeDirs().state().toPath().resolve(applicationId + ".lock");
     }
 
     private void createSymlink(Path lockFile) {
@@ -194,7 +196,7 @@ public abstract class Instance {
         }
 
         try {
-            File sparrowHome = Storage.getSparrowStateHome(true);
+            File sparrowHome = SparrowDirectories.getSparrowHomeDirs(true).state();
             if(!sparrowHome.exists()) {
                 Storage.createOwnerOnlyDirectory(sparrowHome);
                 sparrowHome.deleteOnExit(); //Will only delete on exit if empty

--- a/src/main/java/com/sparrowwallet/sparrow/instance/Instance.java
+++ b/src/main/java/com/sparrowwallet/sparrow/instance/Instance.java
@@ -166,7 +166,7 @@ public abstract class Instance {
             }
         }
 
-        return SparrowDirectories.getSparrowHomeDirs().state().toPath().resolve(applicationId + ".lock");
+        return SparrowDirectories.getHomeDirs().state().toPath().resolve(applicationId + ".lock");
     }
 
     private void createSymlink(Path lockFile) {
@@ -196,7 +196,7 @@ public abstract class Instance {
         }
 
         try {
-            File sparrowHome = SparrowDirectories.getSparrowHomeDirs(true).state();
+            File sparrowHome = SparrowDirectories.getHomeDirs(true).state();
             if(!sparrowHome.exists()) {
                 Storage.createOwnerOnlyDirectory(sparrowHome);
                 sparrowHome.deleteOnExit(); //Will only delete on exit if empty

--- a/src/main/java/com/sparrowwallet/sparrow/io/Config.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Config.java
@@ -109,7 +109,7 @@ public class Config {
     }
 
     private static File getConfigFile() {
-        File sparrowDir = SparrowDirectories.getSparrowDirs().config();
+        File sparrowDir = SparrowDirectories.getDirectories().config();
         return new File(sparrowDir, CONFIG_FILENAME);
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/io/Config.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Config.java
@@ -108,7 +108,7 @@ public class Config {
     }
 
     private static File getConfigFile() {
-        File sparrowDir = Storage.getSparrowDir();
+        File sparrowDir = Storage.getSparrowConfigDir();
         return new File(sparrowDir, CONFIG_FILENAME);
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/io/Config.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Config.java
@@ -9,6 +9,7 @@ import com.sparrowwallet.sparrow.Theme;
 import com.sparrowwallet.sparrow.control.QRDensity;
 import com.sparrowwallet.sparrow.control.QREncoding;
 import com.sparrowwallet.sparrow.control.WebcamResolution;
+import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
 import com.sparrowwallet.sparrow.net.*;
 import com.sparrowwallet.sparrow.wallet.FeeRatesSelection;
 import com.sparrowwallet.sparrow.wallet.OptimizationStrategy;
@@ -108,7 +109,7 @@ public class Config {
     }
 
     private static File getConfigFile() {
-        File sparrowDir = Storage.getSparrowConfigDir();
+        File sparrowDir = SparrowDirectories.getSparrowDirs().config();
         return new File(sparrowDir, CONFIG_FILENAME);
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/io/Hwi.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Hwi.java
@@ -269,7 +269,7 @@ public class Hwi {
     private static void deleteHwiDir() {
         try {
             if(OsType.getCurrent() == OsType.MACOS || OsType.getCurrent() == OsType.WINDOWS) {
-                File hwiHomeDir = new File(Storage.getSparrowDir(), HWI_HOME_DIR);
+                File hwiHomeDir = new File(Storage.getSparrowDataDir(), HWI_HOME_DIR);
                 if(hwiHomeDir.exists()) {
                     IOUtils.deleteDirectory(hwiHomeDir);
                 }
@@ -544,7 +544,7 @@ public class Hwi {
         private BitBoxPairingDialog pairingDialog;
 
         public BitBoxFxNoiseConfig() {
-            super(Path.of(Storage.getSparrowHome().getAbsolutePath(), LARK_HOME_DIR, BITBOX_FILENAME).toFile());
+            super(Path.of(Storage.getSparrowDataHome().getAbsolutePath(), LARK_HOME_DIR, BITBOX_FILENAME).toFile());
         }
 
         @Override
@@ -594,7 +594,7 @@ public class Hwi {
         private String deviceInfo;
 
         public TrezorFxNoiseConfig() {
-            super(Path.of(Storage.getSparrowHome().getAbsolutePath(), LARK_HOME_DIR, TREZOR_FILENAME).toFile());
+            super(Path.of(Storage.getSparrowDataHome().getAbsolutePath(), LARK_HOME_DIR, TREZOR_FILENAME).toFile());
         }
 
         @Override

--- a/src/main/java/com/sparrowwallet/sparrow/io/Hwi.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Hwi.java
@@ -17,6 +17,8 @@ import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.SparrowWallet;
 import com.sparrowwallet.sparrow.control.BitBoxPairingDialog;
 import com.sparrowwallet.sparrow.control.TextfieldDialog;
+import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
+
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
@@ -269,7 +271,7 @@ public class Hwi {
     private static void deleteHwiDir() {
         try {
             if(OsType.getCurrent() == OsType.MACOS || OsType.getCurrent() == OsType.WINDOWS) {
-                File hwiHomeDir = new File(Storage.getSparrowDataDir(), HWI_HOME_DIR);
+                File hwiHomeDir = new File(SparrowDirectories.getSparrowDirs().data(), HWI_HOME_DIR);
                 if(hwiHomeDir.exists()) {
                     IOUtils.deleteDirectory(hwiHomeDir);
                 }
@@ -544,7 +546,7 @@ public class Hwi {
         private BitBoxPairingDialog pairingDialog;
 
         public BitBoxFxNoiseConfig() {
-            super(Path.of(Storage.getSparrowDataHome().getAbsolutePath(), LARK_HOME_DIR, BITBOX_FILENAME).toFile());
+            super(Path.of(SparrowDirectories.getSparrowHomeDirs().data().getAbsolutePath(), LARK_HOME_DIR, BITBOX_FILENAME).toFile());
         }
 
         @Override
@@ -594,7 +596,7 @@ public class Hwi {
         private String deviceInfo;
 
         public TrezorFxNoiseConfig() {
-            super(Path.of(Storage.getSparrowDataHome().getAbsolutePath(), LARK_HOME_DIR, TREZOR_FILENAME).toFile());
+            super(Path.of(SparrowDirectories.getSparrowHomeDirs().data().getAbsolutePath(), LARK_HOME_DIR, TREZOR_FILENAME).toFile());
         }
 
         @Override

--- a/src/main/java/com/sparrowwallet/sparrow/io/Hwi.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Hwi.java
@@ -271,7 +271,7 @@ public class Hwi {
     private static void deleteHwiDir() {
         try {
             if(OsType.getCurrent() == OsType.MACOS || OsType.getCurrent() == OsType.WINDOWS) {
-                File hwiHomeDir = new File(SparrowDirectories.getSparrowDirs().data(), HWI_HOME_DIR);
+                File hwiHomeDir = new File(SparrowDirectories.getDirectories().data(), HWI_HOME_DIR);
                 if(hwiHomeDir.exists()) {
                     IOUtils.deleteDirectory(hwiHomeDir);
                 }
@@ -546,7 +546,7 @@ public class Hwi {
         private BitBoxPairingDialog pairingDialog;
 
         public BitBoxFxNoiseConfig() {
-            super(Path.of(SparrowDirectories.getSparrowHomeDirs().data().getAbsolutePath(), LARK_HOME_DIR, BITBOX_FILENAME).toFile());
+            super(Path.of(SparrowDirectories.getHomeDirs().data().getAbsolutePath(), LARK_HOME_DIR, BITBOX_FILENAME).toFile());
         }
 
         @Override
@@ -596,7 +596,7 @@ public class Hwi {
         private String deviceInfo;
 
         public TrezorFxNoiseConfig() {
-            super(Path.of(SparrowDirectories.getSparrowHomeDirs().data().getAbsolutePath(), LARK_HOME_DIR, TREZOR_FILENAME).toFile());
+            super(Path.of(SparrowDirectories.getHomeDirs().data().getAbsolutePath(), LARK_HOME_DIR, TREZOR_FILENAME).toFile());
         }
 
         @Override

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -504,7 +504,7 @@ public class Storage {
             }
         }
         if(walletsDir == null) {
-            walletsDir = new File(getSparrowDataDir(), WALLETS_DIR);
+            walletsDir = new File(SparrowDirectories.getSparrowDirs().data(), WALLETS_DIR);
         }
         if(!walletsDir.exists()) {
             createOwnerOnlyDirectory(walletsDir);
@@ -559,128 +559,12 @@ public class Storage {
     }
 
     static File getCertsDir() {
-        File certsDir = new File(getSparrowDataDir(), CERTS_DIR);
+        File certsDir = new File(SparrowDirectories.getSparrowDirs().data(), CERTS_DIR);
         if(!certsDir.exists()) {
             createOwnerOnlyDirectory(certsDir);
         }
 
         return certsDir;
-    }
-
-    public static File getSparrowConfigDir() {
-        return getSparrowDirs().config();
-    }
-
-    public static File getSparrowDataDir() {
-        return getSparrowDirs().data();
-    }
-
-    public static File getSparrowCacheDir() {
-        return getSparrowDirs().cache();
-    }
-
-    public static File getSparrowStateDir() {
-        return getSparrowDirs().state();
-    }
-
-    static SparrowDirectories getSparrowDirs() {
-        SparrowDirectories sparrowHomeDirs = getSparrowHome();
-        Map<String, File> sparrowHomeMap = sparrowHomeDirs.asMap();
-        SparrowDirectories sparrowFinalDirs;
-        Network network = Network.get();
-
-        if(network != Network.MAINNET) {
-            sparrowFinalDirs = SparrowDirectories.append(sparrowHomeDirs, network.getHome());
-            if(!network.getName().equals(network.getHome())) {
-                for(Map.Entry<String, File> entry : sparrowFinalDirs.asMap().entrySet()) {
-                    String dirTypeKey = entry.getKey();
-                    File sparrowDir = entry.getValue();
-                    if(!sparrowDir.exists()) {
-                        File networkNameDir = new File(sparrowHomeMap.get(dirTypeKey), network.getName());
-                        if(networkNameDir.exists() && networkNameDir.isDirectory() && !Files.isSymbolicLink(networkNameDir.toPath())) {
-                            try {
-                                if(networkNameDir.renameTo(sparrowDir) && !isWindows()) {
-                                    Files.createSymbolicLink(networkNameDir.toPath(), Path.of(sparrowDir.getName()));
-                                }
-                            } catch(Exception e) {
-                                log.debug("Error creating symlink from " + networkNameDir.getAbsolutePath() + " to " + sparrowDir.getName(), e);
-                             }
-                        }
-                    }
-                }
-            }
-        } else {
-            sparrowFinalDirs = sparrowHomeDirs;
-        }
-
-        for(File sparrowDir : sparrowFinalDirs.asMap().values()) {
-            if(!sparrowDir.exists()) {
-                createOwnerOnlyDirectory(sparrowDir);
-            }
-        }
-
-        if(!network.getName().equals(network.getHome()) && !isWindows()) {
-            for(Map.Entry<String, File> entry : sparrowFinalDirs.asMap().entrySet()) {
-                String dirTypeKey = entry.getKey();
-                File sparrowDir = entry.getValue();
-                try {
-                    Path networkNamePath = sparrowHomeMap.get(dirTypeKey).toPath().resolve(network.getName());
-                    if(Files.isSymbolicLink(networkNamePath)) {
-                        Path symlinkTarget = sparrowHomeMap.get(dirTypeKey).toPath().resolve(Files.readSymbolicLink(networkNamePath));
-                        if(!Files.isSameFile(sparrowDir.toPath(), symlinkTarget)) {
-                            Files.delete(networkNamePath);
-                            Files.createSymbolicLink(networkNamePath, Path.of(sparrowDir.getName()));
-                        }
-                    } else if(!Files.exists(networkNamePath)) {
-                        Files.createSymbolicLink(networkNamePath, Path.of(sparrowDir.getName()));
-                    }
-                } catch(Exception e) {
-                    log.debug("Error updating symlink from " + network.getName() + " to " + sparrowDir.getName(), e);
-                }
-            }
-        }
-
-        return sparrowFinalDirs;
-    }
-
-    public static File getSparrowConfigHome() {
-        return getSparrowHome().config();
-    }
-
-    public static File getSparrowDataHome() {
-        return getSparrowHome().data();
-    }
-
-    public static File getSparrowStateHome() {
-        return getSparrowHome().state();
-    }
-
-    public static File getSparrowCacheHome() {
-        return getSparrowHome().cache();
-    }
-
-    static SparrowDirectories getSparrowHome() {
-        return SparrowDirectories.getSparrowDirs(false);
-    }
-
-    public static File getSparrowConfigHome(boolean useDefault) {
-        return SparrowDirectories.getSparrowDirs(useDefault).config();
-    }
-
-    public static File getSparrowDataHome(boolean useDefault) {
-        return SparrowDirectories.getSparrowDirs(useDefault).data();
-    }
-
-    public static File getSparrowStateHome(boolean useDefault) {
-        return SparrowDirectories.getSparrowDirs(useDefault).state();
-    }
-
-    public static File getSparrowCacheHome(boolean useDefault) {
-        return SparrowDirectories.getSparrowDirs(useDefault).cache();
-    }
-
-    static SparrowDirectories getSparrowHome(boolean useDefault) {
-        return SparrowDirectories.getSparrowDirs(useDefault);
     }
 
     static File getHomeDir() {
@@ -938,7 +822,11 @@ public class Storage {
             return false;
         }
 
-        public static SparrowDirectories getSparrowDirs(boolean useDefault) {
+        public static SparrowDirectories getSparrowHomeDirs() {
+            return SparrowDirectories.getSparrowHomeDirs(false);
+        }
+
+        public static SparrowDirectories getSparrowHomeDirs(boolean useDefault) {
             if(!useDefault && System.getProperty(SparrowWallet.APP_HOME_PROPERTY) != null) {
                 File appHomePropertyDir = new File(System.getProperty(SparrowWallet.APP_HOME_PROPERTY));
                 return fromSingleDir(appHomePropertyDir);
@@ -950,6 +838,66 @@ public class Storage {
             }
 
             return fromSingleDir(new File(homeDir, SPARROW_DIR));
+        }
+
+        static SparrowDirectories getSparrowDirs() {
+            SparrowDirectories sparrowHomeDirs = SparrowDirectories.getSparrowHomeDirs(false);
+            Map<String, File> sparrowHomeMap = sparrowHomeDirs.asMap();
+            SparrowDirectories sparrowFinalDirs;
+            Network network = Network.get();
+
+            if(network != Network.MAINNET) {
+                sparrowFinalDirs = SparrowDirectories.append(sparrowHomeDirs, network.getHome());
+                if(!network.getName().equals(network.getHome())) {
+                    for(Map.Entry<String, File> entry : sparrowFinalDirs.asMap().entrySet()) {
+                        String dirTypeKey = entry.getKey();
+                        File sparrowDir = entry.getValue();
+                        if(!sparrowDir.exists()) {
+                            File networkNameDir = new File(sparrowHomeMap.get(dirTypeKey), network.getName());
+                            if(networkNameDir.exists() && networkNameDir.isDirectory() && !Files.isSymbolicLink(networkNameDir.toPath())) {
+                                try {
+                                    if(networkNameDir.renameTo(sparrowDir) && !isWindows()) {
+                                        Files.createSymbolicLink(networkNameDir.toPath(), Path.of(sparrowDir.getName()));
+                                    }
+                                } catch(Exception e) {
+                                    log.debug("Error creating symlink from " + networkNameDir.getAbsolutePath() + " to " + sparrowDir.getName(), e);
+                                 }
+                            }
+                        }
+                    }
+                }
+            } else {
+                sparrowFinalDirs = sparrowHomeDirs;
+            }
+
+            for(File sparrowDir : sparrowFinalDirs.asMap().values()) {
+                if(!sparrowDir.exists()) {
+                    createOwnerOnlyDirectory(sparrowDir);
+                }
+            }
+
+            if(!network.getName().equals(network.getHome()) && !isWindows()) {
+                for(Map.Entry<String, File> entry : sparrowFinalDirs.asMap().entrySet()) {
+                    String dirTypeKey = entry.getKey();
+                    File sparrowDir = entry.getValue();
+                    try {
+                        Path networkNamePath = sparrowHomeMap.get(dirTypeKey).toPath().resolve(network.getName());
+                        if(Files.isSymbolicLink(networkNamePath)) {
+                            Path symlinkTarget = sparrowHomeMap.get(dirTypeKey).toPath().resolve(Files.readSymbolicLink(networkNamePath));
+                            if(!Files.isSameFile(sparrowDir.toPath(), symlinkTarget)) {
+                                Files.delete(networkNamePath);
+                                Files.createSymbolicLink(networkNamePath, Path.of(sparrowDir.getName()));
+                            }
+                        } else if(!Files.exists(networkNamePath)) {
+                            Files.createSymbolicLink(networkNamePath, Path.of(sparrowDir.getName()));
+                        }
+                    } catch(Exception e) {
+                        log.debug("Error updating symlink from " + network.getName() + " to " + sparrowDir.getName(), e);
+                    }
+                }
+            }
+
+            return sparrowFinalDirs;
         }
     }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -568,112 +568,119 @@ public class Storage {
     }
 
     public static File getSparrowConfigDir() {
-        return getSparrowDir();
+        return getSparrowDirs().config();
     }
 
     public static File getSparrowDataDir() {
-        return getSparrowDir();
+        return getSparrowDirs().data();
     }
 
     public static File getSparrowCacheDir() {
-        return getSparrowDir();
+        return getSparrowDirs().cache();
     }
 
     public static File getSparrowStateDir() {
-        return getSparrowDir();
+        return getSparrowDirs().state();
     }
 
-    static File getSparrowDir() {
-        File sparrowDir;
+    static SparrowDirectories getSparrowDirs() {
+        SparrowDirectories sparrowHomeDirs = getSparrowHome();
+        Map<String, File> sparrowHomeMap = sparrowHomeDirs.asMap();
+        SparrowDirectories sparrowFinalDirs;
         Network network = Network.get();
+
         if(network != Network.MAINNET) {
-            sparrowDir = new File(getSparrowHome(), network.getHome());
-            if(!network.getName().equals(network.getHome()) && !sparrowDir.exists()) {
-                File networkNameDir = new File(getSparrowHome(), network.getName());
-                if(networkNameDir.exists() && networkNameDir.isDirectory() && !Files.isSymbolicLink(networkNameDir.toPath())) {
-                    try {
-                        if(networkNameDir.renameTo(sparrowDir) && !isWindows()) {
-                            Files.createSymbolicLink(networkNameDir.toPath(), Path.of(sparrowDir.getName()));
+            sparrowFinalDirs = SparrowDirectories.append(sparrowHomeDirs, network.getHome());
+            if(!network.getName().equals(network.getHome())) {
+                for(Map.Entry<String, File> entry : sparrowFinalDirs.asMap().entrySet()) {
+                    String dirTypeKey = entry.getKey();
+                    File sparrowDir = entry.getValue();
+                    if(!sparrowDir.exists()) {
+                        File networkNameDir = new File(sparrowHomeMap.get(dirTypeKey), network.getName());
+                        if(networkNameDir.exists() && networkNameDir.isDirectory() && !Files.isSymbolicLink(networkNameDir.toPath())) {
+                            try {
+                                if(networkNameDir.renameTo(sparrowDir) && !isWindows()) {
+                                    Files.createSymbolicLink(networkNameDir.toPath(), Path.of(sparrowDir.getName()));
+                                }
+                            } catch(Exception e) {
+                                log.debug("Error creating symlink from " + networkNameDir.getAbsolutePath() + " to " + sparrowDir.getName(), e);
+                             }
                         }
-                    } catch(Exception e) {
-                        log.debug("Error creating symlink from " + networkNameDir.getAbsolutePath() + " to " + sparrowDir.getName(), e);
                     }
                 }
             }
         } else {
-            sparrowDir = getSparrowHome();
+            sparrowFinalDirs = sparrowHomeDirs;
         }
 
-        if(!sparrowDir.exists()) {
-            createOwnerOnlyDirectory(sparrowDir);
-        }
-
-        if(!network.getName().equals(network.getHome()) && !isWindows()) {
-            try {
-                Path networkNamePath = getSparrowHome().toPath().resolve(network.getName());
-                if(Files.isSymbolicLink(networkNamePath)) {
-                    Path symlinkTarget = getSparrowHome().toPath().resolve(Files.readSymbolicLink(networkNamePath));
-                    if(!Files.isSameFile(sparrowDir.toPath(), symlinkTarget)) {
-                        Files.delete(networkNamePath);
-                        Files.createSymbolicLink(networkNamePath, Path.of(sparrowDir.getName()));
-                    }
-                } else if(!Files.exists(networkNamePath)) {
-                    Files.createSymbolicLink(networkNamePath, Path.of(sparrowDir.getName()));
-                }
-            } catch(Exception e) {
-                log.debug("Error updating symlink from " + network.getName() + " to " + sparrowDir.getName(), e);
+        for(File sparrowDir : sparrowFinalDirs.asMap().values()) {
+            if(!sparrowDir.exists()) {
+                createOwnerOnlyDirectory(sparrowDir);
             }
         }
 
-        return sparrowDir;
+        if(!network.getName().equals(network.getHome()) && !isWindows()) {
+            for(Map.Entry<String, File> entry : sparrowFinalDirs.asMap().entrySet()) {
+                String dirTypeKey = entry.getKey();
+                File sparrowDir = entry.getValue();
+                try {
+                    Path networkNamePath = sparrowHomeMap.get(dirTypeKey).toPath().resolve(network.getName());
+                    if(Files.isSymbolicLink(networkNamePath)) {
+                        Path symlinkTarget = sparrowHomeMap.get(dirTypeKey).toPath().resolve(Files.readSymbolicLink(networkNamePath));
+                        if(!Files.isSameFile(sparrowDir.toPath(), symlinkTarget)) {
+                            Files.delete(networkNamePath);
+                            Files.createSymbolicLink(networkNamePath, Path.of(sparrowDir.getName()));
+                        }
+                    } else if(!Files.exists(networkNamePath)) {
+                        Files.createSymbolicLink(networkNamePath, Path.of(sparrowDir.getName()));
+                    }
+                } catch(Exception e) {
+                    log.debug("Error updating symlink from " + network.getName() + " to " + sparrowDir.getName(), e);
+                }
+            }
+        }
+
+        return sparrowFinalDirs;
     }
 
     public static File getSparrowConfigHome() {
-        return getSparrowHome();
+        return getSparrowHome().config();
     }
 
     public static File getSparrowDataHome() {
-        return getSparrowHome();
+        return getSparrowHome().data();
     }
 
     public static File getSparrowStateHome() {
-        return getSparrowHome();
+        return getSparrowHome().state();
     }
 
     public static File getSparrowCacheHome() {
-        return getSparrowHome();
+        return getSparrowHome().cache();
     }
 
-    static File getSparrowHome() {
-        return getSparrowHome(false);
+    static SparrowDirectories getSparrowHome() {
+        return SparrowDirectories.getSparrowDirs(false);
     }
 
     public static File getSparrowConfigHome(boolean useDefault) {
-        return getSparrowHome(useDefault);
+        return SparrowDirectories.getSparrowDirs(useDefault).config();
     }
 
     public static File getSparrowDataHome(boolean useDefault) {
-        return getSparrowHome(useDefault);
+        return SparrowDirectories.getSparrowDirs(useDefault).data();
     }
 
     public static File getSparrowStateHome(boolean useDefault) {
-        return getSparrowHome(useDefault);
+        return SparrowDirectories.getSparrowDirs(useDefault).state();
     }
 
     public static File getSparrowCacheHome(boolean useDefault) {
-        return getSparrowHome(useDefault);
+        return SparrowDirectories.getSparrowDirs(useDefault).cache();
     }
 
-    static File getSparrowHome(boolean useDefault) {
-        if(!useDefault && System.getProperty(SparrowWallet.APP_HOME_PROPERTY) != null) {
-            return new File(System.getProperty(SparrowWallet.APP_HOME_PROPERTY));
-        }
-
-        if(isWindows()) {
-            return new File(getHomeDir(), WINDOWS_SPARROW_DIR);
-        }
-
-        return new File(getHomeDir(), SPARROW_DIR);
+    static SparrowDirectories getSparrowHome(boolean useDefault) {
+        return SparrowDirectories.getSparrowDirs(useDefault);
     }
 
     static File getHomeDir() {
@@ -895,6 +902,54 @@ public class Storage {
                     return storage.delete(deleteBackups);
                 }
             };
+        }
+    }
+
+    // TODO: flesh out. Currently just a shell of the intended structure doing nothing new.
+    public record SparrowDirectories(File config, File data, File cache, File state) {
+        static final String XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
+        static final String XDG_DATA_HOME = "XDG_DATA_HOME";
+        static final String XDG_CACHE_HOME = "XDG_CACHE_HOME";
+        static final String XDG_STATE_HOME = "XDG_STATE_HOME";
+
+        static SparrowDirectories fromSingleDir(File directory) {
+            return new SparrowDirectories(directory, directory, directory, directory);
+        }
+
+        Map<String, File> asMap() {
+            return Map.of(
+                "config", config,
+                "data", data,
+                "cache", cache,
+                "state", state
+            );
+        }
+
+        static SparrowDirectories append(SparrowDirectories base, String extension) {
+            return new SparrowDirectories(
+                new File(base.config, extension),
+                new File(base.data, extension),
+                new File(base.cache, extension),
+                new File(base.state, extension)
+            );
+        }
+
+        static boolean shouldUseXdgDirs() {
+            return false;
+        }
+
+        public static SparrowDirectories getSparrowDirs(boolean useDefault) {
+            if(!useDefault && System.getProperty(SparrowWallet.APP_HOME_PROPERTY) != null) {
+                File appHomePropertyDir = new File(System.getProperty(SparrowWallet.APP_HOME_PROPERTY));
+                return fromSingleDir(appHomePropertyDir);
+            }
+
+            File homeDir = getHomeDir();
+            if(isWindows()) {
+                return fromSingleDir(new File(homeDir, WINDOWS_SPARROW_DIR));
+            }
+
+            return fromSingleDir(new File(homeDir, SPARROW_DIR));
         }
     }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -504,7 +504,7 @@ public class Storage {
             }
         }
         if(walletsDir == null) {
-            walletsDir = new File(SparrowDirectories.getSparrowDirs().data(), WALLETS_DIR);
+            walletsDir = new File(SparrowDirectories.getDirectories().data(), WALLETS_DIR);
         }
         if(!walletsDir.exists()) {
             createOwnerOnlyDirectory(walletsDir);
@@ -559,7 +559,7 @@ public class Storage {
     }
 
     static File getCertsDir() {
-        File certsDir = new File(SparrowDirectories.getSparrowDirs().data(), CERTS_DIR);
+        File certsDir = new File(SparrowDirectories.getDirectories().data(), CERTS_DIR);
         if(!certsDir.exists()) {
             createOwnerOnlyDirectory(certsDir);
         }
@@ -567,7 +567,7 @@ public class Storage {
         return certsDir;
     }
 
-    static File getHomeDir() {
+    static File getUserHomeDir() {
         if(isWindows()) {
             return new File(Storage.envRetriever.apply(ENV_APPDATA));
         }
@@ -822,17 +822,17 @@ public class Storage {
             return false;
         }
 
-        public static SparrowDirectories getSparrowHomeDirs() {
-            return SparrowDirectories.getSparrowHomeDirs(false);
+        public static SparrowDirectories getHomeDirs() {
+            return SparrowDirectories.getHomeDirs(false);
         }
 
-        public static SparrowDirectories getSparrowHomeDirs(boolean useDefault) {
+        public static SparrowDirectories getHomeDirs(boolean useDefault) {
             if(!useDefault && System.getProperty(SparrowWallet.APP_HOME_PROPERTY) != null) {
                 File appHomePropertyDir = new File(System.getProperty(SparrowWallet.APP_HOME_PROPERTY));
                 return fromSingleDir(appHomePropertyDir);
             }
 
-            File homeDir = getHomeDir();
+            File homeDir = getUserHomeDir();
             if(isWindows()) {
                 return fromSingleDir(new File(homeDir, WINDOWS_SPARROW_DIR));
             }
@@ -840,8 +840,8 @@ public class Storage {
             return fromSingleDir(new File(homeDir, SPARROW_DIR));
         }
 
-        static SparrowDirectories getSparrowDirs() {
-            SparrowDirectories sparrowHomeDirs = SparrowDirectories.getSparrowHomeDirs(false);
+        static SparrowDirectories getDirectories() {
+            SparrowDirectories sparrowHomeDirs = SparrowDirectories.getHomeDirs(false);
             Map<String, File> sparrowHomeMap = sparrowHomeDirs.asMap();
             SparrowDirectories sparrowFinalDirs;
             Network network = Network.get();

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -44,6 +44,7 @@ public class Storage {
 
     public static final String SPARROW_DIR = ".sparrow";
     public static final String WINDOWS_SPARROW_DIR = "Sparrow";
+    public static final String XDG_SPARROW_DIR = "sparrow";
     public static final String WALLETS_DIR = "wallets";
     public static final String WALLETS_BACKUP_DIR = "backup";
     public static final String CERTS_DIR = "certs";
@@ -796,11 +797,6 @@ public class Storage {
         static final String XDG_CACHE_HOME = "XDG_CACHE_HOME";
         static final String XDG_STATE_HOME = "XDG_STATE_HOME";
 
-        // Very defensive, but rather check for than assume a period in '.sparrow'
-        static final String XDG_SPARROW_DIR = SPARROW_DIR.startsWith(".")
-            ? SPARROW_DIR.substring(1)
-            : SPARROW_DIR;
-
         static SparrowDirectories fromSingleDir(File directory) {
             return new SparrowDirectories(directory, directory, directory, directory);
         }
@@ -824,7 +820,17 @@ public class Storage {
         }
 
         static boolean canUseXdgDirs() {
-            return false;
+            if(isWindows()) {
+                return false;
+            }
+
+            String xdgConfigHomeVar = envRetriever.apply(XDG_CONFIG_HOME);
+            File xdgConfigDir = xdgConfigHomeVar != null && !xdgConfigHomeVar.isEmpty()
+                ? new File(xdgConfigHomeVar)
+                : new File(getUserHomeDir(), ".config");
+
+            File sparrowXdgConfigDir = new File(xdgConfigDir, XDG_SPARROW_DIR);
+            return sparrowXdgConfigDir.exists() && sparrowXdgConfigDir.isDirectory();
         }
 
         public static SparrowDirectories getHomeDirs() {

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -30,6 +30,8 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -46,6 +48,11 @@ public class Storage {
     public static final String WALLETS_BACKUP_DIR = "backup";
     public static final String CERTS_DIR = "certs";
     public static final List<String> RESERVED_WALLET_NAMES = List.of("temp");
+
+    static final String ENV_APPDATA = "APPDATA";
+
+    static Supplier<OsType> osTypeSupplier = OsType::getCurrent;
+    static Function<String, String> envRetriever = System::getenv;
 
     private Persistence persistence;
     private File walletFile;
@@ -671,7 +678,7 @@ public class Storage {
 
     static File getHomeDir() {
         if(isWindows()) {
-            return new File(System.getenv("APPDATA"));
+            return new File(Storage.envRetriever.apply(ENV_APPDATA));
         }
 
         return new File(System.getProperty("user.home"));
@@ -729,7 +736,7 @@ public class Storage {
     }
 
     private static boolean isWindows() {
-        return OsType.getCurrent() == OsType.WINDOWS;
+        return osTypeSupplier.get() == OsType.WINDOWS;
     }
 
     public static class LoadWalletService extends Service<WalletAndKey> {

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -823,7 +823,7 @@ public class Storage {
             );
         }
 
-        static boolean shouldUseXdgDirs() {
+        static boolean canUseXdgDirs() {
             return false;
         }
 

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -497,7 +497,7 @@ public class Storage {
             }
         }
         if(walletsDir == null) {
-            walletsDir = new File(getSparrowDir(), WALLETS_DIR);
+            walletsDir = new File(getSparrowDataDir(), WALLETS_DIR);
         }
         if(!walletsDir.exists()) {
             createOwnerOnlyDirectory(walletsDir);
@@ -552,7 +552,7 @@ public class Storage {
     }
 
     static File getCertsDir() {
-        File certsDir = new File(getSparrowDir(), CERTS_DIR);
+        File certsDir = new File(getSparrowDataDir(), CERTS_DIR);
         if(!certsDir.exists()) {
             createOwnerOnlyDirectory(certsDir);
         }
@@ -560,7 +560,23 @@ public class Storage {
         return certsDir;
     }
 
-    public static File getSparrowDir() {
+    public static File getSparrowConfigDir() {
+        return getSparrowDir();
+    }
+
+    public static File getSparrowDataDir() {
+        return getSparrowDir();
+    }
+
+    public static File getSparrowCacheDir() {
+        return getSparrowDir();
+    }
+
+    public static File getSparrowStateDir() {
+        return getSparrowDir();
+    }
+
+    static File getSparrowDir() {
         File sparrowDir;
         Network network = Network.get();
         if(network != Network.MAINNET) {
@@ -605,11 +621,43 @@ public class Storage {
         return sparrowDir;
     }
 
-    public static File getSparrowHome() {
+    public static File getSparrowConfigHome() {
+        return getSparrowHome();
+    }
+
+    public static File getSparrowDataHome() {
+        return getSparrowHome();
+    }
+
+    public static File getSparrowStateHome() {
+        return getSparrowHome();
+    }
+
+    public static File getSparrowCacheHome() {
+        return getSparrowHome();
+    }
+
+    static File getSparrowHome() {
         return getSparrowHome(false);
     }
 
-    public static File getSparrowHome(boolean useDefault) {
+    public static File getSparrowConfigHome(boolean useDefault) {
+        return getSparrowHome(useDefault);
+    }
+
+    public static File getSparrowDataHome(boolean useDefault) {
+        return getSparrowHome(useDefault);
+    }
+
+    public static File getSparrowStateHome(boolean useDefault) {
+        return getSparrowHome(useDefault);
+    }
+
+    public static File getSparrowCacheHome(boolean useDefault) {
+        return getSparrowHome(useDefault);
+    }
+
+    static File getSparrowHome(boolean useDefault) {
         if(!useDefault && System.getProperty(SparrowWallet.APP_HOME_PROPERTY) != null) {
             return new File(System.getProperty(SparrowWallet.APP_HOME_PROPERTY));
         }

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -796,6 +796,11 @@ public class Storage {
         static final String XDG_CACHE_HOME = "XDG_CACHE_HOME";
         static final String XDG_STATE_HOME = "XDG_STATE_HOME";
 
+        // Very defensive, but rather check for than assume a period in '.sparrow'
+        static final String XDG_SPARROW_DIR = SPARROW_DIR.startsWith(".")
+            ? SPARROW_DIR.substring(1)
+            : SPARROW_DIR;
+
         static SparrowDirectories fromSingleDir(File directory) {
             return new SparrowDirectories(directory, directory, directory, directory);
         }

--- a/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Storage.java
@@ -790,7 +790,6 @@ public class Storage {
         }
     }
 
-    // TODO: flesh out. Currently just a shell of the intended structure doing nothing new.
     public record SparrowDirectories(File config, File data, File cache, File state) {
         static final String XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
         static final String XDG_DATA_HOME = "XDG_DATA_HOME";
@@ -801,21 +800,43 @@ public class Storage {
             return new SparrowDirectories(directory, directory, directory, directory);
         }
 
-        Map<String, File> asMap() {
-            return Map.of(
-                "config", config,
-                "data", data,
-                "cache", cache,
-                "state", state
-            );
-        }
-
         static SparrowDirectories append(SparrowDirectories base, String extension) {
             return new SparrowDirectories(
                 new File(base.config, extension),
                 new File(base.data, extension),
                 new File(base.cache, extension),
                 new File(base.state, extension)
+            );
+        }
+
+        private static File fromEnvOrDefault(String envVarKey, File defaultValue) {
+            String envVarValue = envRetriever.apply(envVarKey);
+            return envVarValue == null || envVarValue.isEmpty() ? defaultValue : new File(envVarValue);
+        }
+
+        static SparrowDirectories fromXdgDirs() {
+            File userHome = getUserHomeDir();
+            File xdgConfig = fromEnvOrDefault(XDG_CONFIG_HOME, new File(userHome, ".config"));
+            File xdgData = fromEnvOrDefault(XDG_DATA_HOME, new File(new File(userHome, ".local"), "share"));
+            File xdgCache = fromEnvOrDefault(XDG_CACHE_HOME, new File(userHome, ".cache"));
+            File xdgState = fromEnvOrDefault(XDG_STATE_HOME, new File(new File(userHome, ".local"), "state"));
+
+            SparrowDirectories baseDirs = new SparrowDirectories(
+                xdgConfig,
+                xdgData,
+                xdgCache,
+                xdgState
+            );
+
+            return SparrowDirectories.append(baseDirs, XDG_SPARROW_DIR);
+        }
+
+        Map<String, File> asMap() {
+            return Map.of(
+                "config", config,
+                "data", data,
+                "cache", cache,
+                "state", state
             );
         }
 
@@ -829,8 +850,8 @@ public class Storage {
                 ? new File(xdgConfigHomeVar)
                 : new File(getUserHomeDir(), ".config");
 
-            File sparrowXdgConfigDir = new File(xdgConfigDir, XDG_SPARROW_DIR);
-            return sparrowXdgConfigDir.exists() && sparrowXdgConfigDir.isDirectory();
+            File xdgConfigSparrowDir = new File(xdgConfigDir, XDG_SPARROW_DIR);
+            return xdgConfigSparrowDir.exists() && xdgConfigSparrowDir.isDirectory();
         }
 
         public static SparrowDirectories getHomeDirs() {
@@ -838,17 +859,19 @@ public class Storage {
         }
 
         public static SparrowDirectories getHomeDirs(boolean useDefault) {
-            if(!useDefault && System.getProperty(SparrowWallet.APP_HOME_PROPERTY) != null) {
-                File appHomePropertyDir = new File(System.getProperty(SparrowWallet.APP_HOME_PROPERTY));
-                return fromSingleDir(appHomePropertyDir);
+            if(!useDefault) {
+                String appHomeProperty = System.getProperty(SparrowWallet.APP_HOME_PROPERTY);
+                if(appHomeProperty != null) {
+                    return fromSingleDir(new File(appHomeProperty));
+                }
+
+                if(canUseXdgDirs()) {
+                    return fromXdgDirs();
+                }
             }
 
-            File homeDir = getUserHomeDir();
-            if(isWindows()) {
-                return fromSingleDir(new File(homeDir, WINDOWS_SPARROW_DIR));
-            }
-
-            return fromSingleDir(new File(homeDir, SPARROW_DIR));
+            String sparrowDir = isWindows() ? WINDOWS_SPARROW_DIR : SPARROW_DIR;
+            return fromSingleDir(new File(getUserHomeDir(), sparrowDir));
         }
 
         static SparrowDirectories getDirectories() {

--- a/src/main/java/com/sparrowwallet/sparrow/net/Tor.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/Tor.java
@@ -40,7 +40,7 @@ public class Tor implements Closeable {
     private IPSocketAddress socksAddress;
 
     public Tor(OnEvent<TorListeners> listener) {
-        Path path = Path.of(Storage.getSparrowHome().getAbsolutePath()).resolve(TOR_DIR);
+        Path path = Path.of(Storage.getSparrowDataHome().getAbsolutePath()).resolve(TOR_DIR);
         File oldInstallDir = path.resolve(WORK_DIR).resolve(OLD_INSTALL_DIR).toFile();
         if(oldInstallDir.exists()) {
             IOUtils.deleteDirectory(oldInstallDir);

--- a/src/main/java/com/sparrowwallet/sparrow/net/Tor.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/Tor.java
@@ -4,7 +4,7 @@ import com.google.common.net.HostAndPort;
 import com.sparrowwallet.drongo.IOUtils;
 import com.sparrowwallet.sparrow.EventManager;
 import com.sparrowwallet.sparrow.event.TorStatusEvent;
-import com.sparrowwallet.sparrow.io.Storage;
+import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
 import io.matthewnelson.kmp.tor.resource.exec.tor.ResourceLoaderTorExec;
 import io.matthewnelson.kmp.tor.runtime.Action;
 import io.matthewnelson.kmp.tor.runtime.RuntimeEvent;
@@ -40,7 +40,7 @@ public class Tor implements Closeable {
     private IPSocketAddress socksAddress;
 
     public Tor(OnEvent<TorListeners> listener) {
-        Path path = Path.of(Storage.getSparrowDataHome().getAbsolutePath()).resolve(TOR_DIR);
+        Path path = Path.of(SparrowDirectories.getSparrowHomeDirs().data().getAbsolutePath()).resolve(TOR_DIR);
         File oldInstallDir = path.resolve(WORK_DIR).resolve(OLD_INSTALL_DIR).toFile();
         if(oldInstallDir.exists()) {
             IOUtils.deleteDirectory(oldInstallDir);

--- a/src/main/java/com/sparrowwallet/sparrow/net/Tor.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/Tor.java
@@ -40,7 +40,7 @@ public class Tor implements Closeable {
     private IPSocketAddress socksAddress;
 
     public Tor(OnEvent<TorListeners> listener) {
-        Path path = Path.of(SparrowDirectories.getSparrowHomeDirs().data().getAbsolutePath()).resolve(TOR_DIR);
+        Path path = Path.of(SparrowDirectories.getHomeDirs().data().getAbsolutePath()).resolve(TOR_DIR);
         File oldInstallDir = path.resolve(WORK_DIR).resolve(OLD_INSTALL_DIR).toFile();
         if(oldInstallDir.exists()) {
             IOUtils.deleteDirectory(oldInstallDir);

--- a/src/test/java/com/sparrowwallet/sparrow/io/SparrowDirectoriesTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/SparrowDirectoriesTest.java
@@ -143,7 +143,7 @@ class SparrowDirectoriesTests {
             props.put(SparrowWallet.APP_HOME_PROPERTY, null);
             props.putAll(getValidXdgEnvVarMap());
 
-            File xdgSparrowConfig = new File(xdgConfig, SparrowDirectories.XDG_SPARROW_DIR);
+            File xdgSparrowConfig = new File(xdgConfig, Storage.XDG_SPARROW_DIR);
             xdgSparrowConfig.mkdirs();
 
             prepareMocks(osType, envVars, props);
@@ -151,36 +151,36 @@ class SparrowDirectoriesTests {
 
         @Test
         void shouldUseAppDataDir() {
+            testCanUseXdgDirs(false);
+
             boolean defaultFlag = false;
 
             File expectedLocation = new File(appData, Storage.WINDOWS_SPARROW_DIR);
             SparrowDirectories expected = SparrowDirectories.fromSingleDir(expectedLocation);
             testDirectories(defaultFlag, expected);
-
-            testCanUseXdgDirs(false);
         }
 
         @Test
         void shouldUseAppHomeIfSet() {
             preparePropsMock(getValidAppHomePropsMap());
-            boolean defaultFlag = false;
-
-            SparrowDirectories expected = SparrowDirectories.fromSingleDir(appHome);
-            testDirectories(defaultFlag, expected);
 
             testCanUseXdgDirs(false);
+
+            boolean defaultFlag = false;
+            SparrowDirectories expected = SparrowDirectories.fromSingleDir(appHome);
+            testDirectories(defaultFlag, expected);
         }
 
         @Test
         void defaultFlagHasPrioOverAppHome() {
             preparePropsMock(getValidAppHomePropsMap());
-            boolean defaultFlag = true;
 
+            testCanUseXdgDirs(false);
+
+            boolean defaultFlag = true;
             File expectedLocation = new File(appData, Storage.WINDOWS_SPARROW_DIR);
             SparrowDirectories expected = SparrowDirectories.fromSingleDir(expectedLocation);
             testDirectories(defaultFlag, expected);
-
-            testCanUseXdgDirs(false);
         }
     }
 
@@ -198,11 +198,11 @@ class SparrowDirectoriesTests {
         private void createSparrowXdgConfigFolder(XdgBaseLocation location) {
             File sparrowXdgConfig;
             if (location == XdgBaseLocation.ENV_VAR) {
-                sparrowXdgConfig = new File(xdgConfig, SparrowDirectories.XDG_SPARROW_DIR);
+                sparrowXdgConfig = new File(xdgConfig, Storage.XDG_SPARROW_DIR);
             } else {
                 sparrowXdgConfig = userHome.toPath()
                     .resolve(".config")
-                    .resolve(SparrowDirectories.XDG_SPARROW_DIR)
+                    .resolve(Storage.XDG_SPARROW_DIR)
                     .toFile();
             }
 
@@ -220,52 +220,45 @@ class SparrowDirectoriesTests {
 
         @Test
         void shouldUseUserHomeIfNoXdgFolderExists() {
-            boolean defaultFlag = false;
+            testCanUseXdgDirs(false);
 
+            boolean defaultFlag = false;
             File expectedLocation = new File(userHome, Storage.SPARROW_DIR);
             SparrowDirectories expected = SparrowDirectories.fromSingleDir(expectedLocation);
             testDirectories(defaultFlag, expected);
-
-            testCanUseXdgDirs(false);
         }
 
         @Test
         void shouldUseXdgIfFolderExists() {
             createSparrowXdgConfigFolder(XdgBaseLocation.ENV_VAR);
+            testCanUseXdgDirs(true);
 
             boolean defaultFlag = false;
-
             SparrowDirectories baseDirs = new SparrowDirectories(
                 xdgConfig,
                 xdgData,
                 xdgCache,
                 xdgState
             );
-            SparrowDirectories expected = SparrowDirectories.append(baseDirs, SparrowDirectories.XDG_SPARROW_DIR);
-
+            SparrowDirectories expected = SparrowDirectories.append(baseDirs, Storage.XDG_SPARROW_DIR);
             testDirectories(defaultFlag, expected);
-
-            testCanUseXdgDirs(true);
         }
 
         @Test
         void shouldUseXdgWithoutEnvVarsIfDefaultLocationExists() {
             prepareEnvVarMock(getClearedXdgEnvVarMap());
             createSparrowXdgConfigFolder(XdgBaseLocation.DEFAULT);
-
+            testCanUseXdgDirs(true);
 
             boolean defaultFlag = false;
-
             SparrowDirectories baseDirs = new SparrowDirectories(
                 userHome.toPath().resolve(".config").toFile(),
                 userHome.toPath().resolve(".local/share").toFile(),
                 userHome.toPath().resolve(".cache").toFile(),
                 userHome.toPath().resolve(".local/state").toFile()
             );
-            SparrowDirectories expected = SparrowDirectories.append(baseDirs, SparrowDirectories.XDG_SPARROW_DIR);
+            SparrowDirectories expected = SparrowDirectories.append(baseDirs, Storage.XDG_SPARROW_DIR);
             testDirectories(defaultFlag, expected);
-
-            testCanUseXdgDirs(true);
         }
 
         @Test
@@ -273,12 +266,11 @@ class SparrowDirectoriesTests {
             preparePropsMock(getValidAppHomePropsMap());
             createSparrowXdgConfigFolder(XdgBaseLocation.ENV_VAR);
 
-            boolean defaultFlag = false;
+            testCanUseXdgDirs(true);
 
+            boolean defaultFlag = false;
             SparrowDirectories expected = SparrowDirectories.fromSingleDir(appHome);
             testDirectories(defaultFlag, expected);
-
-            testCanUseXdgDirs(true);
         }
 
         @Test
@@ -286,13 +278,20 @@ class SparrowDirectoriesTests {
             preparePropsMock(getValidAppHomePropsMap());
             createSparrowXdgConfigFolder(XdgBaseLocation.ENV_VAR);
 
-            boolean defaultFlag = true;
+            testCanUseXdgDirs(true);
 
+            boolean defaultFlag = true;
             File expectedLocation = new File(userHome, Storage.SPARROW_DIR);
             SparrowDirectories expected = SparrowDirectories.fromSingleDir(expectedLocation);
             testDirectories(defaultFlag, expected);
+        }
+    }
 
-            testCanUseXdgDirs(true);
+    @Nested
+    class MacOsTests extends UnixTests {
+        @Override
+        OsType getOsType() {
+            return OsType.MACOS;
         }
     }
 }

--- a/src/test/java/com/sparrowwallet/sparrow/io/SparrowDirectoriesTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/SparrowDirectoriesTest.java
@@ -1,0 +1,298 @@
+package com.sparrowwallet.sparrow.io;
+
+import com.sparrowwallet.drongo.OsType;
+import com.sparrowwallet.sparrow.SparrowWallet;
+import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+@Execution(ExecutionMode.SAME_THREAD)
+class SparrowDirectoriesTests {
+    private static final String USER_HOME = "user.home";
+
+    private Map<String, String> propsToRestore = Map.of();
+
+    @TempDir File xdgConfig;
+    @TempDir File xdgData;
+    @TempDir File xdgState;
+    @TempDir File xdgCache;
+
+    @TempDir File userHome;
+    @TempDir File appHome;
+
+    private Map<String, String> getValidXdgEnvVarMap() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put(SparrowDirectories.XDG_CONFIG_HOME, xdgConfig.getAbsolutePath());
+        envVars.put(SparrowDirectories.XDG_DATA_HOME, xdgData.getAbsolutePath());
+        envVars.put(SparrowDirectories.XDG_STATE_HOME, xdgState.getAbsolutePath());
+        envVars.put(SparrowDirectories.XDG_CACHE_HOME, xdgCache.getAbsolutePath());
+        return envVars;
+    }
+
+    private Map<String, String> getClearedXdgEnvVarMap() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put(SparrowDirectories.XDG_CONFIG_HOME, null);
+        envVars.put(SparrowDirectories.XDG_DATA_HOME, null);
+        envVars.put(SparrowDirectories.XDG_STATE_HOME, null);
+        envVars.put(SparrowDirectories.XDG_CACHE_HOME, null);
+        return envVars;
+    }
+
+    private Map<String, String> getValidAppHomePropsMap () {
+        Map<String, String> props = new HashMap<>();
+        props.put(SparrowWallet.APP_HOME_PROPERTY, appHome.getAbsolutePath());
+        return props;
+    }
+
+    private void preparePropsMock(Map<String, String> props) {
+        props.forEach(this::overrideProp);
+    }
+
+    private void overrideProp(String key, String value) {
+        // only keep original value, ignore consecutive changes
+        if(!propsToRestore.containsKey(key)) {
+            propsToRestore.put(key, System.getProperty(key));
+        }
+
+        if(value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+
+    private void prepareEnvVarMock(Map<String, String> envVarOverrides) {
+        Storage.envRetriever = (String key) -> {
+            if(!envVarOverrides.containsKey(key)) {
+                return System.getenv(key);
+            } else {
+                return envVarOverrides.get(key);
+            }
+        };
+    }
+
+    private void prepareMocks(
+            OsType osType,
+            Map<String, String> envVarOverrides,
+            Map<String, String> propOverrides
+        ) {
+        Storage.osTypeSupplier = () -> osType;
+
+        prepareEnvVarMock(envVarOverrides);
+
+        propOverrides.forEach(this::overrideProp);
+    }
+
+    @BeforeEach
+    void setupCases() {
+        propsToRestore = new HashMap<>();
+    }
+
+    private void testDirectories(boolean defaultFlag, SparrowDirectories expectedDirs) {
+        SparrowDirectories sparrowHomeDirs = SparrowDirectories.getHomeDirs(defaultFlag);
+
+        Assertions.assertEquals(expectedDirs, sparrowHomeDirs);
+    }
+
+    private void testCanUseXdgDirs(boolean expected) {
+        boolean actual = SparrowDirectories.canUseXdgDirs();
+        Assertions.assertEquals(expected, actual, String.format("Expected canUseXdgDirs() to return [%b] but was [%b]", expected, actual));
+    }
+
+    @AfterEach
+    void tearDownCases() {
+        Storage.envRetriever = System::getenv;
+        Storage.osTypeSupplier = OsType::getCurrent;
+
+        for(Map.Entry<String, String> entry : propsToRestore.entrySet()) {
+            String key = entry.getKey();
+            String originalValue = propsToRestore.get(key);
+
+            if(originalValue != null) {
+                System.setProperty(key, originalValue);
+            } else {
+                System.clearProperty(key);
+            }
+        }
+    }
+
+    @Nested
+    class WindowsTests {
+        final OsType osType = OsType.WINDOWS;
+
+        @TempDir
+        File appData;
+
+        @BeforeEach
+        private void setup() {
+            Map<String, String> envVars = new HashMap<>();
+            envVars.put(Storage.ENV_APPDATA, appData.getAbsolutePath());
+
+            Map<String, String> props = new HashMap<>();
+            props.put(SparrowWallet.APP_HOME_PROPERTY, null);
+            props.putAll(getValidXdgEnvVarMap());
+
+            File xdgSparrowConfig = new File(xdgConfig, SparrowDirectories.XDG_SPARROW_DIR);
+            xdgSparrowConfig.mkdirs();
+
+            prepareMocks(osType, envVars, props);
+        }
+
+        @Test
+        void shouldUseAppDataDir() {
+            boolean defaultFlag = false;
+
+            File expectedLocation = new File(appData, Storage.WINDOWS_SPARROW_DIR);
+            SparrowDirectories expected = SparrowDirectories.fromSingleDir(expectedLocation);
+            testDirectories(defaultFlag, expected);
+
+            testCanUseXdgDirs(false);
+        }
+
+        @Test
+        void shouldUseAppHomeIfSet() {
+            preparePropsMock(getValidAppHomePropsMap());
+            boolean defaultFlag = false;
+
+            SparrowDirectories expected = SparrowDirectories.fromSingleDir(appHome);
+            testDirectories(defaultFlag, expected);
+
+            testCanUseXdgDirs(false);
+        }
+
+        @Test
+        void defaultFlagHasPrioOverAppHome() {
+            preparePropsMock(getValidAppHomePropsMap());
+            boolean defaultFlag = true;
+
+            File expectedLocation = new File(appData, Storage.WINDOWS_SPARROW_DIR);
+            SparrowDirectories expected = SparrowDirectories.fromSingleDir(expectedLocation);
+            testDirectories(defaultFlag, expected);
+
+            testCanUseXdgDirs(false);
+        }
+    }
+
+    @Nested
+    class UnixTests {
+        OsType getOsType() {
+            return OsType.UNIX;
+        }
+
+        private enum XdgBaseLocation {
+            DEFAULT,
+            ENV_VAR
+        }
+
+        private void createSparrowXdgConfigFolder(XdgBaseLocation location) {
+            File sparrowXdgConfig;
+            if (location == XdgBaseLocation.ENV_VAR) {
+                sparrowXdgConfig = new File(xdgConfig, SparrowDirectories.XDG_SPARROW_DIR);
+            } else {
+                sparrowXdgConfig = userHome.toPath()
+                    .resolve(".config")
+                    .resolve(SparrowDirectories.XDG_SPARROW_DIR)
+                    .toFile();
+            }
+
+            sparrowXdgConfig.mkdirs();
+        }
+
+        @BeforeEach
+        private void setup() {
+            Map<String, String> props = new HashMap<>();
+            props.put(USER_HOME, userHome.getAbsolutePath());
+            props.put(SparrowWallet.APP_HOME_PROPERTY, null);
+
+            prepareMocks(getOsType(), getValidXdgEnvVarMap(), props);
+        }
+
+        @Test
+        void shouldUseUserHomeIfNoXdgFolderExists() {
+            boolean defaultFlag = false;
+
+            File expectedLocation = new File(userHome, Storage.SPARROW_DIR);
+            SparrowDirectories expected = SparrowDirectories.fromSingleDir(expectedLocation);
+            testDirectories(defaultFlag, expected);
+
+            testCanUseXdgDirs(false);
+        }
+
+        @Test
+        void shouldUseXdgIfFolderExists() {
+            createSparrowXdgConfigFolder(XdgBaseLocation.ENV_VAR);
+
+            boolean defaultFlag = false;
+
+            SparrowDirectories baseDirs = new SparrowDirectories(
+                xdgConfig,
+                xdgData,
+                xdgCache,
+                xdgState
+            );
+            SparrowDirectories expected = SparrowDirectories.append(baseDirs, SparrowDirectories.XDG_SPARROW_DIR);
+
+            testDirectories(defaultFlag, expected);
+
+            testCanUseXdgDirs(true);
+        }
+
+        @Test
+        void shouldUseXdgWithoutEnvVarsIfDefaultLocationExists() {
+            prepareEnvVarMock(getClearedXdgEnvVarMap());
+            createSparrowXdgConfigFolder(XdgBaseLocation.DEFAULT);
+
+
+            boolean defaultFlag = false;
+
+            SparrowDirectories baseDirs = new SparrowDirectories(
+                userHome.toPath().resolve(".config").toFile(),
+                userHome.toPath().resolve(".local/share").toFile(),
+                userHome.toPath().resolve(".cache").toFile(),
+                userHome.toPath().resolve(".local/state").toFile()
+            );
+            SparrowDirectories expected = SparrowDirectories.append(baseDirs, SparrowDirectories.XDG_SPARROW_DIR);
+            testDirectories(defaultFlag, expected);
+
+            testCanUseXdgDirs(true);
+        }
+
+        @Test
+        void appHomeHasPrioOverXdg() {
+            preparePropsMock(getValidAppHomePropsMap());
+            createSparrowXdgConfigFolder(XdgBaseLocation.ENV_VAR);
+
+            boolean defaultFlag = false;
+
+            SparrowDirectories expected = SparrowDirectories.fromSingleDir(appHome);
+            testDirectories(defaultFlag, expected);
+
+            testCanUseXdgDirs(true);
+        }
+
+        @Test
+        void defaultFlagHasPrioOverAppHome() {
+            preparePropsMock(getValidAppHomePropsMap());
+            createSparrowXdgConfigFolder(XdgBaseLocation.ENV_VAR);
+
+            boolean defaultFlag = true;
+
+            File expectedLocation = new File(userHome, Storage.SPARROW_DIR);
+            SparrowDirectories expected = SparrowDirectories.fromSingleDir(expectedLocation);
+            testDirectories(defaultFlag, expected);
+
+            testCanUseXdgDirs(true);
+        }
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
@@ -118,7 +118,7 @@ public class StorageTest extends IoTest {
                     : "Path should be in user.home";
 
                 String path = actual.getAbsolutePath();
-                String expectedPathPart = Storage.getHomeDir().getAbsolutePath();
+                String expectedPathPart = Storage.getUserHomeDir().getAbsolutePath();
 
                 Assertions.assertTrue(path.contains(expectedPathPart), msg);
 
@@ -128,7 +128,7 @@ public class StorageTest extends IoTest {
             void respectsAppHomeProperty(@TempDir File tempAppHome) {
                 System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
 
-                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getSparrowHomeDirs(false);
+                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getHomeDirs(false);
 
                 Assertions.assertEquals(tempAppHome, sparrowHomeDirs.config());
                 assertFilesAreSame(sparrowHomeDirs.asMap().values());
@@ -138,7 +138,7 @@ public class StorageTest extends IoTest {
             void respectsDefaultOverride(@TempDir File tempAppHome) {
                 System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
 
-                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getSparrowHomeDirs(true);
+                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getHomeDirs(true);
 
                 Assertions.assertNotEquals(tempAppHome, sparrowHomeDirs.config());
                 assertPathIsInDefaultLocation(sparrowHomeDirs.config());
@@ -149,7 +149,7 @@ public class StorageTest extends IoTest {
             void useDefaultIfNoAppHomeProp() {
                 System.clearProperty(SparrowWallet.APP_HOME_PROPERTY);
 
-                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getSparrowHomeDirs(false);
+                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getHomeDirs(false);
 
                 assertPathIsInDefaultLocation(sparrowHomeDirs.config());
                 assertFilesAreSame(sparrowHomeDirs.asMap().values());
@@ -168,10 +168,10 @@ public class StorageTest extends IoTest {
         abstract class SharedUnixAndMacOsTests extends SharedTests {
             @Test
             void sparrowDirectoriesAreOne() {
-                File configHome = SparrowDirectories.getSparrowHomeDirs().config();
-                File dataHome = SparrowDirectories.getSparrowHomeDirs().data();
-                File stateHome = SparrowDirectories.getSparrowHomeDirs().state();
-                File cacheHome = SparrowDirectories.getSparrowHomeDirs().cache();
+                File configHome = SparrowDirectories.getHomeDirs().config();
+                File dataHome = SparrowDirectories.getHomeDirs().data();
+                File stateHome = SparrowDirectories.getHomeDirs().state();
+                File cacheHome = SparrowDirectories.getHomeDirs().cache();
 
                 assertFilesAreSame(List.of(configHome, dataHome, stateHome, cacheHome));
             }
@@ -182,7 +182,7 @@ public class StorageTest extends IoTest {
                 String userHome = System.getProperty("user.home");
                 Assertions.assertNotNull(userHome);
 
-                File configHome = SparrowDirectories.getSparrowHomeDirs().config();
+                File configHome = SparrowDirectories.getHomeDirs().config();
 
                 String path = configHome.getAbsolutePath();
                 Assertions.assertTrue(path.contains(userHome), "Path should contain user.home");
@@ -200,17 +200,17 @@ public class StorageTest extends IoTest {
 
             @Test
             void sparrowDirectoriesAreOne() {
-                File configHome = SparrowDirectories.getSparrowHomeDirs().config();
-                File dataHome = SparrowDirectories.getSparrowHomeDirs().data();
-                File stateHome = SparrowDirectories.getSparrowHomeDirs().state();
-                File cacheHome = SparrowDirectories.getSparrowHomeDirs().cache();
+                File configHome = SparrowDirectories.getHomeDirs().config();
+                File dataHome = SparrowDirectories.getHomeDirs().data();
+                File stateHome = SparrowDirectories.getHomeDirs().state();
+                File cacheHome = SparrowDirectories.getHomeDirs().cache();
 
                 Assertions.assertTrue(Stream.of(dataHome, stateHome, cacheHome).allMatch(configHome::equals), "All files should have same path");
             }
 
             @Test
             void sparrowDirectoryLocation() {
-                File configHome = SparrowDirectories.getSparrowHomeDirs().config();
+                File configHome = SparrowDirectories.getHomeDirs().config();
 
                 String path = configHome.getAbsolutePath();
                 String appDataPath = Storage.envRetriever.apply(Storage.ENV_APPDATA);

--- a/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
@@ -1,30 +1,18 @@
 package com.sparrowwallet.sparrow.io;
 
 import com.sparrowwallet.drongo.KeyPurpose;
-import com.sparrowwallet.drongo.OsType;
 import com.sparrowwallet.drongo.Utils;
 import com.sparrowwallet.drongo.policy.PolicyType;
 import com.sparrowwallet.drongo.protocol.ScriptType;
 import com.sparrowwallet.drongo.wallet.Keystore;
 import com.sparrowwallet.drongo.wallet.MnemonicException;
 import com.sparrowwallet.drongo.wallet.Wallet;
-import com.sparrowwallet.sparrow.SparrowWallet;
-import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.*;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
 
 public class StorageTest extends IoTest {
     @Test
@@ -95,155 +83,6 @@ public class StorageTest extends IoTest {
         Storage temp2Storage = new Storage(tempWallet);
         wallet = temp2Storage.loadEncryptedWallet("pass").getWallet();
         Assertions.assertTrue(wallet.isValid());
-    }
-
-    @Nested
-    @Execution(ExecutionMode.SAME_THREAD)
-    class SparrowDirectoriesTests {
-        private void assertFilesAreSame(Collection<File> files) {
-            Assertions.assertEquals(1, Set.copyOf(files).size(), "All files should be the same");
-        }
-
-        abstract class SharedTests {
-            String originalAppHome;
-
-            @BeforeEach
-            void setupShared() {
-                originalAppHome = System.getProperty(SparrowWallet.APP_HOME_PROPERTY);
-            }
-
-            private void assertPathIsInDefaultLocation(File actual) {
-                String msg = Storage.osTypeSupplier.get() == OsType.WINDOWS
-                    ? "Path should be in APPHOME"
-                    : "Path should be in user.home";
-
-                String path = actual.getAbsolutePath();
-                String expectedPathPart = Storage.getUserHomeDir().getAbsolutePath();
-
-                Assertions.assertTrue(path.contains(expectedPathPart), msg);
-
-            }
-
-            @Test
-            void respectsAppHomeProperty(@TempDir File tempAppHome) {
-                System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
-
-                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getHomeDirs(false);
-
-                Assertions.assertEquals(tempAppHome, sparrowHomeDirs.config());
-                assertFilesAreSame(sparrowHomeDirs.asMap().values());
-            }
-
-            @Test
-            void respectsDefaultOverride(@TempDir File tempAppHome) {
-                System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
-
-                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getHomeDirs(true);
-
-                Assertions.assertNotEquals(tempAppHome, sparrowHomeDirs.config());
-                assertPathIsInDefaultLocation(sparrowHomeDirs.config());
-                assertFilesAreSame(sparrowHomeDirs.asMap().values());
-            }
-
-            @Test
-            void useDefaultIfNoAppHomeProp() {
-                System.clearProperty(SparrowWallet.APP_HOME_PROPERTY);
-
-                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getHomeDirs(false);
-
-                assertPathIsInDefaultLocation(sparrowHomeDirs.config());
-                assertFilesAreSame(sparrowHomeDirs.asMap().values());
-            }
-
-            @AfterEach
-            void tearDownShared() {
-               if (originalAppHome != null) {
-                   System.setProperty(SparrowWallet.APP_HOME_PROPERTY, originalAppHome);
-               } else {
-                   System.clearProperty(SparrowWallet.APP_HOME_PROPERTY);
-               }
-            }
-        }
-
-        abstract class SharedUnixAndMacOsTests extends SharedTests {
-            @Test
-            void sparrowDirectoriesAreOne() {
-                File configHome = SparrowDirectories.getHomeDirs().config();
-                File dataHome = SparrowDirectories.getHomeDirs().data();
-                File stateHome = SparrowDirectories.getHomeDirs().state();
-                File cacheHome = SparrowDirectories.getHomeDirs().cache();
-
-                assertFilesAreSame(List.of(configHome, dataHome, stateHome, cacheHome));
-            }
-
-            @Test
-            void sparrowDirectoryLocation() {
-                // precondition: user.home must be set
-                String userHome = System.getProperty("user.home");
-                Assertions.assertNotNull(userHome);
-
-                File configHome = SparrowDirectories.getHomeDirs().config();
-
-                String path = configHome.getAbsolutePath();
-                Assertions.assertTrue(path.contains(userHome), "Path should contain user.home");
-                Assertions.assertTrue(path.contains(Storage.SPARROW_DIR), "Path should contain SPARROW_DIR");
-            }
-        }
-
-        @Nested
-        class OsTypeWindows extends SharedTests {
-            @BeforeEach
-            void setup(@TempDir File tempDir) {
-                Storage.osTypeSupplier = () -> OsType.WINDOWS;
-                Storage.envRetriever = (String envVar) -> Storage.ENV_APPDATA.equals(envVar) ? tempDir.getAbsolutePath() : System.getenv(envVar);
-            }
-
-            @Test
-            void sparrowDirectoriesAreOne() {
-                File configHome = SparrowDirectories.getHomeDirs().config();
-                File dataHome = SparrowDirectories.getHomeDirs().data();
-                File stateHome = SparrowDirectories.getHomeDirs().state();
-                File cacheHome = SparrowDirectories.getHomeDirs().cache();
-
-                Assertions.assertTrue(Stream.of(dataHome, stateHome, cacheHome).allMatch(configHome::equals), "All files should have same path");
-            }
-
-            @Test
-            void sparrowDirectoryLocation() {
-                File configHome = SparrowDirectories.getHomeDirs().config();
-
-                String path = configHome.getAbsolutePath();
-                String appDataPath = Storage.envRetriever.apply(Storage.ENV_APPDATA);
-                Assertions.assertTrue(path.contains(appDataPath), "Path should contain APPDATA in path");
-                Assertions.assertTrue(path.contains(Storage.WINDOWS_SPARROW_DIR), "Path should contain WINDOWS_SPARROW_DIR");
-            }
-
-            @AfterEach
-            void tearDown() {
-                Storage.envRetriever = System::getenv;
-            }
-        }
-
-        @Nested
-        class OsTypeUnix extends SharedUnixAndMacOsTests {
-            @BeforeEach
-            void setup() {
-                Storage.osTypeSupplier = () -> OsType.UNIX;
-            }
-        }
-
-        @Nested
-        class OsTypeMacOs extends SharedUnixAndMacOsTests {
-            @BeforeEach
-            void setup() {
-                Storage.osTypeSupplier = () -> OsType.MACOS;
-            }
-        }
-
-        @AfterEach
-        void tearDown() {
-            Storage.osTypeSupplier = OsType::getCurrent;
-        }
     }
 
     @AfterEach

--- a/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
@@ -128,7 +128,7 @@ public class StorageTest extends IoTest {
             void respectsAppHomeProperty(@TempDir File tempAppHome) {
                 System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
 
-                SparrowDirectories sparrowHomeDirs = Storage.getSparrowHome(false);
+                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getSparrowHomeDirs(false);
 
                 Assertions.assertEquals(tempAppHome, sparrowHomeDirs.config());
                 assertFilesAreSame(sparrowHomeDirs.asMap().values());
@@ -138,7 +138,7 @@ public class StorageTest extends IoTest {
             void respectsDefaultOverride(@TempDir File tempAppHome) {
                 System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
 
-                SparrowDirectories sparrowHomeDirs = Storage.getSparrowHome(true);
+                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getSparrowHomeDirs(true);
 
                 Assertions.assertNotEquals(tempAppHome, sparrowHomeDirs.config());
                 assertPathIsInDefaultLocation(sparrowHomeDirs.config());
@@ -149,7 +149,7 @@ public class StorageTest extends IoTest {
             void useDefaultIfNoAppHomeProp() {
                 System.clearProperty(SparrowWallet.APP_HOME_PROPERTY);
 
-                SparrowDirectories sparrowHomeDirs = Storage.getSparrowHome(false);
+                SparrowDirectories sparrowHomeDirs = SparrowDirectories.getSparrowHomeDirs(false);
 
                 assertPathIsInDefaultLocation(sparrowHomeDirs.config());
                 assertFilesAreSame(sparrowHomeDirs.asMap().values());
@@ -168,10 +168,10 @@ public class StorageTest extends IoTest {
         abstract class SharedUnixAndMacOsTests extends SharedTests {
             @Test
             void sparrowDirectoriesAreOne() {
-                File configHome = Storage.getSparrowConfigHome();
-                File dataHome = Storage.getSparrowDataHome();
-                File stateHome = Storage.getSparrowStateHome();
-                File cacheHome = Storage.getSparrowConfigHome();
+                File configHome = SparrowDirectories.getSparrowHomeDirs().config();
+                File dataHome = SparrowDirectories.getSparrowHomeDirs().data();
+                File stateHome = SparrowDirectories.getSparrowHomeDirs().state();
+                File cacheHome = SparrowDirectories.getSparrowHomeDirs().cache();
 
                 assertFilesAreSame(List.of(configHome, dataHome, stateHome, cacheHome));
             }
@@ -182,7 +182,7 @@ public class StorageTest extends IoTest {
                 String userHome = System.getProperty("user.home");
                 Assertions.assertNotNull(userHome);
 
-                File configHome = Storage.getSparrowConfigHome();
+                File configHome = SparrowDirectories.getSparrowHomeDirs().config();
 
                 String path = configHome.getAbsolutePath();
                 Assertions.assertTrue(path.contains(userHome), "Path should contain user.home");
@@ -200,17 +200,17 @@ public class StorageTest extends IoTest {
 
             @Test
             void sparrowDirectoriesAreOne() {
-                File configHome = Storage.getSparrowConfigHome();
-                File dataHome = Storage.getSparrowDataHome();
-                File stateHome = Storage.getSparrowStateHome();
-                File cacheHome = Storage.getSparrowConfigHome();
+                File configHome = SparrowDirectories.getSparrowHomeDirs().config();
+                File dataHome = SparrowDirectories.getSparrowHomeDirs().data();
+                File stateHome = SparrowDirectories.getSparrowHomeDirs().state();
+                File cacheHome = SparrowDirectories.getSparrowHomeDirs().cache();
 
                 Assertions.assertTrue(Stream.of(dataHome, stateHome, cacheHome).allMatch(configHome::equals), "All files should have same path");
             }
 
             @Test
             void sparrowDirectoryLocation() {
-                File configHome = Storage.getSparrowConfigHome();
+                File configHome = SparrowDirectories.getSparrowHomeDirs().config();
 
                 String path = configHome.getAbsolutePath();
                 String appDataPath = Storage.envRetriever.apply(Storage.ENV_APPDATA);

--- a/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
@@ -1,17 +1,26 @@
 package com.sparrowwallet.sparrow.io;
 
 import com.sparrowwallet.drongo.KeyPurpose;
+import com.sparrowwallet.drongo.OsType;
 import com.sparrowwallet.drongo.Utils;
 import com.sparrowwallet.drongo.policy.PolicyType;
 import com.sparrowwallet.drongo.protocol.ScriptType;
 import com.sparrowwallet.drongo.wallet.Keystore;
 import com.sparrowwallet.drongo.wallet.MnemonicException;
 import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.sparrow.SparrowWallet;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.*;
+import java.util.stream.Stream;
 
 public class StorageTest extends IoTest {
     @Test
@@ -82,6 +91,146 @@ public class StorageTest extends IoTest {
         Storage temp2Storage = new Storage(tempWallet);
         wallet = temp2Storage.loadEncryptedWallet("pass").getWallet();
         Assertions.assertTrue(wallet.isValid());
+    }
+
+    @Nested
+    @Execution(ExecutionMode.SAME_THREAD)
+    class SparrowDirectoriesTests {
+        abstract class SharedTests {
+            String originalAppHome;
+
+            @BeforeEach
+            void setupShared() {
+                originalAppHome = System.getProperty(SparrowWallet.APP_HOME_PROPERTY);
+            }
+
+            private void assertPathIsInDefaultLocation(File actual) {
+                String msg = Storage.osTypeSupplier.get() == OsType.WINDOWS
+                    ? "Path should be in APPHOME"
+                    : "Path should be in user.home";
+
+                String path = actual.getAbsolutePath();
+                String expectedPathPart = Storage.getHomeDir().getAbsolutePath();
+
+                Assertions.assertTrue(path.contains(expectedPathPart), msg);
+
+            }
+
+            @Test
+            void respectsAppHomeProperty(@TempDir File tempAppHome) {
+                System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
+
+                File sparrowHome = Storage.getSparrowHome(false);
+                Assertions.assertEquals(tempAppHome, sparrowHome);
+            }
+
+            @Test
+            void respectsDefaultOverride(@TempDir File tempAppHome) {
+                System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
+
+                File sparrowHome = Storage.getSparrowHome(true);
+                Assertions.assertNotEquals(tempAppHome, sparrowHome);
+
+                assertPathIsInDefaultLocation(sparrowHome);
+            }
+
+            @Test
+            void useDefaultIfNoAppHomeProp() {
+                System.clearProperty(SparrowWallet.APP_HOME_PROPERTY);
+
+                File sparrowHome = Storage.getSparrowHome(false);
+                assertPathIsInDefaultLocation(sparrowHome);
+            }
+
+            @AfterEach
+            void tearDownShared() {
+               if (originalAppHome != null) {
+                   System.setProperty(SparrowWallet.APP_HOME_PROPERTY, originalAppHome);
+               } else {
+                   System.clearProperty(SparrowWallet.APP_HOME_PROPERTY);
+               }
+            }
+        }
+
+        abstract class SharedUnixAndMacOsTests extends SharedTests {
+            @Test
+            void sparrowDirectoriesAreOne() {
+                File configHome = Storage.getSparrowConfigHome();
+                File dataHome = Storage.getSparrowDataHome();
+                File stateHome = Storage.getSparrowStateHome();
+                File cacheHome = Storage.getSparrowConfigHome();
+
+                Assertions.assertTrue(Stream.of(dataHome, stateHome, cacheHome).allMatch(configHome::equals), "All files should have same path");
+            }
+
+            @Test
+            void sparrowDirectoryLocation() {
+                // precondition: user.home must be set
+                String userHome = System.getProperty("user.home");
+                Assertions.assertNotNull(userHome);
+
+                File configHome = Storage.getSparrowConfigHome();
+
+                String path = configHome.getAbsolutePath();
+                Assertions.assertTrue(path.contains(userHome), "Path should contain user.home");
+                Assertions.assertTrue(path.contains(Storage.SPARROW_DIR), "Path should contain SPARROW_DIR");
+            }
+        }
+
+        @Nested
+        class OsTypeWindows extends SharedTests {
+            @BeforeEach
+            void setup(@TempDir File tempDir) {
+                Storage.osTypeSupplier = () -> OsType.WINDOWS;
+                Storage.envRetriever = (String envVar) -> Storage.ENV_APPDATA.equals(envVar) ? tempDir.getAbsolutePath() : System.getenv(envVar);
+            }
+
+            @Test
+            void sparrowDirectoriesAreOne() {
+                File configHome = Storage.getSparrowConfigHome();
+                File dataHome = Storage.getSparrowDataHome();
+                File stateHome = Storage.getSparrowStateHome();
+                File cacheHome = Storage.getSparrowConfigHome();
+
+                Assertions.assertTrue(Stream.of(dataHome, stateHome, cacheHome).allMatch(configHome::equals), "All files should have same path");
+            }
+
+            @Test
+            void sparrowDirectoryLocation() {
+                File configHome = Storage.getSparrowConfigHome();
+
+                String path = configHome.getAbsolutePath();
+                String appDataPath = Storage.envRetriever.apply(Storage.ENV_APPDATA);
+                Assertions.assertTrue(path.contains(appDataPath), "Path should contain APPDATA in path");
+                Assertions.assertTrue(path.contains(Storage.WINDOWS_SPARROW_DIR), "Path should contain WINDOWS_SPARROW_DIR");
+            }
+
+            @AfterEach
+            void tearDown() {
+                Storage.envRetriever = System::getenv;
+            }
+        }
+
+        @Nested
+        class OsTypeUnix extends SharedUnixAndMacOsTests {
+            @BeforeEach
+            void setup() {
+                Storage.osTypeSupplier = () -> OsType.UNIX;
+            }
+        }
+
+        @Nested
+        class OsTypeMacOs extends SharedUnixAndMacOsTests {
+            @BeforeEach
+            void setup() {
+                Storage.osTypeSupplier = () -> OsType.MACOS;
+            }
+        }
+
+        @AfterEach
+        void tearDown() {
+            Storage.osTypeSupplier = OsType::getCurrent;
+        }
     }
 
     @AfterEach

--- a/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/StorageTest.java
@@ -9,6 +9,7 @@ import com.sparrowwallet.drongo.wallet.Keystore;
 import com.sparrowwallet.drongo.wallet.MnemonicException;
 import com.sparrowwallet.drongo.wallet.Wallet;
 import com.sparrowwallet.sparrow.SparrowWallet;
+import com.sparrowwallet.sparrow.io.Storage.SparrowDirectories;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -20,6 +21,9 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class StorageTest extends IoTest {
@@ -96,6 +100,10 @@ public class StorageTest extends IoTest {
     @Nested
     @Execution(ExecutionMode.SAME_THREAD)
     class SparrowDirectoriesTests {
+        private void assertFilesAreSame(Collection<File> files) {
+            Assertions.assertEquals(1, Set.copyOf(files).size(), "All files should be the same");
+        }
+
         abstract class SharedTests {
             String originalAppHome;
 
@@ -120,26 +128,31 @@ public class StorageTest extends IoTest {
             void respectsAppHomeProperty(@TempDir File tempAppHome) {
                 System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
 
-                File sparrowHome = Storage.getSparrowHome(false);
-                Assertions.assertEquals(tempAppHome, sparrowHome);
+                SparrowDirectories sparrowHomeDirs = Storage.getSparrowHome(false);
+
+                Assertions.assertEquals(tempAppHome, sparrowHomeDirs.config());
+                assertFilesAreSame(sparrowHomeDirs.asMap().values());
             }
 
             @Test
             void respectsDefaultOverride(@TempDir File tempAppHome) {
                 System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempAppHome.getAbsolutePath());
 
-                File sparrowHome = Storage.getSparrowHome(true);
-                Assertions.assertNotEquals(tempAppHome, sparrowHome);
+                SparrowDirectories sparrowHomeDirs = Storage.getSparrowHome(true);
 
-                assertPathIsInDefaultLocation(sparrowHome);
+                Assertions.assertNotEquals(tempAppHome, sparrowHomeDirs.config());
+                assertPathIsInDefaultLocation(sparrowHomeDirs.config());
+                assertFilesAreSame(sparrowHomeDirs.asMap().values());
             }
 
             @Test
             void useDefaultIfNoAppHomeProp() {
                 System.clearProperty(SparrowWallet.APP_HOME_PROPERTY);
 
-                File sparrowHome = Storage.getSparrowHome(false);
-                assertPathIsInDefaultLocation(sparrowHome);
+                SparrowDirectories sparrowHomeDirs = Storage.getSparrowHome(false);
+
+                assertPathIsInDefaultLocation(sparrowHomeDirs.config());
+                assertFilesAreSame(sparrowHomeDirs.asMap().values());
             }
 
             @AfterEach
@@ -160,7 +173,7 @@ public class StorageTest extends IoTest {
                 File stateHome = Storage.getSparrowStateHome();
                 File cacheHome = Storage.getSparrowConfigHome();
 
-                Assertions.assertTrue(Stream.of(dataHome, stateHome, cacheHome).allMatch(configHome::equals), "All files should have same path");
+                assertFilesAreSame(List.of(configHome, dataHome, stateHome, cacheHome));
             }
 
             @Test


### PR DESCRIPTION
Resolves #1897 

### Usage and preconditions

Allows the use of XDG Base Directory Specification under the following circumstances:
- Applicable to Mac or Unix
- User must at the very least create the folder `XDG_CONFIG_HOME/sparrow` or if `XDG_CONFIG_HOME` is not specified, `user.home/.config/sparrow`
- System property `sparrow.home` takes precedence over XDG locations
- Default location flag takes precedence over `sparrow.home`

No existing files are migrated or changed, so the user must copy them across manually.

### File / folder locations under XDG
When using XDG specs, these are the locations hat will be used:
- `XDG_CONFIG_HOME/sparrow`: the main `config` file
- `XDG_DATA_HOME/sparrow`: wallet folders, hardware folders, certs folders, tor folders
- `XDG_STATE_HOME/sparrow`: logfile, testnet flags, lockfile
- `XDG_CACHE_HOME/sparrow`: unused

### Assumptions, feedback needed
I'd appreciate feedback for the assumptions I made to get here.
- At the very least Sparrow's XDG config folder must exist. The mere existence of environment variables alone is not sufficient.
- For any `XDG_*_HOME` env var: If it is not set, the code will use default locations under `user.home` (`.config`, `.local/share`, etc).
- The log file location was a bit tricky to decide. I went with `state` but an argument can be made to put it under `cache` instead. Particularly since it seems to grow indefinitely?
- The testnet locations are a bit of a mystery to me. I am unsure of using `state` for them and pointers would be very welcome.

And of course any other hints or feedback are much appreciated.