### PR TITLE
Add option to ignore dust transactions on private key sweep

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
@@ -71,8 +71,6 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
     private final FeeRangeSlider feeRange;
     private final CopyableLabel feeRate;
     private UnlabeledToggleSwitch useDustLimit;
-    private final FeeRangeSlider dustLimit;
-    private final CopyableLabel dust;
     private SilentPaymentAddress silentPaymentAddress;
 
     public PrivateKeySweepDialog(Wallet wallet) {
@@ -179,29 +177,9 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
         useDustLimitField.setText("Ignore dust:");
         useDustLimit = new UnlabeledToggleSwitch();
         useDustLimitField.getInputs().add(useDustLimit);
-        useDustLimit.selectedProperty().addListener((observable, oldValue, newValue) -> {
-            updateUseDustLimit();
-        });
         useDustLimit.setSelected(false);
 
-        Field dustRangeField = new Field();
-        dustRangeField.setText("Dust Range:");
-        Field dustLimitField = new Field();
-        dustLimitField.setText("Dust limit:");
-
-        dustLimit = new FeeRangeSlider();
-        dustLimit.setMaxWidth(320);
-        dustRangeField.getInputs().add(dustLimit);
-        dust = new CopyableLabel();
-        dustLimitField.getInputs().add(dust);
-        dustLimit.valueProperty().addListener((observable, oldValue, newValue) -> {
-            updateDustLimit();
-        });
-        dustLimit.setFeeRate(0);
-        updateDustLimit();
-        updateUseDustLimit();
-
-        fieldset.getChildren().addAll(keyField, keyScriptTypeField, addressField, toAddressField, feeRangeField, feeRateField, useDustLimitField, dustRangeField, dustLimitField);
+        fieldset.getChildren().addAll(keyField, keyScriptTypeField, addressField, toAddressField, feeRangeField, feeRateField, useDustLimitField);
         form.getChildren().add(fieldset);
         dialogPane.setContent(form);
 
@@ -439,8 +417,9 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
     // remove any utxos below the dust limit
     private List<TransactionOutput> removeDust(List<TransactionOutput> txOutputs) {
         int removed=0,size=txOutputs.size();
-        long dust = (long)Math.ceil(dustLimit.getFeeRate());
+        long dust = Config.get().getDustAttackThreshold();
         List<TransactionOutput> utxos = new ArrayList<>();
+
         for(TransactionOutput utxo : txOutputs) {
             if(utxo.getValue() >= dust) {
                 // if utxo value >= dust, add it
@@ -578,17 +557,6 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
     private void updateFeeRate() {
         UnitFormat format = Config.get().getUnitFormat() == null ? UnitFormat.DOT : Config.get().getUnitFormat();
         feeRate.setText(format.getCurrencyFormat().format(feeRange.getFeeRate()) + " sats/vB");
-    }
-
-    private void updateDustLimit() {
-        UnitFormat format = Config.get().getUnitFormat() == null ? UnitFormat.DOT : Config.get().getUnitFormat();
-        dust.setText(format.getCurrencyFormat().format(dustLimit.getFeeRate()) + " sats");
-    }
-
-    private void updateUseDustLimit() {
-        boolean udl = !useDustLimit.isSelected();
-        dust.setDisable(udl);
-        dustLimit.setDisable(udl);
     }
 
     @Subscribe

--- a/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
@@ -27,6 +27,8 @@ import com.sparrowwallet.sparrow.io.CardApi;
 import com.sparrowwallet.sparrow.io.Config;
 import com.sparrowwallet.sparrow.net.ElectrumServer;
 import com.sparrowwallet.sparrow.net.ServerType;
+import com.sparrowwallet.sparrow.UnitFormat;
+import com.sparrowwallet.sparrow.control.UnlabeledToggleSwitch;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
@@ -68,6 +70,9 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
     private final ComboBox<Wallet> toWallet;
     private final FeeRangeSlider feeRange;
     private final CopyableLabel feeRate;
+    private UnlabeledToggleSwitch useDustLimit;
+    private final FeeRangeSlider dustLimit;
+    private final CopyableLabel dust;
     private SilentPaymentAddress silentPaymentAddress;
 
     public PrivateKeySweepDialog(Wallet wallet) {
@@ -170,7 +175,33 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
         feeRange.setFeeRate(AppServices.getDefaultFeeRate());
         updateFeeRate();
 
-        fieldset.getChildren().addAll(keyField, keyScriptTypeField, addressField, toAddressField, feeRangeField, feeRateField);
+        Field useDustLimitField = new Field();
+        useDustLimitField.setText("Ignore dust:");
+        useDustLimit = new UnlabeledToggleSwitch();
+        useDustLimitField.getInputs().add(useDustLimit);
+        useDustLimit.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            updateUseDustLimit();
+        });
+        useDustLimit.setSelected(false);
+
+        Field dustRangeField = new Field();
+        dustRangeField.setText("Dust Range:");
+        Field dustLimitField = new Field();
+        dustLimitField.setText("Dust limit:");
+
+        dustLimit = new FeeRangeSlider();
+        dustLimit.setMaxWidth(320);
+        dustRangeField.getInputs().add(dustLimit);
+        dust = new CopyableLabel();
+        dustLimitField.getInputs().add(dust);
+        dustLimit.valueProperty().addListener((observable, oldValue, newValue) -> {
+            updateDustLimit();
+        });
+        dustLimit.setFeeRate(0);
+        updateDustLimit();
+        updateUseDustLimit();
+
+        fieldset.getChildren().addAll(keyField, keyScriptTypeField, addressField, toAddressField, feeRangeField, feeRateField, useDustLimitField, dustRangeField, dustLimitField);
         form.getChildren().add(fieldset);
         dialogPane.setContent(form);
 
@@ -250,6 +281,7 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
             validationSupport.registerValidator(key, (Control c, String newValue) -> ValidationResult.fromErrorIf(c, "Invalid private Key", !key.getText().isEmpty() && !isValidKey()));
             validationSupport.registerValidator(toAddress, (Control c, String newValue) -> ValidationResult.fromErrorIf(c, "Invalid address", !toAddress.getText().isEmpty() && !isValidToAddress()));
         });
+
     }
 
     private boolean isValidKey() {
@@ -362,6 +394,7 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
     }
 
     private void createTransaction() {
+
         try {
             DumpedPrivateKey privateKey = getPrivateKey();
             ScriptType scriptType = keyScriptType.getValue();
@@ -403,9 +436,33 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
         }
     }
 
