### PR TITLE
Fix Electrum read timeout not actually bounding the wait for a response

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/TcpTransport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/TcpTransport.java
@@ -144,29 +144,48 @@ public class TcpTransport implements CloseableTransport, TimeoutCounter {
             }
         }
 
+        //This budget must bound the ENTIRE wait for a response - not just acquiring
+        //readLock below, but also the subsequent wait for the reader thread to deliver
+        //data. Previously only lock acquisition was time-bounded here; the
+        //readingCondition.await() further down was unbounded. readLock is free whenever
+        //the reader thread is blocked on the socket (it releases the lock while
+        //awaiting/reading), so tryLock below returned almost immediately regardless of
+        //the requested timeout, and a server that accepted a request and never replied
+        //hung the caller on that unbounded await forever - never timing out, never
+        //failing the connection, and never triggering a reconnect. Every subsequent RPC
+        //then queued forever behind clientRequestLock too.
+        long remainingNanos = TimeUnit.SECONDS.toNanos(readTimeouts[readTimeoutIndex])
+                + TimeUnit.MILLISECONDS.toNanos(requestIdCount * PER_REQUEST_READ_TIMEOUT_MILLIS);
+
+        boolean locked;
         try {
-            if(!readLock.tryLock((readTimeouts[readTimeoutIndex] * 1000L) + (requestIdCount * PER_REQUEST_READ_TIMEOUT_MILLIS), TimeUnit.MILLISECONDS)) {
-                readTimeoutIndex = Math.min(readTimeoutIndex + 1, readTimeouts.length - 1);
-                log.warn("No response from server, setting read timeout to " + readTimeouts[readTimeoutIndex] + " secs");
-                throw new IOException("No response from server");
-            }
+            locked = readLock.tryLock(remainingNanos, TimeUnit.NANOSECONDS);
         } catch(InterruptedException e) {
             throw new IOException("Read thread interrupted");
         }
 
