### PR TITLE
Improve screen reader accessibility

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -445,9 +445,7 @@ public class AppController implements Initializable {
         serverToggle.setDisable(!Config.get().hasServer());
         onlineProperty().bindBidirectional(serverToggle.selectedProperty());
         onlineProperty().addListener(new WeakChangeListener<>(serverToggleOnlineListener));
-        serverToggle.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
-            Config.get().setMode(serverToggle.isSelected() ? Mode.ONLINE : Mode.OFFLINE);
-        });
+        serverToggle.addEventHandler(ActionEvent.ACTION, event -> Config.get().setMode(serverToggle.isSelected() ? Mode.ONLINE : Mode.OFFLINE));
 
         openTransactionIdItem.disableProperty().bind(onlineProperty().not());
         setNetworkLabel();

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -40,6 +40,7 @@ import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import javafx.concurrent.Worker;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.AccessibleRole;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -951,12 +952,24 @@ public class AppServices {
         stage.getIcons().add(getWindowIcon());
 
         if(stage.getScene() != null) {
+            configureDialogAccessibility(stage.getScene().getRoot(), OsType.getCurrent());
             if(Config.get().getTheme() == Theme.DARK) {
                 stage.getScene().getStylesheets().add(AppServices.class.getResource("darktheme.css").toExternalForm());
             }
             if(Config.get().isChunkAddresses()) {
                 stage.getScene().getRoot().getStyleClass().add("chunk-addresses");
             }
+        }
+    }
+
+    static void configureDialogAccessibility(Parent root, OsType osType) {
+        /*
+         * JavaFX assigns DialogPane the DIALOG role to support Windows screen readers, but the macOS
+         * accessibility bridge does not map that role to a native accessibility element. Restoring
+         * Parent's default role allows VoiceOver to discover and navigate the dialog's children.
+         */
+        if(osType == OsType.MACOS && root.getAccessibleRole() == AccessibleRole.DIALOG) {
+            root.setAccessibleRole(AccessibleRole.PARENT);
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/control/AccessibleField.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/AccessibleField.java
@@ -1,0 +1,20 @@
+package com.sparrowwallet.sparrow.control;
+
+import javafx.collections.ListChangeListener;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import tornadofx.control.Field;
+
+/**
+ * A form field that associates its generated label with its primary input.
+ */
+public class AccessibleField extends Field {
+    public AccessibleField() {
+        getInputs().addListener((ListChangeListener<Node>)change -> updateLabelFor());
+    }
+
+    private void updateLabelFor() {
+        Label label = (Label)getLabelContainer().getChildren().getFirst();
+        label.setLabelFor(getInputs().isEmpty() ? null : getInputs().getFirst());
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/control/AccessibleField.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/AccessibleField.java
@@ -17,4 +17,9 @@ public class AccessibleField extends Field {
         Label label = (Label)getLabelContainer().getChildren().getFirst();
         label.setLabelFor(getInputs().isEmpty() ? null : getInputs().getFirst());
     }
+
+    public void setLabelFor(Node input) {
+        Label label = (Label)getLabelContainer().getChildren().getFirst();
+        label.setLabelFor(input);
+    }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/control/AccessibleStatusBar.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/AccessibleStatusBar.java
@@ -1,0 +1,11 @@
+package com.sparrowwallet.sparrow.control;
+
+import javafx.scene.AccessibleRole;
+import org.controlsfx.control.StatusBar;
+
+public class AccessibleStatusBar extends StatusBar {
+    public AccessibleStatusBar() {
+        setAccessibleRole(AccessibleRole.TOOL_BAR);
+        setAccessibleRoleDescription("status bar");
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/control/AccessibleTreeTableRow.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/AccessibleTreeTableRow.java
@@ -1,0 +1,40 @@
+package com.sparrowwallet.sparrow.control;
+
+import com.sparrowwallet.sparrow.wallet.Entry;
+import javafx.scene.AccessibleAttribute;
+import javafx.scene.Node;
+import javafx.scene.control.TreeTableCell;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTablePosition;
+import javafx.scene.control.TreeTableRow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AccessibleTreeTableRow extends TreeTableRow<Entry> {
+    @Override
+    public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
+        if(attribute == AccessibleAttribute.TEXT && !isEmpty()) {
+            TreeTablePosition<Entry, ?> focusedCell = getTreeTableView().getFocusModel().getFocusedCell();
+            TreeTableColumn<Entry, ?> focusedColumn = focusedCell == null ? null : focusedCell.getTableColumn();
+            List<String> values = new ArrayList<>();
+            for(Node child : getChildrenUnmodifiable()) {
+                if(child instanceof TreeTableCell<?, ?> cell && cell.isVisible()) {
+                    String column = cell.getTableColumn() == null ? null : cell.getTableColumn().getText();
+                    String value = cell.getText();
+                    if(cell.getTableColumn() == focusedColumn && column != null && !column.isBlank()) {
+                        return column + ", " + (value == null || value.isBlank() ? "blank" : value);
+                    } else if(column != null && !column.isBlank()) {
+                        values.add(column + ", " + (value == null || value.isBlank() ? "blank" : value));
+                    }
+                }
+            }
+
+            if(!values.isEmpty()) {
+                return String.join("; ", values);
+            }
+        }
+
+        return super.queryAccessibleAttribute(attribute, parameters);
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/control/BalanceChart.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/BalanceChart.java
@@ -9,6 +9,8 @@ import com.sparrowwallet.sparrow.wallet.Entry;
 import com.sparrowwallet.sparrow.wallet.TransactionEntry;
 import com.sparrowwallet.sparrow.wallet.WalletTransactionsEntry;
 import javafx.beans.NamedArg;
+import javafx.application.Platform;
+import javafx.scene.Parent;
 import javafx.scene.Node;
 import javafx.scene.chart.*;
 
@@ -28,6 +30,9 @@ public class BalanceChart extends LineChart<Number, Number> {
 
     public BalanceChart(@NamedArg("xAxis") Axis<Number> xAxis, @NamedArg("yAxis") Axis<Number> yAxis) {
         super(xAxis, yAxis);
+        setFocusTraversable(false);
+        xAxis.setFocusTraversable(false);
+        yAxis.setFocusTraversable(false);
     }
 
     public void initialize(WalletTransactionsEntry walletTransactionsEntry) {
@@ -77,6 +82,15 @@ public class BalanceChart extends LineChart<Number, Number> {
 
         if(selectedEntry != null) {
             select(selectedEntry);
+        }
+
+        Platform.runLater(() -> disableFocusTraversal(this));
+    }
+
+    private static void disableFocusTraversal(Node node) {
+        node.setFocusTraversable(false);
+        if(node instanceof Parent parent) {
+            parent.getChildrenUnmodifiable().forEach(BalanceChart::disableFocusTraversal);
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/control/CoinTreeTable.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/CoinTreeTable.java
@@ -26,13 +26,19 @@ import io.reactivex.subjects.PublishSubject;
 import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.geometry.Pos;
+import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
+import javafx.scene.TraversalDirection;
 import javafx.scene.control.*;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -46,12 +52,66 @@ public class CoinTreeTable extends TreeTableView<Entry> {
     private final PublishSubject<WalletTableChangedEvent> walletTableSubject = PublishSubject.create();
     private final Observable<WalletTableChangedEvent> walletTableEvents = walletTableSubject.debounce(1, TimeUnit.SECONDS);
 
+    public CoinTreeTable() {
+        setRowFactory(table -> new AccessibleTreeTableRow());
+        setAccessibleRoleDescription("table");
+        getSelectionModel().setCellSelectionEnabled(true);
+        addEventFilter(KeyEvent.KEY_PRESSED, this::moveFocusedColumn);
+    }
+
+    private void moveFocusedColumn(KeyEvent event) {
+        if(event.getCode() == KeyCode.TAB) {
+            requestFocusTraversal(event.isShiftDown() ? TraversalDirection.PREVIOUS : TraversalDirection.NEXT);
+            event.consume();
+            return;
+        }
+
+        if(event.getCode() != KeyCode.LEFT && event.getCode() != KeyCode.RIGHT) {
+            return;
+        }
+
+        TreeTablePosition<Entry, ?> focusedCell = getFocusModel().getFocusedCell();
+        int row = focusedCell == null ? getSelectionModel().getSelectedIndex() : focusedCell.getRow();
+        int column = focusedCell == null || focusedCell.getTableColumn() == null ? 0 : getVisibleLeafIndex(focusedCell.getTableColumn());
+        int nextColumn = column + (event.getCode() == KeyCode.RIGHT ? 1 : -1);
+        if(row >= 0 && nextColumn >= 0 && nextColumn < getVisibleLeafColumns().size()) {
+            TreeTableColumn<Entry, ?> tableColumn = getVisibleLeafColumn(nextColumn);
+            getSelectionModel().clearAndSelect(row, tableColumn);
+            getFocusModel().focus(row, tableColumn);
+
+            Object rowNode = queryAccessibleAttribute(AccessibleAttribute.ROW_AT_INDEX, row);
+            if(rowNode instanceof TreeTableRow<?> tableRow) {
+                tableRow.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
+            }
+            notifyAccessibleAttributeChanged(AccessibleAttribute.FOCUS_ITEM);
+        }
+        event.consume();
+    }
+
+    public static <T> List<T> getSelectedRows(TreeTableView<T> treeTableView) {
+        return treeTableView.getSelectionModel().getSelectedCells().stream()
+                .map(TreeTablePosition::getTreeItem)
+                .filter(Objects::nonNull)
+                .distinct()
+                .map(TreeItem::getValue)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
     public TableType getTableType() {
         return tableType;
     }
 
     public void setTableType(TableType tableType) {
         this.tableType = tableType;
+        setAccessibleText(switch(tableType) {
+            case TRANSACTIONS -> "Transactions";
+            case RECEIVE_ADDRESSES -> "Receive addresses";
+            case CHANGE_ADDRESSES -> "Change addresses";
+            case UTXOS -> "Unspent transaction outputs";
+            case SEARCH_WALLET -> "Wallet search results";
+            case WALLET_SUMMARY -> "Wallet summary";
+        });
     }
 
     public BitcoinUnit getBitcoinUnit() {

--- a/src/main/java/com/sparrowwallet/sparrow/control/EntryCell.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/EntryCell.java
@@ -98,6 +98,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
                 HBox actionBox = new HBox();
                 actionBox.getStyleClass().add("cell-actions");
                 Button viewTransactionButton = new Button("");
+                viewTransactionButton.setFocusTraversable(false);
                 viewTransactionButton.setGraphic(getViewTransactionGlyph());
                 viewTransactionButton.setOnAction(event -> {
                     EventManager.get().post(new ViewTransactionEvent(this.getScene().getWindow(), transactionEntry.getBlockTransaction()));
@@ -108,6 +109,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
                 if(blockTransaction.getHeight() <= 0 && canRBF(blockTransaction, transactionEntry.getWallet()) &&
                         Config.get().isIncludeMempoolOutputs() && transactionEntry.getWallet().allInputsFromWallet(blockTransaction.getHash())) {
                     Button increaseFeeButton = new Button("");
+                    increaseFeeButton.setFocusTraversable(false);
                     increaseFeeButton.setGraphic(getIncreaseFeeRBFGlyph());
                     increaseFeeButton.setOnAction(event -> {
                         increaseFee(transactionEntry, false);
@@ -117,6 +119,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
 
                 if(blockTransaction.getHeight() <= 0 && containsWalletOutputs(transactionEntry)) {
                     Button cpfpButton = new Button("");
+                    cpfpButton.setFocusTraversable(false);
                     cpfpButton.setGraphic(getIncreaseFeeCPFPGlyph());
                     cpfpButton.setOnAction(event -> {
                         createCpfp(transactionEntry);
@@ -140,6 +143,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
 
                 if(!nodeEntry.getNode().getWallet().isBip47() && nodeEntry.getNode().getWallet().getPolicyType() != PolicyType.SINGLE_SP) {
                     Button receiveButton = new Button("");
+                    receiveButton.setFocusTraversable(false);
                     receiveButton.setGraphic(getReceiveGlyph());
                     receiveButton.setOnAction(event -> {
                         EventManager.get().post(new ReceiveActionEvent(nodeEntry));
@@ -150,6 +154,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
 
                 if(canSignMessage(nodeEntry.getNode())) {
                     Button signMessageButton = new Button("");
+                    signMessageButton.setFocusTraversable(false);
                     signMessageButton.setGraphic(getSignMessageGlyph());
                     signMessageButton.setOnAction(event -> {
                         MessageSignDialog messageSignDialog = new MessageSignDialog(nodeEntry.getWallet(), nodeEntry.getNode());
@@ -177,6 +182,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
                 HBox actionBox = new HBox();
                 actionBox.getStyleClass().add("cell-actions");
                 Button viewTransactionButton = new Button("");
+                viewTransactionButton.setFocusTraversable(false);
                 viewTransactionButton.setGraphic(getViewTransactionGlyph());
                 viewTransactionButton.setOnAction(event -> {
                     EventManager.get().post(new ViewTransactionEvent(this.getScene().getWindow(), hashIndexEntry.getBlockTransaction(), hashIndexEntry));
@@ -185,6 +191,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
 
                 if(hashIndexEntry.getType().equals(HashIndexEntry.Type.OUTPUT) && hashIndexEntry.isSpendable() && !hashIndexEntry.getHashIndex().isSpent()) {
                     Button spendUtxoButton = new Button("");
+                    spendUtxoButton.setFocusTraversable(false);
                     spendUtxoButton.setGraphic(getSendGlyph());
                     spendUtxoButton.setOnAction(event -> {
                         sendSelectedUtxos(getTreeTableView(), hashIndexEntry);
@@ -428,8 +435,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
     }
 
     private static void sendSelectedUtxos(TreeTableView<Entry> treeTableView, HashIndexEntry hashIndexEntry) {
-        List<HashIndexEntry> utxoEntries = treeTableView.getSelectionModel().getSelectedCells().stream()
-                .map(tp -> tp.getTreeItem().getValue())
+        List<HashIndexEntry> utxoEntries = CoinTreeTable.getSelectedRows(treeTableView).stream()
                 .filter(e -> e instanceof HashIndexEntry)
                 .map(e -> (HashIndexEntry)e)
                 .filter(e -> e.getType().equals(HashIndexEntry.Type.OUTPUT) && e.isSpendable())
@@ -445,8 +451,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
     }
 
     private static void freezeUtxo(TreeTableView<Entry> treeTableView, HashIndexEntry hashIndexEntry) {
-        List<BlockTransactionHashIndex> utxos = treeTableView.getSelectionModel().getSelectedCells().stream()
-                .map(tp -> tp.getTreeItem().getValue())
+        List<BlockTransactionHashIndex> utxos = CoinTreeTable.getSelectedRows(treeTableView).stream()
                 .filter(e -> e instanceof HashIndexEntry && ((HashIndexEntry)e).getType().equals(HashIndexEntry.Type.OUTPUT))
                 .map(e -> ((HashIndexEntry)e).getHashIndex())
                 .filter(ref -> ref.getStatus() != Status.FROZEN)
@@ -457,8 +462,7 @@ public class EntryCell extends TreeTableCell<Entry, Entry> implements Confirmati
     }
 
     private static void unfreezeUtxo(TreeTableView<Entry> treeTableView, HashIndexEntry hashIndexEntry) {
-        List<BlockTransactionHashIndex> utxos = treeTableView.getSelectionModel().getSelectedCells().stream()
-                .map(tp -> tp.getTreeItem().getValue())
+        List<BlockTransactionHashIndex> utxos = CoinTreeTable.getSelectedRows(treeTableView).stream()
                 .filter(e -> e instanceof HashIndexEntry && ((HashIndexEntry)e).getType().equals(HashIndexEntry.Type.OUTPUT))
                 .map(e -> ((HashIndexEntry)e).getHashIndex())
                 .filter(ref -> ref.getStatus() == Status.FROZEN)

--- a/src/main/java/com/sparrowwallet/sparrow/control/FiatLabel.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/FiatLabel.java
@@ -27,11 +27,20 @@ public class FiatLabel extends CopyableLabel {
 
     public FiatLabel(String text) {
         super(text);
+        updatePresence(text);
+        textProperty().addListener((observable, oldValue, newValue) -> updatePresence(newValue));
         valueProperty().addListener((observable, oldValue, newValue) -> setValueAsText((Long)newValue, Config.get().getUnitFormat()));
         btcRateProperty().addListener((observable, oldValue, newValue) -> setValueAsText(getValue(), Config.get().getUnitFormat()));
         currencyProperty().addListener((observable, oldValue, newValue) -> setValueAsText(getValue(), Config.get().getUnitFormat()));
         tooltip = new Tooltip();
         contextMenu = new FiatContextMenu();
+    }
+
+    private void updatePresence(String text) {
+        boolean present = text != null && !text.isEmpty();
+        setManaged(present);
+        setVisible(present);
+        setFocusTraversable(present);
     }
 
     public final LongProperty valueProperty() {

--- a/src/main/java/com/sparrowwallet/sparrow/control/HelpLabel.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/HelpLabel.java
@@ -23,6 +23,7 @@ public class HelpLabel extends Label {
         tooltip.setShowDuration(Duration.seconds(15));
         tooltip.setShowDelay(Duration.millis(500));
         getStyleClass().add("help-label");
+        accessibleTextProperty().bind(helpTextProperty());
 
         Platform.runLater(() -> setTooltip(tooltip));
     }

--- a/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
@@ -175,6 +175,7 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
         Field ignoreDustField = new Field();
         ignoreDustField.setText("Ignore dust:");
         ignoreDust = new UnlabeledToggleSwitch();
+        ignoreDust.setAccessibleText("Ignore dust");
         ignoreDustField.getInputs().add(ignoreDust);
 
         fieldset.getChildren().addAll(keyField, keyScriptTypeField, addressField, toAddressField, feeRangeField, feeRateField, ignoreDustField);

--- a/src/main/java/com/sparrowwallet/sparrow/control/TabList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/TabList.java
@@ -1,0 +1,46 @@
+package com.sparrowwallet.sparrow.control;
+
+import javafx.scene.AccessibleAttribute;
+import javafx.scene.AccessibleRole;
+import javafx.scene.Node;
+import javafx.scene.layout.VBox;
+
+import java.util.List;
+
+/**
+ * A visually custom list of tabs that exposes the same accessibility contract
+ * as a JavaFX {@link javafx.scene.control.TabPane}.
+ */
+public class TabList extends VBox {
+    public TabList() {
+        setAccessibleRole(AccessibleRole.TAB_PANE);
+    }
+
+    @Override
+    public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
+        List<Node> tabs = getTabs();
+        return switch(attribute) {
+            case FOCUS_ITEM -> tabs.stream()
+                    .filter(tab -> Boolean.TRUE.equals(tab.queryAccessibleAttribute(AccessibleAttribute.SELECTED)))
+                    .findFirst()
+                    .orElse(null);
+            case ITEM_COUNT -> tabs.size();
+            case ITEM_AT_INDEX -> getTabAtIndex(tabs, parameters);
+            default -> super.queryAccessibleAttribute(attribute, parameters);
+        };
+    }
+
+    private List<Node> getTabs() {
+        return getChildren().stream()
+                .filter(node -> node.getAccessibleRole() == AccessibleRole.TAB_ITEM)
+                .toList();
+    }
+
+    private Node getTabAtIndex(List<Node> tabs, Object... parameters) {
+        if(parameters.length == 0 || !(parameters[0] instanceof Integer index) || index < 0 || index >= tabs.size()) {
+            return null;
+        }
+
+        return tabs.get(index);
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/control/TabToggleButton.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/TabToggleButton.java
@@ -1,0 +1,13 @@
+package com.sparrowwallet.sparrow.control;
+
+import javafx.scene.AccessibleRole;
+import javafx.scene.control.ToggleButton;
+
+/**
+ * A toggle button used to select a page in a visually custom tab interface.
+ */
+public class TabToggleButton extends ToggleButton {
+    public TabToggleButton() {
+        setAccessibleRole(AccessibleRole.TAB_ITEM);
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/control/TitledDescriptionPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/TitledDescriptionPane.java
@@ -5,9 +5,13 @@ import com.sparrowwallet.drongo.wallet.Wallet;
 import com.sparrowwallet.drongo.wallet.WalletModel;
 import com.sparrowwallet.sparrow.AppServices;
 import javafx.application.Platform;
+import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.AccessibleAttribute;
+import javafx.scene.AccessibleRole;
 import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
@@ -26,11 +30,22 @@ public class TitledDescriptionPane extends TitledPane {
     public TitledDescriptionPane(String title, String description, String content, WalletModel walletModel) {
         getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
         getStyleClass().add("titled-description-pane");
+
+        //This control is a card with independent header actions and optional details. Exposing the
+        //whole card as a TitledPane makes those descendants unavailable to some accessibility bridges.
+        setAccessibleRole(AccessibleRole.PARENT);
         setAccessibleText(title);
 
         setPadding(Insets.EMPTY);
         setGraphic(getTitle(title, description, walletModel));
         setContent(getContentBox(content));
+        graphicProperty().addListener((observable, oldValue, newValue) -> notifyAccessibleAttributeChanged(AccessibleAttribute.CHILDREN));
+        contentProperty().addListener((observable, oldValue, newValue) -> notifyAccessibleAttributeChanged(AccessibleAttribute.CHILDREN));
+        expandedProperty().addListener((observable, oldValue, newValue) -> {
+            showHideLink.setText(newValue ? "Hide details" : "Show details");
+            notifyAccessibleAttributeChanged(AccessibleAttribute.CHILDREN);
+        });
+        showHideLink.setText(isExpanded() ? "Hide details" : "Show details");
         removeArrow();
     }
 
@@ -61,17 +76,11 @@ public class TitledDescriptionPane extends TitledPane {
 
         descriptionLabel = new Label(description);
         descriptionLabel.getStyleClass().add("description-label");
-        showHideLink = new Hyperlink("Details...");
+        showHideLink = new Hyperlink();
+        showHideLink.setAccessibleRole(AccessibleRole.BUTTON);
         showHideLink.managedProperty().bind(showHideLink.visibleProperty());
         showHideLink.setOnAction(event -> {
             setExpanded(!this.isExpanded());
-        });
-        this.expandedProperty().addListener((observable, oldValue, newValue) -> {
-            if(newValue) {
-                showHideLink.setText(showHideLink.getText().replace("Show", "Hide"));
-            } else {
-                showHideLink.setText(showHideLink.getText().replace("Hide", "Show"));
-            }
         });
         descriptionBox.getChildren().addAll(descriptionLabel, showHideLink);
 
@@ -92,6 +101,27 @@ public class TitledDescriptionPane extends TitledPane {
         });
 
         return listItem;
+    }
+
+    @Override
+    public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
+        if(attribute == AccessibleAttribute.CHILDREN) {
+            //Do not expose collapsed content, but always expose the title, description and header actions.
+            return createAccessibleChildren(getGraphic(), getContent(), isExpanded());
+        }
+
+        return super.queryAccessibleAttribute(attribute, parameters);
+    }
+
+    static ObservableList<Node> createAccessibleChildren(Node graphic, Node content, boolean expanded) {
+        ObservableList<Node> children = FXCollections.observableArrayList();
+        if(graphic != null) {
+            children.add(graphic);
+        }
+        if(expanded && content != null) {
+            children.add(content);
+        }
+        return children;
     }
 
     protected Control createButton() {

--- a/src/main/java/com/sparrowwallet/sparrow/control/UnlabeledToggleSwitch.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/UnlabeledToggleSwitch.java
@@ -1,10 +1,19 @@
 package com.sparrowwallet.sparrow.control;
 
 import impl.org.controlsfx.skin.ToggleSwitchSkin;
+import javafx.scene.AccessibleAction;
+import javafx.scene.AccessibleAttribute;
+import javafx.scene.AccessibleRole;
 import javafx.scene.control.Skin;
 import org.controlsfx.control.ToggleSwitch;
 
 public class UnlabeledToggleSwitch extends ToggleSwitch {
+    public UnlabeledToggleSwitch() {
+        setAccessibleRole(AccessibleRole.TOGGLE_BUTTON);
+        setAccessibleRoleDescription("switch");
+        selectedProperty().addListener((observable, oldValue, newValue) -> notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTED));
+    }
+
     @Override protected Skin<?> createDefaultSkin() {
         return new ToggleSwitchSkin(this) {
             @Override
@@ -12,5 +21,23 @@ public class UnlabeledToggleSwitch extends ToggleSwitch {
                 return super.computePrefWidth(height, topInset, rightInset, bottomInset, leftInset) - 20;
             }
         };
+    }
+
+    @Override
+    public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
+        if(attribute == AccessibleAttribute.SELECTED) {
+            return isSelected();
+        }
+
+        return super.queryAccessibleAttribute(attribute, parameters);
+    }
+
+    @Override
+    public void executeAccessibleAction(AccessibleAction action, Object... parameters) {
+        if(action == AccessibleAction.FIRE) {
+            fire();
+        } else {
+            super.executeAccessibleAction(action, parameters);
+        }
     }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/control/UtxosChart.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/UtxosChart.java
@@ -8,6 +8,8 @@ import com.sparrowwallet.sparrow.wallet.Entry;
 import com.sparrowwallet.sparrow.wallet.UtxoEntry;
 import com.sparrowwallet.sparrow.wallet.WalletUtxosEntry;
 import javafx.beans.NamedArg;
+import javafx.application.Platform;
+import javafx.scene.Parent;
 import javafx.scene.Node;
 import javafx.scene.chart.*;
 import javafx.scene.control.Tooltip;
@@ -30,6 +32,9 @@ public class UtxosChart extends BarChart<String, Number> {
 
     public UtxosChart(@NamedArg("xAxis") Axis<String> xAxis, @NamedArg("yAxis") Axis<Number> yAxis) {
         super(xAxis, yAxis);
+        setFocusTraversable(false);
+        xAxis.setFocusTraversable(false);
+        yAxis.setFocusTraversable(false);
     }
 
     public void initialize(WalletUtxosEntry walletUtxosEntry) {
@@ -76,6 +81,15 @@ public class UtxosChart extends BarChart<String, Number> {
 
         if(selectedEntries != null) {
             select(selectedEntries);
+        }
+
+        Platform.runLater(() -> disableFocusTraversal(this));
+    }
+
+    private static void disableFocusTraversal(Node node) {
+        node.setFocusTraversable(false);
+        if(node instanceof Parent parent) {
+            parent.getChildrenUnmodifiable().forEach(UtxosChart::disableFocusTraversal);
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/control/ViewStack.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/ViewStack.java
@@ -1,0 +1,23 @@
+package com.sparrowwallet.sparrow.control;
+
+import javafx.scene.Node;
+import javafx.scene.layout.StackPane;
+
+import java.util.Objects;
+
+/**
+ * A stack of cached views where only the active view is exposed or rendered.
+ */
+public class ViewStack extends StackPane {
+    public void show(Node view) {
+        Objects.requireNonNull(view);
+
+        if(!getChildren().contains(view)) {
+            getChildren().add(view);
+        }
+
+        for(Node child : getChildren()) {
+            child.setVisible(child == view);
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/control/WalletNameDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/WalletNameDialog.java
@@ -76,6 +76,7 @@ public class WalletNameDialog extends Dialog<WalletNameDialog.NameAndBirthDate> 
 
         final VBox content = new VBox(20);
         name = (CustomTextField)TextFields.createClearableTextField();
+        name.setAccessibleText("Wallet name");
         name.setText(initialName);
         name.setTextFormatter(new TextFormatter<>((change) -> {
             change.setText(change.getText().replaceAll("[\\\\/:*?\"<>|;`]", "_"));
@@ -89,6 +90,7 @@ public class WalletNameDialog extends Dialog<WalletNameDialog.NameAndBirthDate> 
         existingBox.getChildren().add(existingCheck);
 
         existingPicker = new DatePicker();
+        existingPicker.setAccessibleText("Existing transactions start date");
         existingPicker.setConverter(new DateStringConverter());
         existingPicker.setEditable(false);
         existingPicker.setPrefWidth(130);

--- a/src/main/java/com/sparrowwallet/sparrow/control/WalletNameDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/WalletNameDialog.java
@@ -76,7 +76,6 @@ public class WalletNameDialog extends Dialog<WalletNameDialog.NameAndBirthDate> 
 
         final VBox content = new VBox(20);
         name = (CustomTextField)TextFields.createClearableTextField();
-        name.setAccessibleText("Wallet name");
         name.setText(initialName);
         name.setTextFormatter(new TextFormatter<>((change) -> {
             change.setText(change.getText().replaceAll("[\\\\/:*?\"<>|;`]", "_"));

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/TransactionController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/TransactionController.java
@@ -11,6 +11,7 @@ import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.EventManager;
 import com.sparrowwallet.sparrow.TransactionTabData;
 import com.sparrowwallet.sparrow.control.TransactionHexArea;
+import com.sparrowwallet.sparrow.control.ViewStack;
 import com.sparrowwallet.sparrow.event.*;
 import com.sparrowwallet.sparrow.io.Config;
 import com.sparrowwallet.sparrow.net.ElectrumServer;
@@ -51,7 +52,7 @@ public class TransactionController implements Initializable {
     private TreeView<TransactionForm> txtree;
 
     @FXML
-    private Pane txpane;
+    private ViewStack txpane;
 
     @FXML
     private TransactionHexArea txhex;
@@ -261,21 +262,19 @@ public class TransactionController implements Initializable {
                     TransactionForm childForm = (TransactionForm)txdetail.getUserData();
                     if(transactionForm == childForm) {
                         detailPane = txdetail;
-                        txdetail.setViewOrder(0);
-                    } else {
-                        txdetail.setViewOrder(1);
+                        break;
                     }
                 }
 
                 try {
                     if(detailPane == null) {
                         detailPane = transactionForm.getContents();
-                        detailPane.setViewOrder(0);
-                        txpane.getChildren().add(detailPane);
                     }
                 } catch (IOException e) {
                     throw new IllegalStateException("Can't find pane", e);
                 }
+
+                txpane.show(detailPane);
 
                 if(detailPane instanceof Parent) {
                     Parent parent = (Parent)detailPane;

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/PaymentController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/PaymentController.java
@@ -80,7 +80,13 @@ public class PaymentController extends WalletFormController implements Initializ
     private ValidationSupport validationSupport;
 
     @FXML
+    private AccessibleField payToField;
+
+    @FXML
     private ComboBox<Wallet> openWallets;
+
+    @FXML
+    private Label recipientWalletLabel;
 
     @FXML
     private ComboBoxTextField address;
@@ -95,7 +101,13 @@ public class PaymentController extends WalletFormController implements Initializ
     private ComboBox<BitcoinUnit> amountUnit;
 
     @FXML
+    private Label amountUnitLabel;
+
+    @FXML
     private FiatLabel fiatAmount;
+
+    @FXML
+    private Label fiatAmountLabel;
 
     @FXML
     private Label amountStatus;
@@ -300,6 +312,10 @@ public class PaymentController extends WalletFormController implements Initializ
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         EventManager.get().register(this);
+        payToField.setLabelFor(address);
+        recipientWalletLabel.setLabelFor(openWallets);
+        amountUnitLabel.setLabelFor(amountUnit);
+        fiatAmountLabel.setLabelFor(fiatAmount);
     }
 
     public void setSendController(SendController sendController) {

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -114,7 +114,13 @@ public class SendController extends WalletFormController implements Initializabl
     private ComboBox<BitcoinUnit> feeAmountUnit;
 
     @FXML
+    private Label feeAmountUnitLabel;
+
+    @FXML
     private FiatLabel fiatFeeAmount;
+
+    @FXML
+    private Label fiatFeeAmountLabel;
 
     @FXML
     private BlockTargetFeeRatesChart blockTargetFeeRatesChart;
@@ -246,6 +252,8 @@ public class SendController extends WalletFormController implements Initializabl
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         EventManager.get().register(this);
+        feeAmountUnitLabel.setLabelFor(feeAmountUnit);
+        fiatFeeAmountLabel.setLabelFor(fiatFeeAmount);
     }
 
     @Override

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/TransactionsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/TransactionsController.java
@@ -99,6 +99,7 @@ public class TransactionsController extends WalletFormController implements Init
         transactionsMasterDetail.setShowDetailNode(Config.get().isShowLoadingLog());
         loadingLog.appendText("Wallet loading history for " + getWalletForm().getWallet().getFullDisplayName());
         loadingLog.setEditable(false);
+        loadingLog.focusTraversableProperty().bind(transactionsMasterDetail.showDetailNodeProperty());
     }
 
     private void setTransactionCount(WalletTransactionsEntry walletTransactionsEntry) {

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/UtxosController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/UtxosController.java
@@ -93,7 +93,7 @@ public class UtxosController extends WalletFormController implements Initializab
         sendSelected.setTooltip(new Tooltip("Send selected UTXOs. Use " + (OsType.getCurrent() == OsType.MACOS ? "Cmd" : "Ctrl") + "+click to select multiple." ));
 
         utxosTable.getSelectionModel().getSelectedIndices().addListener((ListChangeListener<Integer>) c -> {
-            List<Entry> selectedEntries = utxosTable.getSelectionModel().getSelectedCells().stream().filter(tp -> tp.getTreeItem() != null).map(tp -> tp.getTreeItem().getValue()).collect(Collectors.toList());
+            List<Entry> selectedEntries = getSelectedRows();
             utxosChart.select(selectedEntries);
             updateButtons(Config.get().getUnitFormat(), Config.get().getBitcoinUnit());
             updateUtxoCount(getWalletForm().getWalletUtxosEntry());
@@ -108,14 +108,14 @@ public class UtxosController extends WalletFormController implements Initializab
     }
 
     private void updateUtxoCount(WalletUtxosEntry walletUtxosEntry) {
-        int selectedCount = utxosTable.getSelectionModel().getSelectedCells().size();
+        int selectedCount = getSelectedRows().size();
         utxoCount.setText((selectedCount > 0 ? selectedCount + "/" : "") + (walletUtxosEntry.getChildren() != null ? Integer.toString(walletUtxosEntry.getChildren().size()) : "0"));
     }
 
     private void updateButtons(UnitFormat format, BitcoinUnit unit) {
         List<Entry> selectedEntries = getSelectedEntries();
 
-        selectAll.setDisable(utxosTable.getRoot().getChildren().size() == utxosTable.getSelectionModel().getSelectedCells().size());
+        selectAll.setDisable(utxosTable.getRoot().getChildren().size() == getSelectedRows().size());
         clear.setDisable(selectedEntries.isEmpty());
         sendSelected.setDisable(selectedEntries.isEmpty());
 
@@ -144,11 +144,14 @@ public class UtxosController extends WalletFormController implements Initializab
     }
 
     private List<Entry> getSelectedEntries() {
-        return utxosTable.getSelectionModel().getSelectedCells().stream()
-                .filter(tp -> tp.getTreeItem() != null)
-                .map(tp -> (UtxoEntry)tp.getTreeItem().getValue())
+        return getSelectedRows().stream()
+                .map(entry -> (UtxoEntry)entry)
                 .filter(HashIndexEntry::isSpendable)
                 .collect(Collectors.toList());
+    }
+
+    private List<Entry> getSelectedRows() {
+        return CoinTreeTable.getSelectedRows(utxosTable);
     }
 
     public void sendSelected(ActionEvent event) {
@@ -159,8 +162,7 @@ public class UtxosController extends WalletFormController implements Initializab
     }
 
     private List<UtxoEntry> getSelectedUtxos() {
-        return utxosTable.getSelectionModel().getSelectedCells().stream()
-                .map(tp -> tp.getTreeItem().getValue())
+        return getSelectedRows().stream()
                 .filter(e -> e instanceof HashIndexEntry)
                 .map(e -> (UtxoEntry)e)
                 .filter(e -> e.getType().equals(HashIndexEntry.Type.OUTPUT) && e.isSpendable())

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/WalletController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/WalletController.java
@@ -7,6 +7,7 @@ import com.sparrowwallet.drongo.wallet.Wallet;
 import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.EventManager;
 import com.sparrowwallet.sparrow.control.ViewPasswordField;
+import com.sparrowwallet.sparrow.control.ViewStack;
 import com.sparrowwallet.sparrow.event.*;
 import com.sparrowwallet.sparrow.io.Storage;
 import javafx.application.Platform;
@@ -41,7 +42,7 @@ public class WalletController extends WalletFormController implements Initializa
     private static final Logger log = LoggerFactory.getLogger(WalletController.class);
 
     @FXML
-    private StackPane walletPane;
+    private ViewStack walletPane;
 
     @FXML
     private VBox walletMenuBox;
@@ -78,18 +79,16 @@ public class WalletController extends WalletFormController implements Initializa
 
             Function function = (Function)selectedToggle.getUserData();
 
-            boolean existing = false;
+            Node selectedWalletFunction = null;
             for(Node walletFunction : walletPane.getChildren()) {
                 if(walletFunction.getUserData().equals(function)) {
-                    existing = true;
-                    walletFunction.setViewOrder(0);
-                } else if(function != Function.LOCK) {
-                    walletFunction.setViewOrder(1);
+                    selectedWalletFunction = walletFunction;
+                    break;
                 }
             }
 
             try {
-                if(!existing) {
+                if(selectedWalletFunction == null) {
                     URL url = AppServices.class.getResource("wallet/" + function.toString().toLowerCase(Locale.ROOT) + ".fxml");
                     if(url == null) {
                         throw new IllegalStateException("Cannot find wallet/" + function.toString().toLowerCase(Locale.ROOT) + ".fxml");
@@ -107,9 +106,10 @@ public class WalletController extends WalletFormController implements Initializa
                     }
 
                     controller.setWalletForm(walletForm);
-                    walletFunction.setViewOrder(1);
-                    walletPane.getChildren().add(walletFunction);
+                    selectedWalletFunction = walletFunction;
                 }
+
+                walletPane.show(selectedWalletFunction);
             } catch (IOException e) {
                 throw new IllegalStateException("Can't find pane", e);
             }
@@ -184,6 +184,7 @@ public class WalletController extends WalletFormController implements Initializa
         StackPane stackPane = new StackPane();
         stackPane.getChildren().add(vBox);
         lockPane.setCenter(stackPane);
+        lockPane.setVisible(false);
         walletPane.getChildren().add(lockPane);
 
         walletPane.getScene().getWindow().focusedProperty().addListener(new WeakChangeListener<>(lockFocusListener));
@@ -258,7 +259,7 @@ public class WalletController extends WalletFormController implements Initializa
             }
 
             getWalletForm().setLocked(true);
-            lockPane.setViewOrder(-1);
+            walletPane.show(lockPane);
         }
     }
 
@@ -267,7 +268,11 @@ public class WalletController extends WalletFormController implements Initializa
         if(event.getWallet().equals(walletForm.getMasterWallet())) {
             getWalletForm().setLocked(false);
             if(lockPane != null) {
-                lockPane.setViewOrder(2);
+                Function selectedFunction = (Function)walletMenu.getSelectedToggle().getUserData();
+                walletPane.getChildren().stream()
+                        .filter(node -> node.getUserData().equals(selectedFunction))
+                        .findFirst()
+                        .ifPresent(walletPane::show);
             }
         }
     }

--- a/src/main/resources/com/sparrowwallet/sparrow/app.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/app.fxml
@@ -2,7 +2,7 @@
 
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.controlsfx.control.StatusBar?>
+<?import com.sparrowwallet.sparrow.control.AccessibleStatusBar?>
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.shape.Rectangle?>
 <?import com.sparrowwallet.sparrow.control.UnlabeledToggleSwitch?>
@@ -178,7 +178,7 @@
             <TabPane fx:id="tabs" />
         </DecorationPane>
 
-        <StatusBar fx:id="statusBar" text="" minHeight="36">
+        <AccessibleStatusBar fx:id="statusBar" text="" minHeight="36" accessibleText="Application status">
             <rightItems>
                 <UnlabeledToggleSwitch fx:id="serverToggle" accessibleText="Server connection">
                     <tooltip>
@@ -186,6 +186,6 @@
                     </tooltip>
                 </UnlabeledToggleSwitch>
             </rightItems>
-        </StatusBar>
+        </AccessibleStatusBar>
     </children>
 </VBox>

--- a/src/main/resources/com/sparrowwallet/sparrow/app.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/app.fxml
@@ -180,7 +180,7 @@
 
         <StatusBar fx:id="statusBar" text="" minHeight="36">
             <rightItems>
-                <UnlabeledToggleSwitch fx:id="serverToggle">
+                <UnlabeledToggleSwitch fx:id="serverToggle" accessibleText="Server connection">
                     <tooltip>
                         <Tooltip text="Disconnected" />
                     </tooltip>

--- a/src/main/resources/com/sparrowwallet/sparrow/app.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/app.fxml
@@ -15,7 +15,7 @@
     <children>
         <MenuBar useSystemMenuBar="true">
             <menus>
-                <Menu fx:id="fileMenu" mnemonicParsing="false" text="File">
+                <Menu fx:id="fileMenu" mnemonicParsing="true" text="_File">
                     <items>
                         <MenuItem mnemonicParsing="false" text="New Wallet" accelerator="Shortcut+N" onAction="#newWallet"/>
                         <MenuItem mnemonicParsing="false" text="Open Wallet..." accelerator="Shortcut+O" onAction="#openWallet"/>
@@ -64,7 +64,7 @@
                 <fx:define>
                     <ToggleGroup fx:id="theme"/>
                 </fx:define>
-                <Menu fx:id="viewMenu" mnemonicParsing="false" text="View">
+                <Menu fx:id="viewMenu" mnemonicParsing="true" text="_View">
                     <items>
                         <Menu mnemonicParsing="false" text="Bitcoin Unit">
                             <items>
@@ -142,7 +142,7 @@
                         <MenuItem fx:id="refreshWallet" mnemonicParsing="false" text="Refresh Wallet" accelerator="Shortcut+R" onAction="#refreshWallet"/>
                     </items>
                 </Menu>
-                <Menu fx:id="toolsMenu" mnemonicParsing="false" text="Tools">
+                <Menu fx:id="toolsMenu" mnemonicParsing="true" text="_Tools">
                     <MenuItem mnemonicParsing="false" text="Sign/Verify Message" accelerator="Shortcut+M" onAction="#signVerifyMessage"/>
                     <MenuItem fx:id="sendToMany" mnemonicParsing="false" text="Send To Many" onAction="#sendToMany"/>
                     <MenuItem fx:id="sweepPrivateKey" mnemonicParsing="false" text="Sweep Private Key" onAction="#sweepPrivateKey"/>
@@ -155,7 +155,7 @@
                     <CheckMenuItem fx:id="preventSleep" mnemonicParsing="false" text="Prevent Computer Sleep" onAction="#preventSleep"/>
                     <Menu fx:id="restart" mnemonicParsing="false" text="Restart In" />
                 </Menu>
-                <Menu fx:id="helpMenu" mnemonicParsing="false" text="Help">
+                <Menu fx:id="helpMenu" mnemonicParsing="true" text="_Help">
                     <MenuItem mnemonicParsing="false" text="Show Introduction" onAction="#showIntroduction"/>
                     <MenuItem mnemonicParsing="false" text="Show Online Documentation" onAction="#showDocumentation"/>
                     <MenuItem mnemonicParsing="false" text="Show Log File" onAction="#showLogFile"/>

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/general.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/general.fxml
@@ -31,7 +31,7 @@
     <Form GridPane.columnIndex="0" GridPane.rowIndex="0">
         <Fieldset inputGrow="SOMETIMES" text="Bitcoin" styleClass="wideLabelFieldSet">
             <Field text="Fee rates source:">
-                <ComboBox fx:id="feeRatesSource">
+                <ComboBox fx:id="feeRatesSource" accessibleText="Fee rates source">
                     <items>
                         <FXCollections fx:factory="observableArrayList">
                             <FeeRatesSource fx:constant="ELECTRUM_SERVER" />
@@ -45,16 +45,16 @@
                 <HelpLabel helpText="Recommended fee rates can be sourced from your connected Electrum server, or an external source."/>
             </Field>
             <Field text="Block explorer:">
-                <ComboBox fx:id="blockExplorers" />
+                <ComboBox fx:id="blockExplorers" accessibleText="Block explorer" />
                 <HelpLabel helpText="An external block explorer can be configured to open a transaction from any transaction tab."/>
             </Field>
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Fiat" styleClass="wideLabelFieldSet">
             <Field text="Currency:">
-                <ComboBox fx:id="fiatCurrency" />
+                <ComboBox fx:id="fiatCurrency" accessibleText="Fiat currency" />
             </Field>
             <Field text="Exchange rate source:">
-                <ComboBox fx:id="exchangeSource" prefWidth="160">
+                <ComboBox fx:id="exchangeSource" prefWidth="160" accessibleText="Exchange rate source">
                     <items>
                         <FXCollections fx:factory="observableArrayList">
                             <ExchangeSource fx:constant="NONE" />

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/general.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/general.fxml
@@ -73,31 +73,31 @@
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Wallet" styleClass="wideLabelFieldSet">
             <Field text="Load recent wallets:">
-                <UnlabeledToggleSwitch fx:id="loadRecentWallets" />
+                <UnlabeledToggleSwitch fx:id="loadRecentWallets" accessibleText="Load recent wallets" />
                 <HelpLabel helpText="Keep a record of open wallets, and reopen them on startup."/>
             </Field>
             <Field text="Validate derivations:">
-                <UnlabeledToggleSwitch fx:id="validateDerivationPaths" />
+                <UnlabeledToggleSwitch fx:id="validateDerivationPaths" accessibleText="Validate derivation paths" />
                 <HelpLabel helpText="Disallow keystores to have derivation paths that match the defaults for other script types and networks."/>
             </Field>
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Coin Selection" styleClass="wideLabelFieldSet">
             <Field text="Group by address:">
-                <UnlabeledToggleSwitch fx:id="groupByAddress" />
+                <UnlabeledToggleSwitch fx:id="groupByAddress" accessibleText="Group by address" />
                 <HelpLabel helpText="Group UTXOs by address when sending to improve privacy by only sending from an address once."/>
             </Field>
             <Field text="Allow unconfirmed:">
-                <UnlabeledToggleSwitch fx:id="includeMempoolOutputs" />
+                <UnlabeledToggleSwitch fx:id="includeMempoolOutputs" accessibleText="Allow unconfirmed" />
                 <HelpLabel helpText="Allow a wallet to spend UTXOs that are still in the mempool."/>
             </Field>
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Notifications" styleClass="wideLabelFieldSet">
             <Field text="New transactions:">
-                <UnlabeledToggleSwitch fx:id="notifyNewTransactions" />
+                <UnlabeledToggleSwitch fx:id="notifyNewTransactions" accessibleText="New transaction notifications" />
                 <HelpLabel helpText="Show system notifications on new wallet transactions?"/>
             </Field>
             <Field text="Software updates:">
-                <UnlabeledToggleSwitch fx:id="checkNewVersions" />
+                <UnlabeledToggleSwitch fx:id="checkNewVersions" accessibleText="Software update checks" />
                 <HelpLabel helpText="Check for updates to Sparrow?"/>
             </Field>
         </Fieldset>

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/general.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/general.fxml
@@ -14,6 +14,7 @@
 <?import com.sparrowwallet.sparrow.net.ExchangeSource?>
 <?import com.sparrowwallet.sparrow.control.UnlabeledToggleSwitch?>
 <?import com.sparrowwallet.sparrow.control.HelpLabel?>
+<?import com.sparrowwallet.sparrow.control.AccessibleField?>
 <?import com.sparrowwallet.sparrow.net.FeeRatesSource?>
 <?import org.controlsfx.glyphfont.Glyph?>
 
@@ -30,7 +31,7 @@
 
     <Form GridPane.columnIndex="0" GridPane.rowIndex="0">
         <Fieldset inputGrow="SOMETIMES" text="Bitcoin" styleClass="wideLabelFieldSet">
-            <Field text="Fee rates source:">
+            <AccessibleField text="Fee rates source:">
                 <ComboBox fx:id="feeRatesSource">
                     <items>
                         <FXCollections fx:factory="observableArrayList">
@@ -43,17 +44,17 @@
                     </items>
                 </ComboBox>
                 <HelpLabel helpText="Recommended fee rates can be sourced from your connected Electrum server, or an external source."/>
-            </Field>
-            <Field text="Block explorer:">
+            </AccessibleField>
+            <AccessibleField text="Block explorer:">
                 <ComboBox fx:id="blockExplorers" />
                 <HelpLabel helpText="An external block explorer can be configured to open a transaction from any transaction tab."/>
-            </Field>
+            </AccessibleField>
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Fiat" styleClass="wideLabelFieldSet">
-            <Field text="Currency:">
+            <AccessibleField text="Currency:">
                 <ComboBox fx:id="fiatCurrency" />
-            </Field>
-            <Field text="Exchange rate source:">
+            </AccessibleField>
+            <AccessibleField text="Exchange rate source:">
                 <ComboBox fx:id="exchangeSource" prefWidth="160">
                     <items>
                         <FXCollections fx:factory="observableArrayList">
@@ -69,37 +70,37 @@
                         <Glyph fontFamily="Font Awesome 5 Free Solid" fontSize="12" icon="EXCLAMATION_TRIANGLE" styleClass="field-warning" />
                     </graphic>
                 </Label>
-            </Field>
+            </AccessibleField>
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Wallet" styleClass="wideLabelFieldSet">
-            <Field text="Load recent wallets:">
+            <AccessibleField text="Load recent wallets:">
                 <UnlabeledToggleSwitch fx:id="loadRecentWallets" accessibleText="Load recent wallets" />
                 <HelpLabel helpText="Keep a record of open wallets, and reopen them on startup."/>
-            </Field>
-            <Field text="Validate derivations:">
+            </AccessibleField>
+            <AccessibleField text="Validate derivations:">
                 <UnlabeledToggleSwitch fx:id="validateDerivationPaths" accessibleText="Validate derivation paths" />
                 <HelpLabel helpText="Disallow keystores to have derivation paths that match the defaults for other script types and networks."/>
-            </Field>
+            </AccessibleField>
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Coin Selection" styleClass="wideLabelFieldSet">
-            <Field text="Group by address:">
+            <AccessibleField text="Group by address:">
                 <UnlabeledToggleSwitch fx:id="groupByAddress" accessibleText="Group by address" />
                 <HelpLabel helpText="Group UTXOs by address when sending to improve privacy by only sending from an address once."/>
-            </Field>
-            <Field text="Allow unconfirmed:">
+            </AccessibleField>
+            <AccessibleField text="Allow unconfirmed:">
                 <UnlabeledToggleSwitch fx:id="includeMempoolOutputs" accessibleText="Allow unconfirmed" />
                 <HelpLabel helpText="Allow a wallet to spend UTXOs that are still in the mempool."/>
-            </Field>
+            </AccessibleField>
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Notifications" styleClass="wideLabelFieldSet">
-            <Field text="New transactions:">
+            <AccessibleField text="New transactions:">
                 <UnlabeledToggleSwitch fx:id="notifyNewTransactions" accessibleText="New transaction notifications" />
                 <HelpLabel helpText="Show system notifications on new wallet transactions?"/>
-            </Field>
-            <Field text="Software updates:">
+            </AccessibleField>
+            <AccessibleField text="Software updates:">
                 <UnlabeledToggleSwitch fx:id="checkNewVersions" accessibleText="Software update checks" />
                 <HelpLabel helpText="Check for updates to Sparrow?"/>
-            </Field>
+            </AccessibleField>
         </Fieldset>
     </Form>
 </GridPane>

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/general.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/general.fxml
@@ -31,7 +31,7 @@
     <Form GridPane.columnIndex="0" GridPane.rowIndex="0">
         <Fieldset inputGrow="SOMETIMES" text="Bitcoin" styleClass="wideLabelFieldSet">
             <Field text="Fee rates source:">
-                <ComboBox fx:id="feeRatesSource" accessibleText="Fee rates source">
+                <ComboBox fx:id="feeRatesSource">
                     <items>
                         <FXCollections fx:factory="observableArrayList">
                             <FeeRatesSource fx:constant="ELECTRUM_SERVER" />
@@ -45,16 +45,16 @@
                 <HelpLabel helpText="Recommended fee rates can be sourced from your connected Electrum server, or an external source."/>
             </Field>
             <Field text="Block explorer:">
-                <ComboBox fx:id="blockExplorers" accessibleText="Block explorer" />
+                <ComboBox fx:id="blockExplorers" />
                 <HelpLabel helpText="An external block explorer can be configured to open a transaction from any transaction tab."/>
             </Field>
         </Fieldset>
         <Fieldset inputGrow="SOMETIMES" text="Fiat" styleClass="wideLabelFieldSet">
             <Field text="Currency:">
-                <ComboBox fx:id="fiatCurrency" accessibleText="Fiat currency" />
+                <ComboBox fx:id="fiatCurrency" />
             </Field>
             <Field text="Exchange rate source:">
-                <ComboBox fx:id="exchangeSource" prefWidth="160" accessibleText="Exchange rate source">
+                <ComboBox fx:id="exchangeSource" prefWidth="160">
                     <items>
                         <FXCollections fx:factory="observableArrayList">
                             <ExchangeSource fx:constant="NONE" />

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
@@ -85,14 +85,14 @@
                 <CopyableLabel text="Using a public server means it can see your transactions."/>
             </Field>
             <Field text="URL:">
-                <ComboBox fx:id="publicElectrumServer" />
+                <ComboBox fx:id="publicElectrumServer" accessibleText="Public Electrum server URL" />
             </Field>
             <Field text="Use Proxy:">
                 <UnlabeledToggleSwitch fx:id="publicUseProxy" accessibleText="Use proxy for public Electrum server"/>
             </Field>
             <Field text="Proxy URL:">
-                <TextField fx:id="publicProxyHost" promptText="e.g. 127.0.0.1" />
-                <TextField fx:id="publicProxyPort" maxWidth="120" promptText="e.g. 9050/9150" />
+                <TextField fx:id="publicProxyHost" promptText="e.g. 127.0.0.1" accessibleText="Public server proxy host" />
+                <TextField fx:id="publicProxyPort" maxWidth="120" promptText="e.g. 9050/9150" accessibleText="Public server proxy port" />
             </Field>
         </Fieldset>
     </Form>
@@ -101,10 +101,10 @@
         <Fieldset inputGrow="SOMETIMES" text="Bitcoin Core RPC">
             <Field text="URL:">
                 <StackPane>
-                    <ComboBox fx:id="recentCoreServers" />
-                    <ComboBoxTextField fx:id="coreHost" promptText="e.g. 127.0.0.1" comboProperty="$recentCoreServers" />
+                    <ComboBox fx:id="recentCoreServers" accessibleText="Recent Bitcoin Core servers" />
+                    <ComboBoxTextField fx:id="coreHost" promptText="e.g. 127.0.0.1" comboProperty="$recentCoreServers" accessibleText="Bitcoin Core host" />
                 </StackPane>
-                <TextField fx:id="corePort" promptText="e.g. 8332" maxWidth="120" />
+                <TextField fx:id="corePort" promptText="e.g. 8332" maxWidth="120" accessibleText="Bitcoin Core port" />
             </Field>
             <Field text="Authentication:">
                 <SegmentedButton accessibleText="Bitcoin Core authentication">
@@ -126,23 +126,23 @@
                 </SegmentedButton>
             </Field>
             <Field fx:id="coreDataDirField" text="Data Folder:" styleClass="label-button">
-                <TextField fx:id="coreDataDir"/>
-                <Button fx:id="coreDataDirSelect" maxWidth="35" minWidth="-Infinity" prefWidth="35">
+                <TextField fx:id="coreDataDir" accessibleText="Bitcoin Core data folder"/>
+                <Button fx:id="coreDataDirSelect" maxWidth="35" minWidth="-Infinity" prefWidth="35" accessibleText="Select Bitcoin Core data folder">
                     <graphic>
                         <Glyph fontFamily="FontAwesome" icon="EDIT" fontSize="13" />
                     </graphic>
                 </Button>
             </Field>
             <Field fx:id="coreUserPassField" text="User / Pass:" styleClass="label-button">
-                <TextField fx:id="coreUser"/>
-                <PasswordField fx:id="corePass"/>
+                <TextField fx:id="coreUser" accessibleText="Bitcoin Core username"/>
+                <PasswordField fx:id="corePass" accessibleText="Bitcoin Core password"/>
             </Field>
             <Field text="Use Proxy:">
                 <UnlabeledToggleSwitch fx:id="coreUseProxy" accessibleText="Use proxy for Bitcoin Core"/><HelpLabel helpText="Bitcoin Core RPC onion URLs, and all other non-RPC external addresses will be connected via this proxy if configured." />
             </Field>
             <Field text="Proxy URL:">
-                <TextField fx:id="coreProxyHost" promptText="e.g. 127.0.0.1" />
-                <TextField fx:id="coreProxyPort" maxWidth="120" promptText="e.g. 9050/9150" />
+                <TextField fx:id="coreProxyHost" promptText="e.g. 127.0.0.1" accessibleText="Bitcoin Core proxy host" />
+                <TextField fx:id="coreProxyPort" maxWidth="120" promptText="e.g. 9050/9150" accessibleText="Bitcoin Core proxy port" />
             </Field>
         </Fieldset>
     </Form>
@@ -151,17 +151,17 @@
         <Fieldset inputGrow="SOMETIMES" text="Private Electrum Server">
             <Field text="URL:">
                 <StackPane>
-                    <ComboBox fx:id="recentElectrumServers" />
-                    <ComboBoxTextField fx:id="electrumHost" promptText="e.g. 127.0.0.1 or Tor hostname (.onion)" comboProperty="$recentElectrumServers" />
+                    <ComboBox fx:id="recentElectrumServers" accessibleText="Recent private Electrum servers" />
+                    <ComboBoxTextField fx:id="electrumHost" promptText="e.g. 127.0.0.1 or Tor hostname (.onion)" comboProperty="$recentElectrumServers" accessibleText="Private Electrum server host" />
                 </StackPane>
-                <TextField fx:id="electrumPort" promptText="e.g. 50001" maxWidth="120" />
+                <TextField fx:id="electrumPort" promptText="e.g. 50001" maxWidth="120" accessibleText="Private Electrum server port" />
             </Field>
             <Field text="Use SSL:">
                 <UnlabeledToggleSwitch fx:id="electrumUseSsl" accessibleText="Use SSL for private Electrum server"/>
             </Field>
             <Field text="Certificate:" styleClass="label-button">
-                <TextField fx:id="electrumCertificate" promptText="Optional server certificate (.crt)"/>
-                <Button fx:id="electrumCertificateSelect" maxWidth="35" minWidth="-Infinity" prefWidth="35">
+                <TextField fx:id="electrumCertificate" promptText="Optional server certificate (.crt)" accessibleText="Private Electrum server certificate"/>
+                <Button fx:id="electrumCertificateSelect" maxWidth="35" minWidth="-Infinity" prefWidth="35" accessibleText="Select private Electrum server certificate">
                     <graphic>
                         <Glyph fontFamily="FontAwesome" icon="EDIT" fontSize="13" />
                     </graphic>
@@ -171,8 +171,8 @@
                 <UnlabeledToggleSwitch fx:id="useProxy" accessibleText="Use proxy for private Electrum server"/><HelpLabel helpText="All external addresses will be connected via this proxy if configured." />
             </Field>
             <Field text="Proxy URL:">
-                <TextField fx:id="proxyHost" promptText="e.g. 127.0.0.1" />
-                <TextField fx:id="proxyPort" maxWidth="120" promptText="e.g. 9050/9150" />
+                <TextField fx:id="proxyHost" promptText="e.g. 127.0.0.1" accessibleText="Private Electrum server proxy host" />
+                <TextField fx:id="proxyPort" maxWidth="120" promptText="e.g. 9050/9150" accessibleText="Private Electrum server proxy port" />
             </Field>
         </Fieldset>
     </Form>
@@ -194,7 +194,7 @@
         <padding>
             <Insets top="10.0" bottom="20.0"/>
         </padding>
-        <TextArea fx:id="testResults" editable="false" wrapText="true"/>
+        <TextArea fx:id="testResults" editable="false" wrapText="true" accessibleText="Connection test results"/>
     </StackPane>
 
 </GridPane>

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
@@ -33,12 +33,12 @@
     <Form GridPane.columnIndex="0" GridPane.rowIndex="0">
         <Fieldset inputGrow="SOMETIMES" text="Server">
             <Field text="Type:">
-                <SegmentedButton fx:id="serverTypeSegmentedButton">
+                <SegmentedButton fx:id="serverTypeSegmentedButton" accessibleText="Server type">
                     <toggleGroup>
                         <ToggleGroup fx:id="serverTypeToggleGroup" />
                     </toggleGroup>
                     <buttons>
-                        <ToggleButton fx:id="publicElectrumToggle" text="Public Server" toggleGroup="$serverTypeToggleGroup">
+                        <ToggleButton fx:id="publicElectrumToggle" text="Public Server" toggleGroup="$serverTypeToggleGroup" accessibleRole="RADIO_BUTTON">
                             <graphic>
                                 <Glyph fontFamily="Font Awesome 5 Free Solid" fontSize="12" icon="TOGGLE_ON" styleClass="public-electrum" />
                             </graphic>
@@ -46,7 +46,7 @@
                                 <ServerType fx:constant="PUBLIC_ELECTRUM_SERVER"/>
                             </userData>
                         </ToggleButton>
-                        <ToggleButton text="Bitcoin Core" toggleGroup="$serverTypeToggleGroup">
+                        <ToggleButton text="Bitcoin Core" toggleGroup="$serverTypeToggleGroup" accessibleRole="RADIO_BUTTON">
                             <graphic>
                                 <Glyph fontFamily="Font Awesome 5 Free Solid" fontSize="12" icon="TOGGLE_ON" styleClass="bitcoin-core" />
                             </graphic>
@@ -54,7 +54,7 @@
                                 <ServerType fx:constant="BITCOIN_CORE"/>
                             </userData>
                         </ToggleButton>
-                        <ToggleButton text="Private Electrum" toggleGroup="$serverTypeToggleGroup">
+                        <ToggleButton text="Private Electrum" toggleGroup="$serverTypeToggleGroup" accessibleRole="RADIO_BUTTON">
                             <graphic>
                                 <Glyph fontFamily="Font Awesome 5 Free Solid" fontSize="12" icon="TOGGLE_ON" styleClass="private-electrum" />
                             </graphic>
@@ -107,17 +107,17 @@
                 <TextField fx:id="corePort" promptText="e.g. 8332" maxWidth="120" />
             </Field>
             <Field text="Authentication:">
-                <SegmentedButton>
+                <SegmentedButton accessibleText="Bitcoin Core authentication">
                     <toggleGroup>
                         <ToggleGroup fx:id="coreAuthToggleGroup" />
                     </toggleGroup>
                     <buttons>
-                        <ToggleButton text="Default" toggleGroup="$coreAuthToggleGroup">
+                        <ToggleButton text="Default" toggleGroup="$coreAuthToggleGroup" accessibleRole="RADIO_BUTTON">
                             <userData>
                                 <CoreAuthType fx:constant="COOKIE"/>
                             </userData>
                         </ToggleButton>
-                        <ToggleButton text="User / Pass" toggleGroup="$coreAuthToggleGroup">
+                        <ToggleButton text="User / Pass" toggleGroup="$coreAuthToggleGroup" accessibleRole="RADIO_BUTTON">
                             <userData>
                                 <CoreAuthType fx:constant="USERPASS"/>
                             </userData>

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
@@ -88,7 +88,7 @@
                 <ComboBox fx:id="publicElectrumServer" />
             </Field>
             <Field text="Use Proxy:">
-                <UnlabeledToggleSwitch fx:id="publicUseProxy"/>
+                <UnlabeledToggleSwitch fx:id="publicUseProxy" accessibleText="Use proxy for public Electrum server"/>
             </Field>
             <Field text="Proxy URL:">
                 <TextField fx:id="publicProxyHost" promptText="e.g. 127.0.0.1" />
@@ -138,7 +138,7 @@
                 <PasswordField fx:id="corePass"/>
             </Field>
             <Field text="Use Proxy:">
-                <UnlabeledToggleSwitch fx:id="coreUseProxy"/><HelpLabel helpText="Bitcoin Core RPC onion URLs, and all other non-RPC external addresses will be connected via this proxy if configured." />
+                <UnlabeledToggleSwitch fx:id="coreUseProxy" accessibleText="Use proxy for Bitcoin Core"/><HelpLabel helpText="Bitcoin Core RPC onion URLs, and all other non-RPC external addresses will be connected via this proxy if configured." />
             </Field>
             <Field text="Proxy URL:">
                 <TextField fx:id="coreProxyHost" promptText="e.g. 127.0.0.1" />
@@ -157,7 +157,7 @@
                 <TextField fx:id="electrumPort" promptText="e.g. 50001" maxWidth="120" />
             </Field>
             <Field text="Use SSL:">
-                <UnlabeledToggleSwitch fx:id="electrumUseSsl"/>
+                <UnlabeledToggleSwitch fx:id="electrumUseSsl" accessibleText="Use SSL for private Electrum server"/>
             </Field>
             <Field text="Certificate:" styleClass="label-button">
                 <TextField fx:id="electrumCertificate" promptText="Optional server certificate (.crt)"/>
@@ -168,7 +168,7 @@
                 </Button>
             </Field>
             <Field text="Use Proxy:">
-                <UnlabeledToggleSwitch fx:id="useProxy"/><HelpLabel helpText="All external addresses will be connected via this proxy if configured." />
+                <UnlabeledToggleSwitch fx:id="useProxy" accessibleText="Use proxy for private Electrum server"/><HelpLabel helpText="All external addresses will be connected via this proxy if configured." />
             </Field>
             <Field text="Proxy URL:">
                 <TextField fx:id="proxyHost" promptText="e.g. 127.0.0.1" />

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
@@ -91,8 +91,8 @@
                 <UnlabeledToggleSwitch fx:id="publicUseProxy" accessibleText="Use proxy for public Electrum server"/>
             </Field>
             <Field text="Proxy URL:">
-                <TextField fx:id="publicProxyHost" promptText="e.g. 127.0.0.1" accessibleText="Public server proxy host" />
-                <TextField fx:id="publicProxyPort" maxWidth="120" promptText="e.g. 9050/9150" accessibleText="Public server proxy port" />
+                <TextField fx:id="publicProxyHost" promptText="e.g. 127.0.0.1" />
+                <TextField fx:id="publicProxyPort" maxWidth="120" promptText="e.g. 9050/9150" />
             </Field>
         </Fieldset>
     </Form>
@@ -102,9 +102,9 @@
             <Field text="URL:">
                 <StackPane>
                     <ComboBox fx:id="recentCoreServers" />
-                    <ComboBoxTextField fx:id="coreHost" promptText="e.g. 127.0.0.1" comboProperty="$recentCoreServers" accessibleText="Bitcoin Core host" />
+                    <ComboBoxTextField fx:id="coreHost" promptText="e.g. 127.0.0.1" comboProperty="$recentCoreServers" />
                 </StackPane>
-                <TextField fx:id="corePort" promptText="e.g. 8332" maxWidth="120" accessibleText="Bitcoin Core port" />
+                <TextField fx:id="corePort" promptText="e.g. 8332" maxWidth="120" />
             </Field>
             <Field text="Authentication:">
                 <SegmentedButton accessibleText="Bitcoin Core authentication">
@@ -126,7 +126,7 @@
                 </SegmentedButton>
             </Field>
             <Field fx:id="coreDataDirField" text="Data Folder:" styleClass="label-button">
-                <TextField fx:id="coreDataDir" accessibleText="Bitcoin Core data folder"/>
+                <TextField fx:id="coreDataDir"/>
                 <Button fx:id="coreDataDirSelect" maxWidth="35" minWidth="-Infinity" prefWidth="35" accessibleText="Select Bitcoin Core data folder">
                     <graphic>
                         <Glyph fontFamily="FontAwesome" icon="EDIT" fontSize="13" />
@@ -134,15 +134,15 @@
                 </Button>
             </Field>
             <Field fx:id="coreUserPassField" text="User / Pass:" styleClass="label-button">
-                <TextField fx:id="coreUser" accessibleText="Bitcoin Core username"/>
+                <TextField fx:id="coreUser"/>
                 <PasswordField fx:id="corePass" accessibleText="Bitcoin Core password"/>
             </Field>
             <Field text="Use Proxy:">
                 <UnlabeledToggleSwitch fx:id="coreUseProxy" accessibleText="Use proxy for Bitcoin Core"/><HelpLabel helpText="Bitcoin Core RPC onion URLs, and all other non-RPC external addresses will be connected via this proxy if configured." />
             </Field>
             <Field text="Proxy URL:">
-                <TextField fx:id="coreProxyHost" promptText="e.g. 127.0.0.1" accessibleText="Bitcoin Core proxy host" />
-                <TextField fx:id="coreProxyPort" maxWidth="120" promptText="e.g. 9050/9150" accessibleText="Bitcoin Core proxy port" />
+                <TextField fx:id="coreProxyHost" promptText="e.g. 127.0.0.1" />
+                <TextField fx:id="coreProxyPort" maxWidth="120" promptText="e.g. 9050/9150" />
             </Field>
         </Fieldset>
     </Form>
@@ -152,15 +152,15 @@
             <Field text="URL:">
                 <StackPane>
                     <ComboBox fx:id="recentElectrumServers" />
-                    <ComboBoxTextField fx:id="electrumHost" promptText="e.g. 127.0.0.1 or Tor hostname (.onion)" comboProperty="$recentElectrumServers" accessibleText="Private Electrum server host" />
+                    <ComboBoxTextField fx:id="electrumHost" promptText="e.g. 127.0.0.1 or Tor hostname (.onion)" comboProperty="$recentElectrumServers" />
                 </StackPane>
-                <TextField fx:id="electrumPort" promptText="e.g. 50001" maxWidth="120" accessibleText="Private Electrum server port" />
+                <TextField fx:id="electrumPort" promptText="e.g. 50001" maxWidth="120" />
             </Field>
             <Field text="Use SSL:">
                 <UnlabeledToggleSwitch fx:id="electrumUseSsl" accessibleText="Use SSL for private Electrum server"/>
             </Field>
             <Field text="Certificate:" styleClass="label-button">
-                <TextField fx:id="electrumCertificate" promptText="Optional server certificate (.crt)" accessibleText="Private Electrum server certificate"/>
+                <TextField fx:id="electrumCertificate" promptText="Optional server certificate (.crt)"/>
                 <Button fx:id="electrumCertificateSelect" maxWidth="35" minWidth="-Infinity" prefWidth="35" accessibleText="Select private Electrum server certificate">
                     <graphic>
                         <Glyph fontFamily="FontAwesome" icon="EDIT" fontSize="13" />
@@ -171,8 +171,8 @@
                 <UnlabeledToggleSwitch fx:id="useProxy" accessibleText="Use proxy for private Electrum server"/><HelpLabel helpText="All external addresses will be connected via this proxy if configured." />
             </Field>
             <Field text="Proxy URL:">
-                <TextField fx:id="proxyHost" promptText="e.g. 127.0.0.1" accessibleText="Private Electrum server proxy host" />
-                <TextField fx:id="proxyPort" maxWidth="120" promptText="e.g. 9050/9150" accessibleText="Private Electrum server proxy port" />
+                <TextField fx:id="proxyHost" promptText="e.g. 127.0.0.1" />
+                <TextField fx:id="proxyPort" maxWidth="120" promptText="e.g. 9050/9150" />
             </Field>
         </Fieldset>
     </Form>
@@ -194,7 +194,7 @@
         <padding>
             <Insets top="10.0" bottom="20.0"/>
         </padding>
-        <TextArea fx:id="testResults" editable="false" wrapText="true" accessibleText="Connection test results"/>
+        <TextArea fx:id="testResults" editable="false" wrapText="true"/>
     </StackPane>
 
 </GridPane>

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/server.fxml
@@ -85,7 +85,7 @@
                 <CopyableLabel text="Using a public server means it can see your transactions."/>
             </Field>
             <Field text="URL:">
-                <ComboBox fx:id="publicElectrumServer" accessibleText="Public Electrum server URL" />
+                <ComboBox fx:id="publicElectrumServer" />
             </Field>
             <Field text="Use Proxy:">
                 <UnlabeledToggleSwitch fx:id="publicUseProxy" accessibleText="Use proxy for public Electrum server"/>
@@ -101,7 +101,7 @@
         <Fieldset inputGrow="SOMETIMES" text="Bitcoin Core RPC">
             <Field text="URL:">
                 <StackPane>
-                    <ComboBox fx:id="recentCoreServers" accessibleText="Recent Bitcoin Core servers" />
+                    <ComboBox fx:id="recentCoreServers" />
                     <ComboBoxTextField fx:id="coreHost" promptText="e.g. 127.0.0.1" comboProperty="$recentCoreServers" accessibleText="Bitcoin Core host" />
                 </StackPane>
                 <TextField fx:id="corePort" promptText="e.g. 8332" maxWidth="120" accessibleText="Bitcoin Core port" />
@@ -151,7 +151,7 @@
         <Fieldset inputGrow="SOMETIMES" text="Private Electrum Server">
             <Field text="URL:">
                 <StackPane>
-                    <ComboBox fx:id="recentElectrumServers" accessibleText="Recent private Electrum servers" />
+                    <ComboBox fx:id="recentElectrumServers" />
                     <ComboBoxTextField fx:id="electrumHost" promptText="e.g. 127.0.0.1 or Tor hostname (.onion)" comboProperty="$recentElectrumServers" accessibleText="Private Electrum server host" />
                 </StackPane>
                 <TextField fx:id="electrumPort" promptText="e.g. 50001" maxWidth="120" accessibleText="Private Electrum server port" />

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/settings.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/settings.fxml
@@ -7,12 +7,14 @@
 <?import javafx.scene.layout.*?>
 
 <?import javafx.geometry.Insets?>
+<?import com.sparrowwallet.sparrow.control.TabList?>
+<?import com.sparrowwallet.sparrow.control.TabToggleButton?>
 <?import com.sparrowwallet.sparrow.settings.SettingsGroup?>
 <?import org.controlsfx.glyphfont.Glyph?>
 <BorderPane stylesheets="@../general.css, @settings.css" styleClass="line-border" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="com.sparrowwallet.sparrow.settings.SettingsController">
     <left>
-        <VBox styleClass="list-menu">
-            <ToggleButton VBox.vgrow="ALWAYS" text="General" wrapText="true" textAlignment="CENTER" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$settingsMenu">
+        <TabList styleClass="list-menu" accessibleText="Settings sections">
+            <TabToggleButton VBox.vgrow="ALWAYS" text="General" wrapText="true" textAlignment="CENTER" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$settingsMenu">
                 <toggleGroup>
                     <ToggleGroup fx:id="settingsMenu" />
                 </toggleGroup>
@@ -22,16 +24,16 @@
                 <userData>
                     <SettingsGroup fx:constant="GENERAL"/>
                 </userData>
-            </ToggleButton>
-            <ToggleButton VBox.vgrow="ALWAYS" text="Server" wrapText="true" textAlignment="CENTER" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$settingsMenu">
+            </TabToggleButton>
+            <TabToggleButton VBox.vgrow="ALWAYS" text="Server" wrapText="true" textAlignment="CENTER" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$settingsMenu">
                 <graphic>
                     <Glyph fontFamily="Font Awesome 5 Free Solid" fontSize="20" icon="SERVER" />
                 </graphic>
                 <userData>
                     <SettingsGroup fx:constant="SERVER"/>
                 </userData>
-            </ToggleButton>
-        </VBox>
+            </TabToggleButton>
+        </TabList>
     </left>
     <center>
         <StackPane fx:id="settingsPane">

--- a/src/main/resources/com/sparrowwallet/sparrow/transaction/input.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/transaction/input.fxml
@@ -88,7 +88,7 @@
                 <CopyableLabel fx:id="signatures" />
             </Field>
             <Field text="RBF:">
-                <UnlabeledToggleSwitch fx:id="rbf"/>
+                <UnlabeledToggleSwitch fx:id="rbf" accessibleText="Replace-by-fee"/>
             </Field>
         </Fieldset>
     </Form>

--- a/src/main/resources/com/sparrowwallet/sparrow/transaction/transaction.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/transaction/transaction.fxml
@@ -5,6 +5,7 @@
 <?import org.fxmisc.flowless.VirtualizedScrollPane?>
 <?import org.controlsfx.control.MasterDetailPane?>
 <?import com.sparrowwallet.sparrow.control.TransactionHexArea?>
+<?import com.sparrowwallet.sparrow.control.ViewStack?>
 
 <SplitPane fx:id="tabContent" dividerPositions="0.82" orientation="VERTICAL" stylesheets="@transaction.css" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.sparrowwallet.sparrow.transaction.TransactionController">
 <items>
@@ -15,7 +16,7 @@
                     <TreeView fx:id="txtree" minWidth="170">
                         <SplitPane.resizableWithParent>false</SplitPane.resizableWithParent>
                     </TreeView>
-                    <StackPane fx:id="txpane" styleClass="tx-pane" minHeight="0"/>
+                    <ViewStack fx:id="txpane" styleClass="tx-pane" minHeight="0"/>
                 </items>
             </SplitPane>
         </masterNode>

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/payment.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/payment.fxml
@@ -15,6 +15,7 @@
 <?import org.controlsfx.glyphfont.Glyph?>
 <?import javafx.geometry.Insets?>
 <?import com.sparrowwallet.sparrow.control.ComboBoxTextField?>
+<?import com.sparrowwallet.sparrow.control.AccessibleField?>
 
 <GridPane styleClass="send-form" hgap="10.0" vgap="10.0" stylesheets="@payment.css, @send.css, @wallet.css, @../script.css, @../general.css" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.sparrowwallet.sparrow.wallet.PaymentController">
     <padding>
@@ -30,7 +31,8 @@
     </rowConstraints>
     <Form GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.columnSpan="2">
         <Fieldset inputGrow="ALWAYS">
-            <Field text="Pay to:">
+            <AccessibleField fx:id="payToField" text="Pay to:">
+                <Label fx:id="recipientWalletLabel" text="Recipient wallet:" managed="false" visible="false" />
                 <StackPane>
                     <ComboBox fx:id="openWallets" />
                     <ComboBoxTextField fx:id="address" styleClass="address-text-field" comboProperty="$openWallets">
@@ -39,16 +41,17 @@
                         </tooltip>
                     </ComboBoxTextField>
                 </StackPane>
-            </Field>
-            <Field text="Label:">
+            </AccessibleField>
+            <AccessibleField text="Label:">
                 <TextField fx:id="label" promptText="Required">
                     <tooltip>
                         <Tooltip text="Required to label the transaction (privately in this wallet)"/>
                     </tooltip>
                 </TextField>
-            </Field>
-            <Field text="Amount:">
+            </AccessibleField>
+            <AccessibleField text="Amount:">
                 <TextField fx:id="amount" styleClass="amount-field" />
+                <Label fx:id="amountUnitLabel" text="Payment unit:" managed="false" visible="false" />
                 <ComboBox fx:id="amountUnit" styleClass="amount-unit">
                     <items>
                         <FXCollections fx:factory="observableArrayList">
@@ -58,6 +61,7 @@
                     </items>
                 </ComboBox>
                 <Label style="-fx-pref-width: 15" />
+                <Label fx:id="fiatAmountLabel" text="Fiat amount:" managed="false" visible="false" />
                 <FiatLabel fx:id="fiatAmount" />
                 <Group managed="false" translateY="38">
                     <Label fx:id="amountStatus" text="Insufficient funds">
@@ -79,13 +83,13 @@
                 </Group>
                 <Region style="-fx-pref-width: 5" />
                 <ToggleButton fx:id="maxButton" text="Max" onAction="#setMaxInput" />
-            </Field>
+            </AccessibleField>
         </Fieldset>
     </Form>
     <Form GridPane.columnIndex="2" GridPane.rowIndex="0">
         <Fieldset inputGrow="ALWAYS" style="-fx-padding: 5 0 0 0">
             <HBox>
-                <Button text="" fx:id="scanQrButton" onAction="#scanQrAddress" prefHeight="30">
+                <Button text="" fx:id="scanQrButton" accessibleText="Scan QR code" onAction="#scanQrAddress" prefHeight="30">
                     <graphic>
                         <Glyph fontFamily="Font Awesome 5 Free Solid" fontSize="12" icon="CAMERA" />
                     </graphic>

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/send.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/send.fxml
@@ -26,6 +26,7 @@
 <?import com.sparrowwallet.sparrow.wallet.OptimizationStrategy?>
 <?import com.sparrowwallet.sparrow.control.HelpLabel?>
 <?import com.sparrowwallet.sparrow.control.FeeRangeSlider?>
+<?import com.sparrowwallet.sparrow.control.AccessibleField?>
 <?import com.sparrowwallet.sparrow.control.RecentBlocksView?>
 
 <BorderPane stylesheets="@send.css, @wallet.css, @../script.css, @../general.css" styleClass="wallet-pane" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.sparrowwallet.sparrow.wallet.SendController">
@@ -117,8 +118,9 @@
                                 </graphic>
                             </Label>
                         </Field>
-                        <Field text="Fee:">
+                        <AccessibleField text="Fee:">
                             <TextField fx:id="fee" styleClass="amount-field"/>
+                            <Label fx:id="feeAmountUnitLabel" text="Fee unit:" managed="false" visible="false" />
                             <ComboBox fx:id="feeAmountUnit" styleClass="amount-unit">
                                 <items>
                                     <FXCollections fx:factory="observableArrayList">
@@ -128,8 +130,9 @@
                                 </items>
                             </ComboBox>
                             <Label style="-fx-pref-width: 15" />
+                            <Label fx:id="fiatFeeAmountLabel" text="Fiat fee amount:" managed="false" visible="false" />
                             <FiatLabel fx:id="fiatFeeAmount" />
-                        </Field>
+                        </AccessibleField>
                     </Fieldset>
                 </Form>
                 <AnchorPane GridPane.columnIndex="1" GridPane.rowIndex="2" GridPane.columnSpan="2">

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/wallet.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/wallet.fxml
@@ -5,13 +5,15 @@
 <?import javafx.scene.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
+<?import com.sparrowwallet.sparrow.control.TabList?>
+<?import com.sparrowwallet.sparrow.control.TabToggleButton?>
 <?import org.controlsfx.glyphfont.Glyph?>
 <?import com.sparrowwallet.sparrow.wallet.Function?>
 
 <BorderPane stylesheets="@wallet.css, @../general.css" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="com.sparrowwallet.sparrow.wallet.WalletController">
     <left>
-        <VBox fx:id="walletMenuBox" styleClass="list-menu">
-            <ToggleButton VBox.vgrow="ALWAYS" text="Transactions" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity">
+        <TabList fx:id="walletMenuBox" styleClass="list-menu" accessibleText="Wallet sections">
+            <TabToggleButton VBox.vgrow="ALWAYS" text="Transactions" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity">
                 <toggleGroup>
                     <ToggleGroup fx:id="walletMenu" />
                 </toggleGroup>
@@ -21,48 +23,48 @@
                 <userData>
                     <Function fx:constant="TRANSACTIONS"/>
                 </userData>
-            </ToggleButton>
-            <ToggleButton VBox.vgrow="ALWAYS" text="Send" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
+            </TabToggleButton>
+            <TabToggleButton VBox.vgrow="ALWAYS" text="Send" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
                 <graphic>
                     <Glyph fontFamily="FontAwesome" icon="SEND" fontSize="20" />
                 </graphic>
                 <userData>
                     <Function fx:constant="SEND"/>
                 </userData>
-            </ToggleButton>
-            <ToggleButton VBox.vgrow="ALWAYS" text="Receive" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
+            </TabToggleButton>
+            <TabToggleButton VBox.vgrow="ALWAYS" text="Receive" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
                 <graphic>
                     <Glyph fontFamily="FontAwesome" icon="ARROW_DOWN" fontSize="20" />
                 </graphic>
                 <userData>
                     <Function fx:constant="RECEIVE"/>
                 </userData>
-            </ToggleButton>
-            <ToggleButton VBox.vgrow="ALWAYS" text="Addresses" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
+            </TabToggleButton>
+            <TabToggleButton VBox.vgrow="ALWAYS" text="Addresses" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
                 <graphic>
                     <Glyph fontFamily="FontAwesome" icon="TH_LIST" fontSize="20" />
                 </graphic>
                 <userData>
                     <Function fx:constant="ADDRESSES"/>
                 </userData>
-            </ToggleButton>
-            <ToggleButton VBox.vgrow="ALWAYS" text="UTXOs" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
+            </TabToggleButton>
+            <TabToggleButton VBox.vgrow="ALWAYS" text="UTXOs" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
                 <graphic>
                     <Glyph fontFamily="Font Awesome 5 Free Solid" icon="COINS" fontSize="20" />
                 </graphic>
                 <userData>
                     <Function fx:constant="UTXOS"/>
                 </userData>
-            </ToggleButton>
-            <ToggleButton VBox.vgrow="ALWAYS" text="Settings" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
+            </TabToggleButton>
+            <TabToggleButton VBox.vgrow="ALWAYS" text="Settings" contentDisplay="TOP" styleClass="list-item" maxHeight="Infinity" toggleGroup="$walletMenu">
                 <graphic>
                     <Glyph fontFamily="FontAwesome" icon="COG" fontSize="20" />
                 </graphic>
                 <userData>
                     <Function fx:constant="SETTINGS"/>
                 </userData>
-            </ToggleButton>
-        </VBox>
+            </TabToggleButton>
+        </TabList>
     </left>
     <center>
         <StackPane fx:id="walletPane" styleClass="wallet-pane">

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/wallet.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/wallet.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.layout.*?>
 <?import com.sparrowwallet.sparrow.control.TabList?>
 <?import com.sparrowwallet.sparrow.control.TabToggleButton?>
+<?import com.sparrowwallet.sparrow.control.ViewStack?>
 <?import org.controlsfx.glyphfont.Glyph?>
 <?import com.sparrowwallet.sparrow.wallet.Function?>
 
@@ -67,8 +68,8 @@
         </TabList>
     </left>
     <center>
-        <StackPane fx:id="walletPane" styleClass="wallet-pane">
+        <ViewStack fx:id="walletPane" styleClass="wallet-pane">
 
-        </StackPane>
+        </ViewStack>
     </center>
 </BorderPane>

--- a/src/main/resources/com/sparrowwallet/sparrow/welcome.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/welcome.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<?import org.controlsfx.control.StatusBar?>
+<?import com.sparrowwallet.sparrow.control.AccessibleStatusBar?>
 <?import com.sparrowwallet.sparrow.control.UnlabeledToggleSwitch?>
 <?import org.controlsfx.glyphfont.Glyph?>
 <?import com.sparrowwallet.sparrow.control.DialogImage?>
@@ -62,11 +62,11 @@
                 <Label text="A blue toggle means you are connected to a private Electrum server. You're now ready to configure a server and start using Sparrow!" wrapText="true" styleClass="content-text" />
             </VBox>
             <Region VBox.vgrow="ALWAYS" />
-            <StatusBar fx:id="serverStatus">
+            <AccessibleStatusBar fx:id="serverStatus" accessibleText="Demonstration connection status">
                 <rightItems>
                     <UnlabeledToggleSwitch fx:id="serverToggle" accessibleText="Demonstration server connection" />
                 </rightItems>
-            </StatusBar>
+            </AccessibleStatusBar>
         </VBox>
     </VBox>
 </StackPane>

--- a/src/main/resources/com/sparrowwallet/sparrow/welcome.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/welcome.fxml
@@ -64,7 +64,7 @@
             <Region VBox.vgrow="ALWAYS" />
             <StatusBar fx:id="serverStatus">
                 <rightItems>
-                    <UnlabeledToggleSwitch fx:id="serverToggle" />
+                    <UnlabeledToggleSwitch fx:id="serverToggle" accessibleText="Demonstration server connection" />
                 </rightItems>
             </StatusBar>
         </VBox>

--- a/src/test/java/com/sparrowwallet/sparrow/AppServicesTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/AppServicesTest.java
@@ -1,0 +1,41 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.OsType;
+import javafx.scene.AccessibleRole;
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AppServicesTest {
+    @Test
+    public void dialogRoleIsExposedAsParentOnMacOs() {
+        Pane root = new Pane();
+        root.setAccessibleRole(AccessibleRole.DIALOG);
+
+        AppServices.configureDialogAccessibility(root, OsType.MACOS);
+
+        Assertions.assertEquals(AccessibleRole.PARENT, root.getAccessibleRole());
+    }
+
+    @Test
+    public void nonDialogRoleIsUnchangedOnMacOs() {
+        Pane root = new Pane();
+        root.setAccessibleRole(AccessibleRole.NODE);
+
+        AppServices.configureDialogAccessibility(root, OsType.MACOS);
+
+        Assertions.assertEquals(AccessibleRole.NODE, root.getAccessibleRole());
+    }
+
+    @Test
+    public void dialogRoleIsUnchangedOnOtherPlatforms() {
+        for(OsType osType : new OsType[] {OsType.WINDOWS, OsType.UNIX, OsType.UNKNOWN}) {
+            Pane root = new Pane();
+            root.setAccessibleRole(AccessibleRole.DIALOG);
+
+            AppServices.configureDialogAccessibility(root, osType);
+
+            Assertions.assertEquals(AccessibleRole.DIALOG, root.getAccessibleRole(), osType.getPlatformId());
+        }
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/JavaFxTestSupport.java
+++ b/src/test/java/com/sparrowwallet/sparrow/JavaFxTestSupport.java
@@ -1,0 +1,33 @@
+package com.sparrowwallet.sparrow;
+
+import javafx.application.Platform;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+public final class JavaFxTestSupport {
+    private static boolean started;
+
+    private JavaFxTestSupport() {
+    }
+
+    public static synchronized void startJavaFx() throws InterruptedException {
+        if(started) {
+            return;
+        }
+
+        System.setProperty("glass.platform", "Headless");
+        CountDownLatch startupLatch = new CountDownLatch(1);
+        Platform.startup(startupLatch::countDown);
+        Assertions.assertTrue(startupLatch.await(10, TimeUnit.SECONDS));
+        started = true;
+    }
+
+    public static void runOnFxThread(Runnable runnable) throws Exception {
+        FutureTask<Void> task = new FutureTask<>(runnable, null);
+        Platform.runLater(task);
+        task.get(10, TimeUnit.SECONDS);
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/control/AccessibleFieldTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/AccessibleFieldTest.java
@@ -1,0 +1,29 @@
+package com.sparrowwallet.sparrow.control;
+
+import com.sparrowwallet.sparrow.JavaFxTestSupport;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class AccessibleFieldTest {
+    @BeforeAll
+    public static void startJavaFx() throws InterruptedException {
+        JavaFxTestSupport.startJavaFx();
+    }
+
+    @Test
+    public void associatesLabelWithPrimaryInput() throws Exception {
+        JavaFxTestSupport.runOnFxThread(() -> {
+            AccessibleField field = new AccessibleField();
+            ComboBox<String> comboBox = new ComboBox<>();
+
+            field.getInputs().add(comboBox);
+
+            Label label = (Label)field.getLabelContainer().getChildren().getFirst();
+            Assertions.assertSame(comboBox, label.getLabelFor());
+        });
+    }
+
+}

--- a/src/test/java/com/sparrowwallet/sparrow/control/AccessibleFieldTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/AccessibleFieldTest.java
@@ -1,11 +1,20 @@
 package com.sparrowwallet.sparrow.control;
 
 import com.sparrowwallet.sparrow.JavaFxTestSupport;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.AccessibleAttribute;
+import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.TextField;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 public class AccessibleFieldTest {
     @BeforeAll
@@ -24,6 +33,126 @@ public class AccessibleFieldTest {
             Label label = (Label)field.getLabelContainer().getChildren().getFirst();
             Assertions.assertSame(comboBox, label.getLabelFor());
         });
+    }
+
+    @Test
+    public void paymentScreenHasNoUnnamedFocusableControls() throws Exception {
+        JavaFxTestSupport.runOnFxThread(() -> {
+            try {
+                FXMLLoader loader = new FXMLLoader(AccessibleFieldTest.class.getResource("/com/sparrowwallet/sparrow/wallet/payment.fxml"));
+                Parent payment = loader.load();
+
+                ComboBox<?> openWallets = (ComboBox<?>)loader.getNamespace().get("openWallets");
+                Label recipientWalletLabel = (Label)loader.getNamespace().get("recipientWalletLabel");
+                TextField address = (TextField)loader.getNamespace().get("address");
+                AccessibleField payToField = (AccessibleField)loader.getNamespace().get("payToField");
+                ComboBox<?> amountUnit = (ComboBox<?>)loader.getNamespace().get("amountUnit");
+                Label amountUnitLabel = (Label)loader.getNamespace().get("amountUnitLabel");
+                Label payToLabel = (Label)payToField.getLabelContainer().getChildren().getFirst();
+                Assertions.assertSame(address, payToLabel.getLabelFor());
+                Assertions.assertEquals("Recipient wallet:", recipientWalletLabel.getText());
+                Assertions.assertSame(openWallets, recipientWalletLabel.getLabelFor());
+                Assertions.assertEquals("Payment unit:", amountUnitLabel.getText());
+                Assertions.assertSame(amountUnit, amountUnitLabel.getLabelFor());
+                Assertions.assertFalse(recipientWalletLabel.isManaged());
+                Assertions.assertFalse(recipientWalletLabel.isVisible());
+                Assertions.assertFalse(amountUnitLabel.isManaged());
+                Assertions.assertFalse(amountUnitLabel.isVisible());
+
+                address.setText("bc1qrecipient");
+                TextField label = (TextField)loader.getNamespace().get("label");
+                label.setText("Coffee");
+                TextField amount = (TextField)loader.getNamespace().get("amount");
+                amount.setText("0.001");
+                FiatLabel fiatAmount = (FiatLabel)loader.getNamespace().get("fiatAmount");
+                fiatAmount.setText("$ 100.00");
+                Assertions.assertEquals("bc1qrecipient", address.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+                Assertions.assertEquals("Coffee", label.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+                Assertions.assertEquals("0.001", amount.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+                Assertions.assertEquals("$ 100.00", fiatAmount.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+
+                Assertions.assertEquals(List.of(), descendants(payment)
+                        .filter(Node::isFocusTraversable)
+                        .filter(Node::isVisible)
+                        .filter(node -> !hasAccessibleName(payment, node))
+                        .map(node -> node.getClass().getSimpleName() + "#" + node.getId())
+                        .toList());
+            } catch(Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void sendScreenPreservesFeeValues() throws Exception {
+        JavaFxTestSupport.runOnFxThread(() -> {
+            try {
+                FXMLLoader loader = new FXMLLoader(AccessibleFieldTest.class.getResource("/com/sparrowwallet/sparrow/wallet/send.fxml"));
+                loader.load();
+
+                TextField fee = (TextField)loader.getNamespace().get("fee");
+                ComboBox<?> feeAmountUnit = (ComboBox<?>)loader.getNamespace().get("feeAmountUnit");
+                Label feeAmountUnitLabel = (Label)loader.getNamespace().get("feeAmountUnitLabel");
+                FiatLabel fiatFeeAmount = (FiatLabel)loader.getNamespace().get("fiatFeeAmount");
+                Label fiatFeeAmountLabel = (Label)loader.getNamespace().get("fiatFeeAmountLabel");
+                Assertions.assertSame(feeAmountUnit, feeAmountUnitLabel.getLabelFor());
+                Assertions.assertSame(fiatFeeAmount, fiatFeeAmountLabel.getLabelFor());
+                Assertions.assertFalse(feeAmountUnitLabel.isManaged());
+                Assertions.assertFalse(feeAmountUnitLabel.isVisible());
+                Assertions.assertFalse(fiatFeeAmountLabel.isManaged());
+                Assertions.assertFalse(fiatFeeAmountLabel.isVisible());
+
+                fee.setText("1000");
+                fiatFeeAmount.setText("$ 10.00");
+                Assertions.assertEquals("1000", fee.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+                Assertions.assertEquals("$ 10.00", fiatFeeAmount.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+            } catch(Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void emptyFiatValueIsNotExposed() throws Exception {
+        JavaFxTestSupport.runOnFxThread(() -> {
+            FiatLabel fiatLabel = new FiatLabel();
+
+            Assertions.assertFalse(fiatLabel.isManaged());
+            Assertions.assertFalse(fiatLabel.isVisible());
+            Assertions.assertFalse(fiatLabel.isFocusTraversable());
+
+            fiatLabel.setText("$ 1.00");
+
+            Assertions.assertTrue(fiatLabel.isManaged());
+            Assertions.assertTrue(fiatLabel.isVisible());
+            Assertions.assertTrue(fiatLabel.isFocusTraversable());
+        });
+    }
+
+    private static Stream<Node> descendants(Parent parent) {
+        return parent.getChildrenUnmodifiable().stream().flatMap(node -> node instanceof Parent child
+                ? Stream.concat(Stream.of(node), descendants(child))
+                : Stream.of(node));
+    }
+
+    private static boolean hasAccessibleName(Parent root, Node node) {
+        if(node.getAccessibleText() != null && !node.getAccessibleText().isBlank()) {
+            return true;
+        }
+
+        Object labeledBy = node.queryAccessibleAttribute(AccessibleAttribute.LABELED_BY);
+        if(labeledBy instanceof Labeled label && label.getText() != null && !label.getText().isBlank()) {
+            return true;
+        }
+
+        if(node instanceof Labeled labeled && labeled.getText() != null && !labeled.getText().isBlank()) {
+            return true;
+        }
+
+        return descendants(root)
+                .filter(Label.class::isInstance)
+                .map(Label.class::cast)
+                .anyMatch(label -> label.getLabelFor() == node && label.getText() != null && !label.getText().isBlank());
     }
 
 }

--- a/src/test/java/com/sparrowwallet/sparrow/control/CoinTreeTableTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/CoinTreeTableTest.java
@@ -1,0 +1,43 @@
+package com.sparrowwallet.sparrow.control;
+
+import com.sparrowwallet.sparrow.JavaFxTestSupport;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class CoinTreeTableTest {
+    @BeforeAll
+    public static void startJavaFx() throws InterruptedException {
+        JavaFxTestSupport.startJavaFx();
+    }
+
+    @Test
+    public void selectedRowsAreDistinctByTreeItem() throws Exception {
+        JavaFxTestSupport.runOnFxThread(() -> {
+            TreeItem<String> root = new TreeItem<>("root");
+            root.getChildren().add(new TreeItem<>("first"));
+            root.getChildren().add(new TreeItem<>("second"));
+            root.setExpanded(true);
+
+            TreeTableView<String> treeTableView = new TreeTableView<>(root);
+            treeTableView.setShowRoot(false);
+            TreeTableColumn<String, String> firstColumn = new TreeTableColumn<>("First");
+            TreeTableColumn<String, String> secondColumn = new TreeTableColumn<>("Second");
+            treeTableView.getColumns().add(firstColumn);
+            treeTableView.getColumns().add(secondColumn);
+            treeTableView.getSelectionModel().setCellSelectionEnabled(true);
+            treeTableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+            treeTableView.getSelectionModel().select(0, firstColumn);
+            treeTableView.getSelectionModel().select(0, secondColumn);
+            treeTableView.getSelectionModel().select(1, firstColumn);
+
+            Assertions.assertEquals(List.of("first", "second"), CoinTreeTable.getSelectedRows(treeTableView));
+        });
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/control/TitledDescriptionPaneTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/TitledDescriptionPaneTest.java
@@ -1,48 +1,27 @@
 package com.sparrowwallet.sparrow.control;
 
 import com.sparrowwallet.drongo.wallet.WalletModel;
-import javafx.application.Platform;
+import com.sparrowwallet.sparrow.JavaFxTestSupport;
 import javafx.scene.AccessibleAction;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.AccessibleRole;
 import javafx.scene.Node;
 import javafx.scene.layout.Pane;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
 
 public class TitledDescriptionPaneTest {
-    private static String glassPlatform;
-
     @BeforeAll
     public static void startJavaFx() throws InterruptedException {
-        glassPlatform = System.getProperty("glass.platform");
-        System.setProperty("glass.platform", "Headless");
-
-        CountDownLatch startupLatch = new CountDownLatch(1);
-        Platform.startup(startupLatch::countDown);
-        Assertions.assertTrue(startupLatch.await(10, TimeUnit.SECONDS));
-    }
-
-    @AfterAll
-    public static void stopJavaFx() {
-        Platform.exit();
-        if(glassPlatform == null) {
-            System.clearProperty("glass.platform");
-        } else {
-            System.setProperty("glass.platform", glassPlatform);
-        }
+        JavaFxTestSupport.startJavaFx();
     }
 
     @Test
     public void paneExposesHeaderActionsAndExpandedContent() throws Exception {
-        runOnFxThread(() -> {
+        JavaFxTestSupport.runOnFxThread(() -> {
             TitledDescriptionPane pane = new TitledDescriptionPane("Descriptor", "Wallet import", "Import a wallet descriptor", WalletModel.SPARROW);
             Node originalContent = pane.getContent();
 
@@ -69,17 +48,11 @@ public class TitledDescriptionPaneTest {
 
     @Test
     public void absentHeaderOrContentIsIgnored() throws Exception {
-        runOnFxThread(() -> {
+        JavaFxTestSupport.runOnFxThread(() -> {
             Node content = new Pane();
 
             Assertions.assertEquals(List.of(), TitledDescriptionPane.createAccessibleChildren(null, content, false));
             Assertions.assertEquals(List.of(content), TitledDescriptionPane.createAccessibleChildren(null, content, true));
         });
-    }
-
-    private static void runOnFxThread(Runnable runnable) throws Exception {
-        FutureTask<Void> task = new FutureTask<>(runnable, null);
-        Platform.runLater(task);
-        task.get(10, TimeUnit.SECONDS);
     }
 }

--- a/src/test/java/com/sparrowwallet/sparrow/control/TitledDescriptionPaneTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/TitledDescriptionPaneTest.java
@@ -1,0 +1,85 @@
+package com.sparrowwallet.sparrow.control;
+
+import com.sparrowwallet.drongo.wallet.WalletModel;
+import javafx.application.Platform;
+import javafx.scene.AccessibleAction;
+import javafx.scene.AccessibleAttribute;
+import javafx.scene.AccessibleRole;
+import javafx.scene.Node;
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+public class TitledDescriptionPaneTest {
+    private static String glassPlatform;
+
+    @BeforeAll
+    public static void startJavaFx() throws InterruptedException {
+        glassPlatform = System.getProperty("glass.platform");
+        System.setProperty("glass.platform", "Headless");
+
+        CountDownLatch startupLatch = new CountDownLatch(1);
+        Platform.startup(startupLatch::countDown);
+        Assertions.assertTrue(startupLatch.await(10, TimeUnit.SECONDS));
+    }
+
+    @AfterAll
+    public static void stopJavaFx() {
+        Platform.exit();
+        if(glassPlatform == null) {
+            System.clearProperty("glass.platform");
+        } else {
+            System.setProperty("glass.platform", glassPlatform);
+        }
+    }
+
+    @Test
+    public void paneExposesHeaderActionsAndExpandedContent() throws Exception {
+        runOnFxThread(() -> {
+            TitledDescriptionPane pane = new TitledDescriptionPane("Descriptor", "Wallet import", "Import a wallet descriptor", WalletModel.SPARROW);
+            Node originalContent = pane.getContent();
+
+            Assertions.assertEquals(AccessibleRole.PARENT, pane.getAccessibleRole());
+            Assertions.assertEquals(AccessibleRole.BUTTON, pane.showHideLink.getAccessibleRole());
+            Assertions.assertEquals("Hide details", pane.showHideLink.getText());
+            Assertions.assertEquals(List.of(pane.getGraphic(), originalContent), pane.queryAccessibleAttribute(AccessibleAttribute.CHILDREN));
+
+            pane.showHideLink.executeAccessibleAction(AccessibleAction.FIRE);
+
+            Assertions.assertFalse(pane.isExpanded());
+            Assertions.assertEquals("Show details", pane.showHideLink.getText());
+            Assertions.assertEquals(List.of(pane.getGraphic()), pane.queryAccessibleAttribute(AccessibleAttribute.CHILDREN));
+
+            Node replacementContent = new Pane();
+            pane.setContent(replacementContent);
+            pane.showHideLink.executeAccessibleAction(AccessibleAction.FIRE);
+
+            Assertions.assertTrue(pane.isExpanded());
+            Assertions.assertEquals("Hide details", pane.showHideLink.getText());
+            Assertions.assertEquals(List.of(pane.getGraphic(), replacementContent), pane.queryAccessibleAttribute(AccessibleAttribute.CHILDREN));
+        });
+    }
+
+    @Test
+    public void absentHeaderOrContentIsIgnored() throws Exception {
+        runOnFxThread(() -> {
+            Node content = new Pane();
+
+            Assertions.assertEquals(List.of(), TitledDescriptionPane.createAccessibleChildren(null, content, false));
+            Assertions.assertEquals(List.of(content), TitledDescriptionPane.createAccessibleChildren(null, content, true));
+        });
+    }
+
+    private static void runOnFxThread(Runnable runnable) throws Exception {
+        FutureTask<Void> task = new FutureTask<>(runnable, null);
+        Platform.runLater(task);
+        task.get(10, TimeUnit.SECONDS);
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/control/ViewStackTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/ViewStackTest.java
@@ -1,0 +1,27 @@
+package com.sparrowwallet.sparrow.control;
+
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ViewStackTest {
+    @Test
+    public void onlyShownViewIsVisible() {
+        ViewStack viewStack = new ViewStack();
+        Pane first = new Pane();
+        Pane second = new Pane();
+
+        viewStack.show(first);
+        viewStack.show(second);
+
+        Assertions.assertFalse(first.isVisible());
+        Assertions.assertTrue(second.isVisible());
+        Assertions.assertEquals(2, viewStack.getChildren().size());
+
+        viewStack.show(first);
+
+        Assertions.assertTrue(first.isVisible());
+        Assertions.assertFalse(second.isVisible());
+        Assertions.assertEquals(2, viewStack.getChildren().size());
+    }
+}


### PR DESCRIPTION
## Summary

Improve screen reader and keyboard support throughout the main Sparrow desktop interface.

- expose dialogs, status bars, settings sections, and wallet sections with useful accessibility roles
- associate form labels and help text with their controls while preserving editable text and selected values
- expose toggle switches and segmented choices with their expected roles, state, and actions
- make wallet tables navigable by cell and announce the focused column and value
- keep inactive stacked views, collapsed logs, and noninteractive charts out of keyboard and screen reader navigation
- label the send form controls and icon-only actions

The macOS dialog workaround is deliberately platform-specific. JavaFX dialog roots retain their `DIALOG` role on Windows, while macOS uses the parent role so VoiceOver can discover the dialog contents.

No visual changes are intended. Additional labels used for compound controls are unmanaged and hidden, and exist only to provide label relationships.

Refs #1713

## Testing

- `./gradlew test --rerun-tasks`
- `./gradlew jpackage`
- manually verified with VoiceOver on macOS
- manually verified with JAWS and NVDA on Windows

Automated coverage includes dialog role selection, form label relationships and value preservation, distinct row selection in cell-selection tables, titled-pane accessibility children, and inactive view visibility.
