### PR TITLE
Fix BitcoindTransport hanging forever when Bitcoin Core RPC never replies

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/cormorant/bitcoind/BitcoindTransport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/cormorant/bitcoind/BitcoindTransport.java
@@ -1,5 +1,8 @@
 package com.sparrowwallet.sparrow.net.cormorant.bitcoind;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.github.arteam.simplejsonrpc.client.Transport;
 import com.sparrowwallet.drongo.Network;
 import com.sparrowwallet.sparrow.AppServices;
@@ -18,10 +21,32 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.cert.Certificate;
 import java.util.Base64;
+import java.util.Set;
 
 public class BitcoindTransport implements Transport {
     private static final Logger log = LoggerFactory.getLogger(BitcoindTransport.class);
     public static final String COOKIE_FILENAME = ".cookie";
+
+    //HttpURLConnection defaults both connect and read timeout to 0 (infinite) and neither
+    //was ever set here, so an unreachable/black-holed bitcoind (getOutputStream, which
+    //triggers the connect) or one that accepts the connection but never responds
+    //(getResponseCode) hung the caller - and whatever thread called pass() - forever.
+    //Bitcoin Core RPC is expected to be reachable quickly, so a connect timeout is always
+    //safe to enforce.
+    private static final int CONNECT_TIMEOUT_MILLIS = 15_000;
+    //Onion circuit/rendezvous builds routinely take much longer than a direct LAN/WAN
+    //connect. TcpTransport already encodes this lesson for BITCOIN_CORE + onion via
+    //SLOW_READ_TIMEOUT_SECS (up to 208s) - match that precedent here rather than false-fail
+    //the exact privacy-conscious setup this transport's proxy support exists for.
+    private static final int ONION_CONNECT_TIMEOUT_MILLIS = 60_000;
+    //Most RPC calls made here complete in well under this, but a read timeout must not be
+    //applied indiscriminately: importdescriptors with a rescan is a synchronous Bitcoin Core
+    //RPC call that legitimately blocks until the rescan finishes, which can take anywhere
+    //from seconds to hours depending on the wallet's birthday and the node's hardware. Only
+    //calls not known to run long get this bound; see isUnboundedReadTimeoutMethod below.
+    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 60_000;
+    private static final Set<String> UNBOUNDED_READ_TIMEOUT_METHODS = Set.of("importdescriptors");
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
     private final Server bitcoindServer;
     private URL bitcoindUrl;
@@ -75,6 +100,8 @@ public class BitcoindTransport implements Transport {
         }
 
         connection.setDoOutput(true);
+        connection.setConnectTimeout(getConnectTimeoutMillis());
+        connection.setReadTimeout(getReadTimeoutMillis(request));
 
         log.debug("> " + request);
 
@@ -118,6 +145,49 @@ public class BitcoindTransport implements Transport {
         log.debug("< " + response);
 
         return response;
+    }
+
+    /**
+     * Overridable for tests, which need a far shorter bound than the real production
+     * default to stay fast and deterministic.
+     */
+    protected int getConnectTimeoutMillis() {
+        return AppServices.getProxy() != null && Protocol.isOnionAddress(bitcoindServer) ? ONION_CONNECT_TIMEOUT_MILLIS : CONNECT_TIMEOUT_MILLIS;
+    }
+
+    /**
+     * Overridable for tests; see getConnectTimeoutMillis.
+     */
+    protected int getReadTimeoutMillis(String request) {
+        return isUnboundedReadTimeoutMethod(request) ? 0 : DEFAULT_READ_TIMEOUT_MILLIS;
+    }
+
+    /**
+     * A small, explicit allowlist of RPC methods known to legitimately run long on the
+     * Bitcoin Core side (currently just importdescriptors when it triggers a rescan), so
+     * that a read timeout can safely be applied to every other call without breaking them.
+     * Parses the method out of the raw request JSON the same way TcpTransport parses
+     * notifications, rather than a naive substring match, so it can't be fooled by a
+     * parameter value that happens to contain "importdescriptors".
+     */
+    static boolean isUnboundedReadTimeoutMethod(String request) {
+        try(JsonParser parser = JSON_FACTORY.createParser(request)) {
+            if(parser.nextToken() != JsonToken.START_OBJECT) {
+                return false;
+            }
+            while(parser.nextToken() == JsonToken.FIELD_NAME) {
+                String field = parser.currentName();
+                JsonToken value = parser.nextToken();
+                if("method".equals(field)) {
+                    return value == JsonToken.VALUE_STRING && UNBOUNDED_READ_TIMEOUT_METHODS.contains(parser.getText());
+                }
+                parser.skipChildren();
+            }
+            return false;
+        } catch(Exception e) {
+            log.warn("Could not parse JSON-RPC request method, applying default read timeout", e);
+            return false;
+        }
     }
 
     private String getBitcoindAuthEncoded() throws IOException {

--- a/src/test/java/com/sparrowwallet/sparrow/net/cormorant/bitcoind/BitcoindTransportTimeoutTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/cormorant/bitcoind/BitcoindTransportTimeoutTest.java
@@ -1,0 +1,101 @@
+package com.sparrowwallet.sparrow.net.cormorant.bitcoind;
+
+import com.sparrowwallet.sparrow.io.Server;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for BitcoindTransport#pass never timing out. HttpURLConnection defaults
+ * both connect and read timeout to 0 (infinite), and neither was ever set - so a bitcoind
+ * that accepted a connection and a request but never replied hung the caller forever.
+ * <p>
+ * A short, injected timeout is used here (via the protected test hooks) instead of the real
+ * 60s production default so the test stays fast; what's being verified is that pass()
+ * actually respects whatever timeout is configured, not the specific default value.
+ */
+public class BitcoindTransportTimeoutTest {
+
+    @Test
+    public void methodClassificationIsNotFooledByParamsContainingTheName() {
+        assertTrue(BitcoindTransport.isUnboundedReadTimeoutMethod(
+                "{\"id\":1,\"method\":\"importdescriptors\",\"params\":{}}"));
+        assertFalse(BitcoindTransport.isUnboundedReadTimeoutMethod(
+                "{\"id\":1,\"method\":\"getblockchaininfo\",\"params\":{}}"));
+        //A param value that happens to contain the long-running method's name must not
+        //match - only the top-level "method" field should be inspected.
+        assertFalse(BitcoindTransport.isUnboundedReadTimeoutMethod(
+                "{\"id\":1,\"method\":\"getwalletinfo\",\"params\":{\"note\":\"importdescriptors\"}}"));
+        assertFalse(BitcoindTransport.isUnboundedReadTimeoutMethod("not valid json"));
+        assertFalse(BitcoindTransport.isUnboundedReadTimeoutMethod(""));
+    }
+
+    @Test
+    public void nonRespondingServerFailsWithinTimeoutInsteadOfHangingForever() throws Exception {
+        try(ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            Thread acceptThread = new Thread(() -> {
+                try(Socket accepted = serverSocket.accept()) {
+                    //Accept the connection and read the request, then simply never reply -
+                    //simulating bitcoind accepting an RPC call and hanging.
+                    BufferedReader in = new BufferedReader(new InputStreamReader(accepted.getInputStream()));
+                    while(in.readLine() != null) {
+                        //drain headers/body, then go silent
+                    }
+                } catch(Exception e) {
+                    //Expected once the test's read timeout fires and the connection is torn down
+                }
+            });
+            acceptThread.setDaemon(true);
+            acceptThread.start();
+
+            Server server = new Server("http://127.0.0.1:" + serverSocket.getLocalPort());
+            TestableBitcoindTransport transport = new TestableBitcoindTransport(server, 500);
+
+            assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+                IOException thrown = assertThrows(IOException.class,
+                        () -> transport.pass("{\"id\":1,\"method\":\"getblockchaininfo\",\"params\":{}}"));
+                assertTrue(thrown instanceof SocketTimeoutException || thrown.getCause() instanceof SocketTimeoutException,
+                        "Expected a read timeout, got: " + thrown);
+            });
+        }
+    }
+
+    @Test
+    public void unboundedMethodIsNotSubjectToTheReadTimeout() {
+        TestableBitcoindTransport transport = new TestableBitcoindTransport(new Server("http://127.0.0.1:1"), 500);
+        assertEquals(0, transport.getReadTimeoutMillis("{\"id\":1,\"method\":\"importdescriptors\",\"params\":{}}"));
+        assertEquals(500, transport.getReadTimeoutMillis("{\"id\":1,\"method\":\"getblockchaininfo\",\"params\":{}}"));
+    }
+
+    private static class TestableBitcoindTransport extends BitcoindTransport {
+        private final int testReadTimeoutMillis;
+
+        TestableBitcoindTransport(Server server, int testReadTimeoutMillis) {
+            super(server, "test", "user:pass");
+            this.testReadTimeoutMillis = testReadTimeoutMillis;
+        }
+
+        @Override
+        protected int getConnectTimeoutMillis() {
+            return testReadTimeoutMillis;
+        }
+
+        @Override
+        protected int getReadTimeoutMillis(String request) {
+            return isUnboundedReadTimeoutMethod(request) ? 0 : testReadTimeoutMillis;
+        }
+    }
+}