-        if(readTimeoutIndex == readTimeouts.length - 1) {
-            readTimeoutIndex--;
+        if(!locked) {
+            failReadTimeout();
+            throw new IOException("No response from server");
         }
 
         try {
+            if(readTimeoutIndex == readTimeouts.length - 1) {
+                readTimeoutIndex--;
+            }
+
             if(firstRead) {
                 readingCondition.signal();
                 firstRead = false;
             }
 
             while(reading && running) {
+                if(remainingNanos <= 0) {
+                    failReadTimeout();
+                    throw new IOException("No response from server");
+                }
                 try {
-                    readingCondition.await();
+                    remainingNanos = readingCondition.awaitNanos(remainingNanos);
                 } catch(InterruptedException e) {
                     //Restore interrupt status and break
                     Thread.currentThread().interrupt();
@@ -188,6 +207,33 @@ public class TcpTransport implements CloseableTransport, TimeoutCounter {
             return response;
         } finally {
             readLock.unlock();
+        }
+    }
+
+    /**
+     * No response was received from the server within the current read timeout. This
+     * escalates the timeout for future reads (as before this fix), but - unlike before -
+     * also actually fails this connection: stop the reader loop and close the socket, so
+     * a server that stops replying doesn't leave a dead connection sitting open forever
+     * with every future request queuing behind clientRequestLock. Closing the socket here
+     * unblocks readInputLoop's reader thread out of its readLine() retry loop (which
+     * otherwise only retries on SocketTimeoutException and never gives up on its own),
+     * which then signals the failure and lets Sparrow's existing reconnect handling take
+     * over on the next request.
+     */
+    private void failReadTimeout() {
+        readTimeoutIndex = Math.min(readTimeoutIndex + 1, readTimeouts.length - 1);
+        log.warn("No response from server, setting read timeout to " + readTimeouts[readTimeoutIndex] + " secs");
+
+        if(running) {
+            running = false;
+            try {
+                if(socket != null) {
+                    socket.close();
+                }
+            } catch(IOException e) {
+                log.debug("Error closing socket after read timeout", e);
+            }
         }
     }
 

--- a/src/test/java/com/sparrowwallet/sparrow/net/TcpTransportTimeoutTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/TcpTransportTimeoutTest.java
@@ -1,0 +1,74 @@
+package com.sparrowwallet.sparrow.net;
+
+import com.google.common.net.HostAndPort;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression test for a hang in TcpTransport#readResponse: a server that accepts a
+ * connection and a request but never replies used to block the caller forever.
+ * <p>
+ * readResponse() only time-bounded acquiring readLock via tryLock(). readLock is free
+ * whenever the reader thread is blocked on the socket (it releases the lock while
+ * awaiting/reading), so tryLock returned almost immediately regardless of the requested
+ * timeout, and the actual wait for a response was an unbounded readingCondition.await()
+ * right below it - which a non-responding server would never signal. The connection was
+ * also never marked failed on that path, so it was never retried/reconnected either.
+ */
+public class TcpTransportTimeoutTest {
+
+    @Test
+    public void nonRespondingServerFailsWithinTimeoutInsteadOfHangingForever() throws Exception {
+        try(ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            Thread acceptThread = new Thread(() -> {
+                try(Socket accepted = serverSocket.accept()) {
+                    //Accept the connection and read the request, then simply never reply.
+                    BufferedReader in = new BufferedReader(new InputStreamReader(accepted.getInputStream()));
+                    in.readLine();
+                    Thread.sleep(Long.MAX_VALUE);
+                } catch(Exception e) {
+                    //Expected once the test tears down the server/transport
+                }
+            });
+            acceptThread.setDaemon(true);
+            acceptThread.start();
+
+            HostAndPort server = HostAndPort.fromParts("127.0.0.1", serverSocket.getLocalPort());
+            TcpTransport transport = new TcpTransport(server);
+            transport.connect();
+
+            Thread readerThread = new Thread(() -> {
+                try {
+                    transport.readInputLoop();
+                } catch(ServerException e) {
+                    //Expected once the transport fails
+                }
+            });
+            readerThread.setDaemon(true);
+            readerThread.start();
+
+            try {
+                //readTimeouts[0] defaults to 3s (BASE_READ_TIMEOUT_SECS). This must fail well
+                //before it would have hung indefinitely under the old unbounded-await behaviour -
+                //if this test hangs/times out instead of throwing, the regression is back.
+                assertTimeoutPreemptively(Duration.ofSeconds(10), () ->
+                    assertThrows(IOException.class, () -> transport.pass("{\"id\":1,\"method\":\"server.ping\",\"params\":[]}")));
+
+                assertFalse(transport.isConnected(), "Transport must be marked failed, not left hanging open, after a read timeout");
+            } finally {
+                transport.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

`TcpTransport.readResponse()` only bounded **acquiring `readLock`**
via `tryLock(timeout)`. `readLock` is free whenever the reader thread
is blocked on the socket (it releases the lock while
awaiting/reading), so `tryLock` returns almost immediately regardless
of the requested timeout — the actual wait for a response is the
**unbounded** `readingCondition.await()` right below it.

`readLine()` also swallows `SocketTimeoutException` in a retry loop
and never gives up on its own. So a server that accepts a request and
never replies hangs the caller forever, with every other RPC queued
behind `clientRequestLock`. The transport was also never marked
failed on the (effectively unreachable) timeout path, so Sparrow never
reconnected.

Knock-on effect: `readTimeoutIndex` — and the page-halving backoff in
`PagedBatchRequestBuilder.getPageSize()` built on top of it via
`TimeoutCounter` — essentially never escalates in this scenario, since
the lock timeout meant to drive it is effectively unreachable.

## Fix

- Track a single time budget across both the `tryLock()` and the
  subsequent wait, using the idiomatic
  `Condition.awaitNanos()` loop instead of an unbounded `await()`.
- On genuine expiry, actually fail the connection (stop the reader
  loop, close the socket) instead of only logging/escalating, so the
  failure surfaces to callers and existing reconnect handling kicks in
  instead of the connection sitting open indefinitely.

Pre-existing decay quirk (`readTimeoutIndex--` when already at max,
right after a successful lock acquisition) is left untouched — out of
scope for this fix.

No build toolchain available in the environment this was written in,
so this has been reviewed by hand/tracing rather than compiled against
the full project — happy to iterate on review feedback.