+    // remove any utxos below the dust limit
+    private List<TransactionOutput> removeDust(List<TransactionOutput> txOutputs) {
+        int removed=0,size=txOutputs.size();
+        long dust = (long)Math.ceil(dustLimit.getFeeRate());
+        List<TransactionOutput> utxos = new ArrayList<>();
+        for(TransactionOutput utxo : txOutputs) {
+            if(utxo.getValue() >= dust) {
+                // if utxo value >= dust, add it
+                utxos.add(utxo);
+            }
+            else {
+                ++removed;
+                log.info("Removed "+utxo.getValue()+" is less than dust: "+dust);
+            }
+        }
+        log.info("Original count: " + size + ", new: "+utxos.size());
+        return utxos;
+    }
+
     private void createTransaction(ECKey privKey, ScriptType scriptType, List<TransactionOutput> txOutputs, Payment payment) {
         Address destAddress = payment instanceof SilentPayment silentPayment ? computeSilentPaymentAddress(privKey, scriptType, txOutputs, silentPayment) : payment.getAddress();
         ECKey pubKey = ECKey.fromPublicOnly(privKey);
+
+        // remove dust
+        if(useDustLimit.isSelected()) {
+            txOutputs=removeDust(txOutputs);
+        }
 
         Transaction noFeeTransaction = new Transaction();
         long total = 0;
@@ -521,6 +578,17 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
     private void updateFeeRate() {
         UnitFormat format = Config.get().getUnitFormat() == null ? UnitFormat.DOT : Config.get().getUnitFormat();
         feeRate.setText(format.getCurrencyFormat().format(feeRange.getFeeRate()) + " sats/vB");
+    }
+
+    private void updateDustLimit() {
+        UnitFormat format = Config.get().getUnitFormat() == null ? UnitFormat.DOT : Config.get().getUnitFormat();
+        dust.setText(format.getCurrencyFormat().format(dustLimit.getFeeRate()) + " sats");
+    }
+
+    private void updateUseDustLimit() {
+        boolean udl = !useDustLimit.isSelected();
+        dust.setDisable(udl);
+        dustLimit.setDisable(udl);
     }
 
     @Subscribe


### PR DESCRIPTION
### Summary
Add an option to the sweep private key dialog to set a minimum sat threshold for UTXOs.


<img width="678" height="661" alt="Screenshot from 2026-07-27 22-05-47" src="https://github.com/user-attachments/assets/04b6ee6e-4e22-485b-811b-2b5a27eae600" />
