### PR TITLE
Add an option to derive a BIP85 child mnemonic when importing BIP39 software wallet

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/control/MnemonicKeystoreImportPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/MnemonicKeystoreImportPane.java
@@ -1,25 +1,37 @@
 package com.sparrowwallet.sparrow.control;
 
 import com.sparrowwallet.drongo.KeyDerivation;
+import com.sparrowwallet.drongo.Utils;
 import com.sparrowwallet.drongo.crypto.ChildNumber;
+import com.sparrowwallet.drongo.crypto.DeterministicKey;
+import com.sparrowwallet.drongo.crypto.HDKeyDerivation;
+import com.sparrowwallet.drongo.crypto.HDDerivationException;
 import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.wallet.Bip85;
 import com.sparrowwallet.drongo.wallet.DeterministicSeed;
 import com.sparrowwallet.drongo.wallet.Keystore;
 import com.sparrowwallet.drongo.wallet.MnemonicException;
 import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.EventManager;
 import com.sparrowwallet.sparrow.event.KeystoreImportEvent;
+import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
 import com.sparrowwallet.sparrow.io.ImportException;
 import com.sparrowwallet.sparrow.io.KeystoreMnemonicImport;
+import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.*;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import org.controlsfx.tools.Borders;
+import org.controlsfx.glyphfont.Glyph;
 import org.controlsfx.validation.ValidationResult;
 import org.controlsfx.validation.ValidationSupport;
 import org.controlsfx.validation.Validator;
