### PR TITLE
Warn users about Coldcard Mk3 seed-entropy advisory at device selection

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/control/TitledDescriptionPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/TitledDescriptionPane.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 
 public class TitledDescriptionPane extends TitledPane {
     private static final String COLDCARD_SEED_WARNING_URL = "https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/";
-    private static final String COLDCARD_SEED_WARNING = "\u26A0 Security warning: Coldcard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q generated seeds with reduced entropy. If your seed was generated on-device without extra dice rolls, update firmware, generate a new seed and move your funds:";
+    private static final String COLDCARD_SEED_WARNING = "\u26A0 Security warning: Coldcard Mk2/Mk3 (firmware 4.0.1-4.1.9) and Mk4/Mk5/Q before their fixed firmware generated seeds with reduced entropy. If your seed was generated on-device with fewer than 50 independent dice rolls, update firmware, generate a new seed and move your funds:";
 
     private Label mainLabel;
     private Label descriptionLabel;

--- a/src/main/java/com/sparrowwallet/sparrow/control/TitledDescriptionPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/TitledDescriptionPane.java
@@ -18,6 +18,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class TitledDescriptionPane extends TitledPane {
+    private static final String COLDCARD_SEED_WARNING_URL = "https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/";
+    private static final String COLDCARD_SEED_WARNING = "\u26A0 Security warning: Coldcard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q generated seeds with reduced entropy. If your seed was generated on-device without extra dice rolls, update firmware, generate a new seed and move your funds:";
+
     private Label mainLabel;
     private Label descriptionLabel;
     protected Hyperlink showHideLink;
@@ -74,6 +77,15 @@ public class TitledDescriptionPane extends TitledPane {
             }
         });
         descriptionBox.getChildren().addAll(descriptionLabel, showHideLink);
+
+        if(walletModel == WalletModel.COLDCARD) {
+            Label warningLabel = createWrappedLabel(COLDCARD_SEED_WARNING);
+            warningLabel.getStyleClass().add("description-error");
+            Hyperlink warningLink = createHyperlink(COLDCARD_SEED_WARNING_URL);
+            VBox warningBox = new VBox(warningLabel, warningLink);
+            warningBox.setSpacing(2);
+            labelsBox.getChildren().add(warningBox);
+        }
 
         listItem.getChildren().add(labelsBox);
         HBox.setHgrow(labelsBox, Priority.ALWAYS);


### PR DESCRIPTION
## Summary

Adds a visible security warning, linking Coinkite's advisory, whenever a **Coldcard** is selected as a device in Sparrow.

On 30–31 Jul 2026 Coinkite [disclosed](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/) that a firmware build error caused Coldcard seed generation to fall back to a software RNG, reducing generated-seed entropy on **Mk3 (fw 4.0.1–5.0.3)** to well below the intended 128 bits (and to ~72 bits on pre-fix Mk4/Q). Sparrow doesn't generate the Coldcard seed, so this isn't a Sparrow flaw — but users who set up a Coldcard via Sparrow may hold funds on an affected seed, and Sparrow's setup flows currently give no indication.

## Change

One guarded block in the shared `TitledDescriptionPane.getTitle()` renders a warning row + advisory link in the pane header. Because every device pane (`FileImportPane`, `DevicePane`, `FileWalletExportPane`) extends `TitledDescriptionPane` and passes a `WalletModel`, this single point covers **all** selection surfaces at once:

- New wallet import (file/QR), single & multisig
- Add keystore to existing wallet (airgapped)
- USB hardware wallet
- Wallet export to Coldcard multisig

The warning is always visible (not hidden behind *Details…*) and independent of expand state.

## Safety of detection

Detection is `walletModel == WalletModel.COLDCARD`, **not** `instanceof`. Several devices subclass the Coldcard importer classes but override `getWalletModel()` — `PassportSinglesig`, `KeystoneMultisig`, `JadeMultisig`, `CoboVaultMultisig`, `PassportMultisig`, `BlueWalletMultisig`, `KeycardShellMultisig`. These correctly do **not** trigger the warning.

## Testing

- Diff is additive and uses only already-imported types (`WalletModel`, `Label`, `Hyperlink`, `VBox`) and existing in-class helpers (`createWrappedLabel`, `createHyperlink`); brace/paren balanced.
- **Note:** I was not able to run a full local Gradle build in my environment (submodule + toolchain setup), so I'd appreciate a maintainer build/verify. Manual check: open *New Wallet → Import*, expand any Coldcard entry (single & multisig) — the warning + link should appear; confirm Passport/Keystone/Jade do **not** show it.

## Notes

- References a public Coinkite advisory (not an undisclosed Sparrow vulnerability), hence a regular PR rather than the SECURITY.md process. Happy to adjust wording, styling, or scope (e.g. limit to import panes only) per your preference.

🤖 Drafted with Claude Code
