### PR TITLE
Add list of toxic utxos to remove from sweep txns

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
@@ -69,6 +69,7 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
     private final FeeRangeSlider feeRange;
     private final CopyableLabel feeRate;
     private final UnlabeledToggleSwitch ignoreDust;
+    private final UnlabeledToggleSwitch includeToxicTxns;
     private SilentPaymentAddress silentPaymentAddress;
 
     public PrivateKeySweepDialog(Wallet wallet) {
@@ -177,6 +178,15 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
         ignoreDustField.getInputs().add(ignoreDust);
 
         fieldset.getChildren().addAll(keyField, keyScriptTypeField, addressField, toAddressField, feeRangeField, feeRateField, ignoreDustField);
+
+        includeToxicTxns = Config.get().getExpertMode() ? new UnlabeledToggleSwitch() : null;
+        if(includeToxicTxns != null) {
+            Field includeToxicField = new Field();
+            includeToxicField.setText("Toxic UTXOs:");
+            includeToxicField.getInputs().add(includeToxicTxns);
+            fieldset.getChildren().add(includeToxicField);
+        }
+
         form.getChildren().add(fieldset);
         dialogPane.setContent(form);
 
@@ -390,6 +400,20 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
             ElectrumServer.AddressUtxosService addressUtxosService = new ElectrumServer.AddressUtxosService(fromAddress, since);
             addressUtxosService.setOnSucceeded(successEvent -> {
                 List<TransactionOutput> utxos = addressUtxosService.getValue();
+
+                if(includeToxicTxns != null && !includeToxicTxns.isSelected()) {
+                    int size = utxos.size();
+                    utxos = removeToxicTransactions(utxos);
+                    if(utxos.isEmpty()) {
+                        AppServices.showErrorDialog("No outputs to sweep", "All of the unspent outputs for this private key have been removed as toxic.");
+                        return;
+                    }
+                    if(size != utxos.size()) {
+                        size -= utxos.size();
+                        AppServices.showWarningDialog("Toxic UTXOs Removed", "Removed " + size + " toxic transactions.");
+                    }
+                }
+
                 if(ignoreDust.isSelected()) {
                     utxos = removeDust(utxos);
                     if(utxos.isEmpty()) {
@@ -421,6 +445,11 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
     private List<TransactionOutput> removeDust(List<TransactionOutput> txOutputs) {
         long dustAttackThreshold = Config.get().getDustAttackThreshold();
         return txOutputs.stream().filter(txOutput -> txOutput.getValue() > dustAttackThreshold).collect(Collectors.toList());
+    }
+
+    private List<TransactionOutput> removeToxicTransactions(List<TransactionOutput> txOutputs) {
+        List<String> toxicTransactions=Config.get().getToxicTransactions();
+        return txOutputs.stream().filter(txOutput -> !toxicTransactions.contains(txOutput.getHash().toString())).collect(Collectors.toList());
     }
 
     private void createTransaction(ECKey privKey, ScriptType scriptType, List<TransactionOutput> txOutputs, Payment payment) {

--- a/src/main/java/com/sparrowwallet/sparrow/io/Config.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Config.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.lang.reflect.Type;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.sparrowwallet.sparrow.AppServices.ENUMERATE_HW_PERIOD_SECS;
 import static com.sparrowwallet.sparrow.net.PagedBatchRequestBuilder.DEFAULT_PAGE_SIZE;
@@ -95,6 +96,8 @@ public class Config {
     private double minRelayFeeRate = Transaction.DEFAULT_MIN_RELAY_FEE;
     private Double appWidth;
     private Double appHeight;
+    private boolean expertMode = false;
+    private List<String> toxicTransactions;
 
     private static Config INSTANCE;
 
@@ -793,6 +796,25 @@ public class Config {
     public void setAppHeight(Double appHeight) {
         this.appHeight = appHeight;
         flush();
+    }
+
+    public void setExpertMode(boolean mode) {
+        expertMode = mode;
+    }
+
+    public boolean getExpertMode() {
+        return expertMode;
+    }
+
+    public void setToxicTransactions(List<String> txns) {
+        toxicTransactions = txns;
+    }
+
+    public List<String> getToxicTransactions() {
+        if(toxicTransactions != null) {
+            toxicTransactions = toxicTransactions.stream().map(txn -> txn.toLowerCase()).collect(Collectors.toList());
+        }
+        return toxicTransactions != null ? toxicTransactions : new ArrayList<String>();
     }
 
     private synchronized void flush() {


### PR DESCRIPTION

Allows users to add a list of txids to exclude on sweeps by adding the following to their config file.

"toxicTransactions": [
    "txid1....",
    "txid2....",
    "txid3...."
  ]