### PR DESCRIPTION
HttpURLConnection defaults both connect and read timeout to 0 (infinite), and neither was ever set here, so an unreachable/black-holed bitcoind (getOutputStream, which triggers the connect) or one that accepts the connection but never responds (getResponseCode) hangs the caller — and whatever thread called `pass()` — forever.

- Connect timeout: 15s direct, 60s when routed over a Tor proxy to an onion address (onion circuit builds are slow — mirrors the precedent `TcpTransport` already sets via `SLOW_READ_TIMEOUT_SECS` for `BITCOIN_CORE` + onion).
- Read timeout: 60s for all methods except `importdescriptors`, which is exempted because a wallet-birthday rescan can legitimately block for hours. Method name is parsed out of the request JSON (not string-matched), so a `params` value cannot spoof the allowlist.

Tested with a bare, non-responding HTTP server standing in for a black-holed bitcoind: pre-fix, `pass()` hangs indefinitely (confirmed via a differential probe against the pre-fix class); post-fix, it fails within the read timeout instead. Also verified `importdescriptors` is correctly exempted and that the method-name JSON parsing is not fooled by an unrelated `params` value containing the string.

Same failure class as #1 / sparrowwallet#2042 (untimed `HttpURLConnection`/read loop letting a non-responding server hang the client forever), split out into its own PR since it is a different transport (Bitcoin Core RPC vs Electrum TCP) with an independent fix.