@@ -27,6 +39,8 @@ import org.controlsfx.validation.decoration.StyleClassValidationDecoration;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.text.Normalizer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,6 +52,7 @@ public class MnemonicKeystoreImportPane extends MnemonicKeystorePane {
     private SplitMenuButton importButton;
 
     private Button generateButton;
+    private Button deriveBip85Button;
     private Button calculateButton;
     private Button backButton;
     private Button nextButton;
@@ -118,6 +133,14 @@ public class MnemonicKeystoreImportPane extends MnemonicKeystorePane {
         calculateButton.managedProperty().bind(calculateButton.visibleProperty());
         calculateButton.setTooltip(new Tooltip("Create the keystore from the provided word list"));
 
+        deriveBip85Button = new Button("BIP85 child mnemonic");
+        deriveBip85Button.setOnAction(event -> {
+            deriveBip85Child();
+        });
+        deriveBip85Button.managedProperty().bind(deriveBip85Button.visibleProperty());
+        deriveBip85Button.setVisible(false);
+        deriveBip85Button.setTooltip(new Tooltip("Derive child seed words from the entered BIP39 parent seed"));
+
         backButton = new Button("Back");
         backButton.setOnAction(event -> {
             displayMnemonicCode();
@@ -135,7 +158,7 @@ public class MnemonicKeystoreImportPane extends MnemonicKeystorePane {
         nextButton.setVisible(false);
         nextButton.setDefaultButton(true);
 
-        return List.of(backButton, nextButton, confirmButton, calculateButton);
+        return List.of(backButton, nextButton, confirmButton, deriveBip85Button, calculateButton);
     }
 
     protected void onWordChange(boolean empty, boolean validWords, boolean validChecksum) {
@@ -155,9 +178,45 @@ public class MnemonicKeystoreImportPane extends MnemonicKeystorePane {
         }
 
         generateButton.setVisible(empty && generatedMnemonicCode == null);
+        deriveBip85Button.setVisible(!empty && validChecksum && generatedMnemonicCode == null);
         calculateButton.setDisable(!validChecksum);
         validLabel.setVisible(validChecksum);
         invalidLabel.setVisible(!validChecksum && !empty);
+    }
+
+    private void deriveBip85Child() {
+        String parentPassphrase = passphraseProperty.get() == null ? "" : passphraseProperty.get();
+        long creationTimeMillis = System.currentTimeMillis();
+        DeterministicSeed parentSeed = new DeterministicSeed(wordEntriesProperty.get(), parentPassphrase, creationTimeMillis, DeterministicSeed.Type.BIP39);
+        byte[] parentSeedBytes = null;
+        try {
+            parentSeed.check();
+            parentSeedBytes = parentSeed.getSeedBytes();
+            byte[] parentMasterFingerprint = HDKeyDerivation.createMasterPrivateKey(parentSeedBytes).getFingerprint();
+            Bip85ChildDialog bip85ChildDialog = new Bip85ChildDialog(wordEntriesProperty.get().size(), parentPassphrase, parentMasterFingerprint);
+            bip85ChildDialog.initOwner(this.getScene().getWindow());
+            Optional<Bip85Child> optChild = bip85ChildDialog.showAndWait();
+            if(optChild.isEmpty()) {
+                return;
+            }
+
+            DeterministicKey parentMasterKey = HDKeyDerivation.createMasterPrivateKey(parentSeedBytes);
+            DeterministicSeed childSeed = Bip85.deriveBip39Child(parentMasterKey, optChild.get().words(), optChild.get().index(), creationTimeMillis);
+
+            passphraseProperty.unbind();
+            passphraseProperty.set("");
+            generatedMnemonicCode = childSeed.getMnemonicCode();
+            setContent(getMnemonicWordsEntry(generatedMnemonicCode.size(), true, true));
+            displayMnemonicCode();
+        } catch(MnemonicException | HDDerivationException e) {
+            String errorMessage = e.getMessage() == null || e.getMessage().isEmpty() ? "Could not derive BIP85 child mnemonic" : e.getMessage();
+            setError("BIP85 Error", errorMessage + ".");
+        } finally {
+            parentSeed.clear();
+            if(parentSeedBytes != null) {
+                Arrays.fill(parentSeedBytes, (byte)0);
+            }
+        }
     }
 
     private void generateNew() {
@@ -184,6 +243,7 @@ public class MnemonicKeystoreImportPane extends MnemonicKeystorePane {
         calculateButton.setVisible(false);
         nextButton.setVisible(true);
         backButton.setVisible(false);
+        deriveBip85Button.setVisible(false);
 
         if(generatedMnemonicCode.size() != wordsPane.getChildren().size()) {
             throw new IllegalStateException("Generated mnemonic words list not same size as displayed words list");
@@ -224,6 +284,7 @@ public class MnemonicKeystoreImportPane extends MnemonicKeystorePane {
         nextButton.setVisible(false);
         confirmButton.setVisible(true);
         generateButton.setVisible(false);
+        deriveBip85Button.setVisible(false);
     }
 
     private void confirmBackup() {
@@ -233,6 +294,7 @@ public class MnemonicKeystoreImportPane extends MnemonicKeystorePane {
         setExpanded(true);
         backButton.setVisible(true);
         generateButton.setVisible(false);
+        deriveBip85Button.setVisible(false);
     }
 
     private void prepareImport() {
@@ -319,5 +381,168 @@ public class MnemonicKeystoreImportPane extends MnemonicKeystorePane {
         contentBox.setPrefHeight(60);
 
         return contentBox;
+    }
+
+    private record Bip85Child(int words, int index) {
+    }
+
+    private static class Bip85ChildDialog extends Dialog<Bip85Child> {
+        private static final int MAX_INDEX = Integer.MAX_VALUE;
+        private static final List<Integer> WORD_COUNTS = List.of(24, 21, 18, 15, 12);
+
+        private final String parentPassphrase;
+        private final byte[] parentMasterFingerprint;
+        private final ComboBox<Integer> wordCount;
+        private final IntegerSpinner childIndex;
+        private final ViewPasswordField passphrase;
+        private final boolean requiresParentPassphrase;
+
+        public Bip85ChildDialog(int defaultWords, String parentPassphrase, byte[] parentMasterFingerprint) {
+            this.parentPassphrase = parentPassphrase == null ? "" : parentPassphrase;
+            this.parentMasterFingerprint = parentMasterFingerprint;
+            this.passphrase = new ViewPasswordField();
+            this.requiresParentPassphrase = !this.parentPassphrase.isEmpty();
+
+            final DialogPane dialogPane = getDialogPane();
+            setTitle("Derive BIP85 child mnemonic");
+            dialogPane.setHeaderText(requiresParentPassphrase ? "Choose BIP85 child mnemonic details\nand confirm the parent passphrase:" : "Choose BIP85 child mnemonic details:");
+            dialogPane.getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
+            AppServices.setStageIcon(dialogPane.getScene().getWindow());
+            dialogPane.getButtonTypes().addAll(ButtonType.CANCEL, ButtonType.OK);
+            dialogPane.setPrefWidth(380);
+            dialogPane.setPrefHeight(requiresParentPassphrase ? 340 : 290);
+            AppServices.moveToActiveWindowScreen(this);
+
+            Glyph key = new Glyph(FontAwesome5.FONT_NAME, FontAwesome5.Glyph.KEY);
+            key.setFontSize(50);
+            dialogPane.setGraphic(key);
+
+            GridPane gridPane = new GridPane();
+            gridPane.setHgap(10);
+            gridPane.setVgap(10);
+
+            wordCount = new ComboBox<>();
+            wordCount.getItems().addAll(WORD_COUNTS);
+            wordCount.getSelectionModel().select(WORD_COUNTS.contains(defaultWords) ? Integer.valueOf(defaultWords) : Integer.valueOf(24));
+            wordCount.setMaxWidth(Double.MAX_VALUE);
+            GridPane.setHgrow(wordCount, Priority.ALWAYS);
+
+            childIndex = new IntegerSpinner();
+            childIndex.setValueFactory(new IntegerSpinner.ValueFactory(0, MAX_INDEX, 0));
+            childIndex.setEditable(true);
+            childIndex.getEditor().setTextFormatter(new TextFormatter<>((TextFormatter.Change change) -> {
+                String newText = change.getControlNewText();
+                if(!newText.matches("\\d*")) {
+                    return null;
+                }
+                if(newText.isEmpty()) {
+                    return change;
+                }
+
+                try {
+                    return Long.parseLong(newText) <= MAX_INDEX ? change : null;
+                } catch(NumberFormatException e) {
+                    return null;
+                }
+            }));
+            childIndex.getEditor().textProperty().addListener((observable, oldValue, newValue) -> {
+                if(newValue != null && !newValue.isEmpty()) {
+                    childIndex.getValueFactory().setValue(Integer.parseInt(newValue));
+                }
+            });
+            childIndex.setMaxWidth(Double.MAX_VALUE);
+            GridPane.setHgrow(childIndex, Priority.ALWAYS);
+
+            TextField derivationPath = new TextField();
+            derivationPath.setEditable(false);
+            derivationPath.setFocusTraversable(false);
+            derivationPath.setMaxWidth(Double.MAX_VALUE);
+            derivationPath.textProperty().bind(Bindings.createStringBinding(() ->
+                    "m/83696968'/39'/0'/" + wordCount.getValue() + "'/" +
+                            (childIndex.getEditor().getText().isEmpty() ? "" : childIndex.getValue()) + "'",
+                    wordCount.valueProperty(), childIndex.valueProperty(), childIndex.getEditor().textProperty()));
+            GridPane.setHgrow(derivationPath, Priority.ALWAYS);
+
+            gridPane.add(new Label("Number of words"), 0, 0);
+            gridPane.add(wordCount, 1, 0);
+            gridPane.add(new Label("Child index"), 0, 1);
+            gridPane.add(childIndex, 1, 1);
+            gridPane.add(new Label("Derivation path"), 0, 2);
+            gridPane.add(derivationPath, 1, 2);
+
+            int nextRow = 3;
+            if(requiresParentPassphrase) {
+                passphrase.setMaxWidth(Double.MAX_VALUE);
+                GridPane.setHgrow(passphrase, Priority.ALWAYS);
+                gridPane.add(new Label("Parent passphrase"), 0, nextRow);
+                gridPane.add(passphrase, 1, nextRow++);
+
+                ValidationSupport validationSupport = new ValidationSupport();
+                validationSupport.setValidationDecorator(new StyleClassValidationDecoration());
+                validationSupport.registerValidator(passphrase, (Control c, String newValue) ->
+                        ValidationResult.fromErrorIf(c, "Passphrase does not match", !isParentPassphraseConfirmed()));
+            }
+
+            HBox fingerprintBox = new HBox(10);
+            fingerprintBox.setAlignment(Pos.CENTER_LEFT);
+            TextField fingerprintHex = new TextField();
+            fingerprintHex.setDisable(true);
+            fingerprintHex.setMaxWidth(80);
+            fingerprintHex.getStyleClass().addAll("fixed-width");
+            fingerprintHex.setStyle("-fx-opacity: 0.6");
+            fingerprintHex.setText(Utils.bytesToHex(parentMasterFingerprint));
+            LifeHashIcon lifeHashIcon = new LifeHashIcon();
+            lifeHashIcon.setData(parentMasterFingerprint);
+            HelpLabel helpLabel = new HelpLabel();
+            helpLabel.setHelpText("The parent master fingerprint identifies the parent seed and passphrase used for child seed derivation." +
+                    "\nTake a moment to identify it before deriving the BIP85 child mnemonic.");
+            fingerprintBox.getChildren().addAll(fingerprintHex, lifeHashIcon, helpLabel);
+            gridPane.add(new Label("Parent fingerprint"), 0, nextRow);
+            gridPane.add(fingerprintBox, 1, nextRow++);
+
+            if(requiresParentPassphrase) {
+                Glyph warnGlyph = new Glyph(FontAwesome5.FONT_NAME, FontAwesome5.Glyph.EXCLAMATION_TRIANGLE);
+                warnGlyph.getStyleClass().add("warn-icon");
+                warnGlyph.setFontSize(12);
+                Label warnLabel = new Label("Note the parent fingerprint before proceeding!", warnGlyph);
+                warnLabel.setGraphicTextGap(5);
+                GridPane.setColumnSpan(warnLabel, 2);
+                gridPane.add(warnLabel, 0, nextRow);
+            }
+
+            VBox content = new VBox(10);
+            content.setPrefHeight(requiresParentPassphrase ? 230 : 180);
+            content.getChildren().add(gridPane);
+            dialogPane.setContent(content);
+
+            Button okButton = (Button)dialogPane.lookupButton(ButtonType.OK);
+            okButton.disableProperty().bind(Bindings.createBooleanBinding(
+                    () -> childIndex.getEditor().getText().isEmpty() || !isParentPassphraseConfirmed(),
+                    childIndex.getEditor().textProperty(), passphrase.textProperty()));
+
+            Platform.runLater(childIndex::requestFocus);
+
+            setResultConverter(dialogButton -> {
+                if(dialogButton != ButtonType.OK) {
+                    return null;
+                }
+
+                if(childIndex.getEditor().getText().isEmpty() || !isParentPassphraseConfirmed()) {
+                    return null;
+                }
+
+                childIndex.commitValue();
+                return new Bip85Child(wordCount.getValue(), childIndex.getValue());
+            });
+        }
+
+        private boolean isParentPassphraseConfirmed() {
+            if (!requiresParentPassphrase) {
+                return true;
+            }
+            return Normalizer.normalize(parentPassphrase, Normalizer.Form.NFKD)
+                    .equals(Normalizer.normalize(passphrase.getText(), Normalizer.Form.NFKD));
+        }
+
     }
 }


### PR DESCRIPTION
Add an option to derive a BIP85 child mnemonic when importing BIP39 software wallet. The scope is intentionally narrowed to only BIP39 software keys to make the diff as small as possible. Future PR's can add derivation for other  key types. 

A new button to derive "BIP85 child mnemonic"

<img width="642" height="324" alt="1pw" src="https://github.com/user-attachments/assets/7e841e1f-ea9d-4195-8297-55011cabcb5b" />

Dialog asks for the word count and index. Optional parent passphrase needs to match. With the passphrase, an additional warning to verify the master key fingerprint is shown to the user.

<img width="644" height="553" alt="2pw" src="https://github.com/user-attachments/assets/fb792595-9369-4b40-b27c-1e4951e7a855" />


After deriving the BIP85 child, the process continues normally by asking the user to "Confirm backup" of the child mnemonic.

<img width="459" height="309" alt="3pw" src="https://github.com/user-attachments/assets/1d1ffbd6-1e9c-4e14-ac69-36634740aa80" />

The example from the screenshots was crosschecked against a SeedSigner. Further correctness tests are part of the drongo PR linked below.

Related links
- drongo: https://github.com/sparrowwallet/drongo/pull/47
- earlier issue: https://github.com/sparrowwallet/sparrow/issues/622

Disclaimer: LLM's were used as part of the development process. The code changes were iterated, reviewed and manually tested by me.